### PR TITLE
glass: add orch service

### DIFF
--- a/src/glass/src/app/shared/services/api/orch.service.spec.ts
+++ b/src/glass/src/app/shared/services/api/orch.service.spec.ts
@@ -1,0 +1,33 @@
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+
+import { OrchService } from './orch.service';
+
+describe('OrchService', () => {
+  let service: OrchService;
+  let httpTesting: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule]
+    });
+    service = TestBed.inject(OrchService);
+    httpTesting = TestBed.inject(HttpTestingController);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should call devices', () => {
+    service.devices().subscribe();
+    const req = httpTesting.expectOne('api/orch/devices');
+    expect(req.request.method).toBe('GET');
+  });
+
+  it('should call hosts', () => {
+    service.hosts().subscribe();
+    const req = httpTesting.expectOne('api/orch/hosts');
+    expect(req.request.method).toBe('GET');
+  });
+});

--- a/src/glass/src/app/shared/services/api/orch.service.ts
+++ b/src/glass/src/app/shared/services/api/orch.service.ts
@@ -1,0 +1,51 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+
+export type Host = {
+  hostname: string;
+  address: string;
+};
+
+export type Device = {
+  available: boolean;
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  device_id: string;
+  model: string;
+  vendor: string;
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  human_readable_type: string;
+  size: number;
+  path: string;
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  rejected_reasons: string[];
+};
+
+export type HostDevices = {
+  address: string;
+  hostname: string;
+  devices: Device[];
+};
+
+@Injectable({
+  providedIn: 'root'
+})
+export class OrchService {
+  private url = 'api/orch';
+
+  constructor(private http: HttpClient) {}
+
+  /**
+   * Get host information
+   */
+  hosts(): Observable<{ hosts: Host[] }> {
+    return this.http.get<{ hosts: Host[] }>(`${this.url}/hosts`);
+  }
+
+  /**
+   * Get devices information
+   */
+  devices(): Observable<{ [hostName: string]: HostDevices }> {
+    return this.http.get<{ [hostName: string]: HostDevices }>(`${this.url}/devices`);
+  }
+}


### PR DESCRIPTION
Add orch service in order to call hosts and devices endpoints.

Signed-off-by: Tatjana Dehler <tdehler@suse.com>