### PR TITLE
glass: add angular proxy conf

### DIFF
--- a/src/glass/angular.json
+++ b/src/glass/angular.json
@@ -80,7 +80,8 @@
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
           "options": {
-            "browserTarget": "glass:build"
+            "browserTarget": "glass:build",
+            "proxyConfig": "proxy.conf.json"
           },
           "configurations": {
             "production": {

--- a/src/glass/proxy.conf.json
+++ b/src/glass/proxy.conf.json
@@ -1,0 +1,6 @@
+{
+  "/api": {
+    "target": "http://localhost:1337",
+    "secure": false
+  }
+}


### PR DESCRIPTION
Add Angular proxy conf in order to consume the gravel
REST API running on the Vagrant box.

Signed-off-by: Tatjana Dehler <tdehler@suse.com>