### PR TITLE
gravel/orch: add base cephfs class 

### DIFF
--- a/src/gravel/controllers/orch/cephfs.py
+++ b/src/gravel/controllers/orch/cephfs.py
@@ -1,0 +1,56 @@
+# project aquarium's backend
+# Copyright (C) 2021 SUSE, LLC.
+
+
+from typing import List
+
+from pydantic.tools import parse_obj_as
+from gravel.controllers.orch.ceph import CephCommandError, Mgr, Mon
+
+from gravel.controllers.orch.models \
+    import CephFSNameModel, CephFSVolumeListModel
+
+
+class CephFSError(Exception):
+    pass
+
+
+class CephFS:
+
+    mgr: Mgr
+    mon: Mon
+
+    def __init__(self):
+        self.mgr = Mgr()
+        self.mon = Mon()
+        pass
+
+    def create(self, name: str) -> None:
+
+        cmd = {
+            "prefix": "fs volume create",
+            "name": name
+        }
+        try:
+            res = self.mgr.call(cmd)
+        except CephCommandError as e:
+            raise CephFSError(e) from e
+        # this command does not support json at this time, and will output
+        # free-form text instead. We are not going to parse it, but we'll make
+        # sure we've got something out of it.
+        assert "result" in res
+        assert len(res["result"]) > 0
+
+    def ls(self) -> CephFSVolumeListModel:
+
+        cmd = {
+            "prefix": "fs volume ls",
+            "format": "json"
+        }
+        try:
+            res = self.mgr.call(cmd)
+        except CephCommandError as e:
+            raise CephFSError(e) from e
+        return CephFSVolumeListModel(
+            volumes=parse_obj_as(List[CephFSNameModel], res)
+        )

--- a/src/gravel/controllers/orch/models.py
+++ b/src/gravel/controllers/orch/models.py
@@ -64,3 +64,11 @@ class OrchDevicesPerHostModel(BaseModel):
     devices: List[OrchDeviceModel]
     labels: List[str]
     name: str
+
+
+class CephFSNameModel(BaseModel):
+    name: str
+
+
+class CephFSVolumeListModel(BaseModel):
+    volumes: List[CephFSNameModel]

--- a/tests/gravel/test_cephfs.py
+++ b/tests/gravel/test_cephfs.py
@@ -1,0 +1,13 @@
+# project aquarium's backend
+# Copyright (C) 2021 SUSE, LLC.
+
+from gravel.controllers.orch.cephfs import CephFS, CephFSError
+
+if __name__ == "__main__":
+    cephfs = CephFS()
+    try:
+        cephfs.create("foobarbaz")
+    except CephFSError as e:
+        print(f"error: {str(e)}")
+    res = cephfs.ls()
+    print(res.json())


### PR DESCRIPTION
**note:** This patchset requires #73 to be merged first.

Create and list cephfs volumes through ceph-mgr's volumes module.

Signed-off-by: Joao Eduardo Luis \<joao@suse.com>