### PR TITLE
gravel: provision osds through API call

### DIFF
--- a/src/gravel/api/orch.py
+++ b/src/gravel/api/orch.py
@@ -6,7 +6,9 @@
 # License as published by the Free Software Foundation; either
 # version 2.1 of the License, or (at your option) any later version.
 
+from logging import Logger
 from fastapi.routing import APIRouter
+from fastapi.logger import logger as fastapi_logger
 from pydantic import BaseModel
 from typing import Dict, List
 from gravel.cephadm.cephadm import Cephadm
@@ -16,6 +18,8 @@ from gravel.controllers.orch.models import OrchDevicesPerHostModel
 from gravel.controllers.orch.orchestrator \
     import Orchestrator
 
+
+logger: Logger = fastapi_logger
 
 router: APIRouter = APIRouter(
     prefix="/orch",
@@ -108,3 +112,16 @@ async def get_volumes() -> List[VolumeDeviceModel]:
 async def get_node_info() -> NodeInfoModel:
     cephadm = Cephadm()
     return await cephadm.get_node_info()
+
+
+@router.post("/devices/assimilate", response_model=bool)
+async def assimilate_devices() -> bool:
+
+    try:
+        orch = Orchestrator()
+        orch.assimilate_all_devices()
+    except Exception as e:
+        logger.error(str(e))
+        return False
+
+    return True

--- a/src/gravel/controllers/orch/orchestrator.py
+++ b/src/gravel/controllers/orch/orchestrator.py
@@ -30,3 +30,11 @@ class Orchestrator:
         cmd = {"prefix": "orch device ls"}
         res = self.call(cmd)
         return parse_obj_as(List[OrchDevicesPerHostModel], res)
+
+    def assimilate_all_devices(self) -> None:
+        cmd = {
+            "prefix": "orch apply osd",
+            "all_available_devices": True
+        }
+        res = self.call(cmd)
+        assert "result" in res


### PR DESCRIPTION
This is a very basic approach to assimilating existing available devices in a node and have osds deployed on them.

Signed-off-by: Joao Eduardo Luis \<joao@suse.com>