### PR TITLE
glass/gravel: serve frontend 'dist/'

### DIFF
--- a/src/aquarium.py
+++ b/src/aquarium.py
@@ -62,6 +62,6 @@ app.mount(
 # mounting root "/" must be the last thing, so it does not override "/api".
 app.mount(
     "/",
-    StaticFiles(directory="dist", html=True),
+    StaticFiles(directory="./glass/dist/", html=True),
     name="static"
 )

--- a/src/dist/README.md
+++ b/src/dist/README.md
@@ -1,6 +1,0 @@
-dist
-=====
-
-This is where frontend files should/would live in a production system.
-These are mounted by the app as static files, into the application's root.
-

--- a/src/glass/angular.json
+++ b/src/glass/angular.json
@@ -20,7 +20,7 @@
         "build": {
           "builder": "@angular-devkit/build-angular:browser",
           "options": {
-            "outputPath": "dist/glass",
+            "outputPath": "dist/",
             "index": "src/index.html",
             "main": "src/main.ts",
             "polyfills": "src/polyfills.ts",


### PR DESCRIPTION
This patch not only serves 'glass/dist/' by the backend, but also
changes something pretty significant on the frontend side: where angular
drops the 'dist/' files. By default it places them under 'dist/glass/',
but for simplicity's sake, we're changing it to 'dist/', simply.

Reasoning is that it feels weird to serve 'glass/dist/glass/', versus
'glass/dist/'.

Signed-off-by: Joao Eduardo Luis \<joao@suse.com>