### PR TITLE
glass: set app prefix to `glass`

### DIFF
--- a/src/glass/angular.json
+++ b/src/glass/angular.json
@@ -15,7 +15,7 @@
       },
       "root": "",
       "sourceRoot": "src",
-      "prefix": "app",
+      "prefix": "glass",
       "architect": {
         "build": {
           "builder": "@angular-devkit/build-angular:browser",


### PR DESCRIPTION
Set the app prefix to `glass` so that it's assigned correctly to new elements.

Signed-off-by: Tatjana Dehler <tdehler@suse.com>