### PR TITLE
glass: add `bytes-to-size` pipe

### DIFF
--- a/src/glass/src/app/shared/pipes/bytes-to-size.pipe.spec.ts
+++ b/src/glass/src/app/shared/pipes/bytes-to-size.pipe.spec.ts
@@ -1,0 +1,58 @@
+import { BytesToSizePipe } from './bytes-to-size.pipe';
+
+describe('BytesToSizePipe', () => {
+  const pipe = new BytesToSizePipe();
+
+  it('create an instance', () => {
+    expect(pipe).toBeTruthy();
+  });
+
+  it('transforms 0 bytes', () => {
+    expect(pipe.transform(0)).toBe('0 Bytes');
+  });
+
+  it('transforms 1024^0', () => {
+    const value = Math.pow(1024, 0);
+    expect(pipe.transform(value)).toBe('1 Bytes');
+  });
+
+  it('transforms 1024^1', () => {
+    const value = Math.pow(1024, 1);
+    expect(pipe.transform(value)).toBe('1 KB');
+  });
+
+  it('transforms 1024^2', () => {
+    const value = Math.pow(1024, 2);
+    expect(pipe.transform(value)).toBe('1 MB');
+  });
+
+  it('transforms 1024^3', () => {
+    const value = Math.pow(1024, 3);
+    expect(pipe.transform(value)).toBe('1 GB');
+  });
+
+  it('transforms 1024^4', () => {
+    const value = Math.pow(1024, 4);
+    expect(pipe.transform(value)).toBe('1 TB');
+  });
+
+  it('transforms 1024^5', () => {
+    const value = Math.pow(1024, 5);
+    expect(pipe.transform(value)).toBe('1 PB');
+  });
+
+  it('transforms 1024^6', () => {
+    const value = Math.pow(1024, 6);
+    expect(pipe.transform(value)).toBe('1 EB');
+  });
+
+  it('transforms 1024^7', () => {
+    const value = Math.pow(1024, 7);
+    expect(pipe.transform(value)).toBe('1 ZB');
+  });
+
+  it('transforms 1024^8', () => {
+    const value = Math.pow(1024, 8);
+    expect(pipe.transform(value)).toBe('1 YB');
+  });
+});

--- a/src/glass/src/app/shared/pipes/bytes-to-size.pipe.ts
+++ b/src/glass/src/app/shared/pipes/bytes-to-size.pipe.ts
@@ -1,0 +1,17 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'bytesToSize'
+})
+export class BytesToSizePipe implements PipeTransform {
+  transform(bytes: number): string {
+    if (bytes === 0) {
+      return '0 Bytes';
+    }
+
+    const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
+    const factor = 1024;
+    const i = Math.floor(Math.log(bytes) / Math.log(factor));
+    return Math.round(bytes / Math.pow(factor, i)) + ' ' + sizes[i];
+  }
+}

--- a/src/glass/src/app/shared/shared.module.ts
+++ b/src/glass/src/app/shared/shared.module.ts
@@ -2,8 +2,11 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 
 import { MaterialModule } from '~/app/material.modules';
+import { BytesToSizePipe } from '~/app/shared/pipes/bytes-to-size.pipe';
 
 @NgModule({
+  declarations: [BytesToSizePipe],
+  exports: [BytesToSizePipe],
   imports: [CommonModule, MaterialModule]
 })
 export class SharedModule {}


### PR DESCRIPTION
Add a `bytes-to-size` pipe in order to convert
bytes into a nicely readable size string.

Signed-off-by: Tatjana Dehler <tdehler@suse.com>