### PR TITLE
Add Docker build environment for building MicroOS Vagrant box

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+**/.github
+**/ceph.git
+**/venv/
+**/node_modules/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM registry.opensuse.org/opensuse/leap:15.2
+MAINTAINER Volker Theile <vtheile@suse.com>
+
+RUN zypper ref && zypper --non-interactive install zsh git \
+    python3 python3-pip python3-rados python3-kiwi nodejs-common \
+    vagrant vagrant-libvirt npm sudo which gptfdisk kpartx \
+    btrfsprogs dosfstools e2fsprogs
+
+CMD ["zsh"]

--- a/tests/vagrant/setup.sh
+++ b/tests/vagrant/setup.sh
@@ -64,9 +64,9 @@ done
   echo "error: setup with name '${setup_name} already exists" && \
   exit 1
 
-
+echo "=> Searching for Vagrant box '${box}' ..."
 if ! vagrant box list | grep -q "^${box}[ ]\+" ; then
-  echo "=> vagrant box '${box}' not found, searching for existing build"
+  echo "=> Vagrant box '${box}' not found, searching for existing build"
 
   imgdir=$(realpath ${basedir}/../../images)
 
@@ -88,6 +88,8 @@ if ! vagrant box list | grep -q "^${box}[ ]\+" ; then
     exit 1
 
   vagrant box add ${box} ${img} || exit 1
+else
+  echo "=> Vagrant box '${box}' already exists"
 fi
 
 sdir=${setupdir}/${setup_name}

--- a/tools/setup-dev.sh
+++ b/tools/setup-dev.sh
@@ -45,12 +45,12 @@ while [[ $# -gt 0 ]]; do
   shift 1
 done
 
-osid=$(grep '^ID=' /etc/os-release)
+osid=$(grep '^ID=' /etc/os-release | sed -e 's/^ID="\(.\+\)"/\1/')
 
 if ${show_dependencies} ; then
 
   case $osid in
-    *opensuse-tumbleweed*)
+    opensuse-tumbleweed | opensuse-leap)
       echo "  > ${dependencies_opensuse_tumbleweed[*]}"
       ;;
     *)
@@ -67,9 +67,9 @@ fi
 if ! ${skip_install_deps} ; then
 
   case $osid in
-    *opensuse-tumbleweed*)
+    opensuse-tumbleweed | opensuse-leap)
       echo "=> try installing dependencies"
-      sudo zypper install ${dependencies_opensuse_tumbleweed[*]} || exit 1
+      sudo zypper --non-interactive install ${dependencies_opensuse_tumbleweed[*]} || exit 1
       ;;
     *)
       echo "error: unsupported distribution ($osid)"


### PR DESCRIPTION
Add Dockerfile that creates a container to be able to build the MicroOS image on non openSUSE systems.

Build and run the container via
```
$ ~/git/aquarium:/aquarium
$ docker build -t aquarium-dev-docker .
$ docker run -itd -v ~/git/aquarium:/aquarium --hostname=aquarium-dev-docker --privileged aquarium-dev-docker
```

Signed-off-by: Volker Theile <vtheile@suse.com>