### PR TITLE
tests/vagrant: rename synced folder to 'aquarium'

### DIFF
--- a/tests/vagrant/Vagrantfile.tmpl
+++ b/tests/vagrant/Vagrantfile.tmpl
@@ -3,7 +3,7 @@
 
 Vagrant.configure("2") do |config|
     config.vm.box = "{{BOXNAME}}"
-    config.vm.synced_folder "{{ROOTDIR}}", "/srv/backend", type: "nfs"
+    config.vm.synced_folder "{{ROOTDIR}}", "/srv/aquarium", type: "nfs"
     config.vm.synced_folder ".", "/vagrant", disabled: true
 
     config.vm.define :"node01", primary: true do |node|


### PR DESCRIPTION
We were still using 'backend' instead. We are much more than that. We
are aquarium.

Signed-off-by: Joao Eduardo Luis \<joao@suse.com>