### PR TITLE
images: don't use filesystems:ceph OBS repo

### DIFF
--- a/images/microOS/config.xml
+++ b/images/microOS/config.xml
@@ -562,9 +562,6 @@
     <repository type="rpm-md" alias="Tumbleweed_OSS">
         <source path='https://download.opensuse.org/tumbleweed/repo/oss'/>
     </repository>
-    <repository type="rpm-md" alias="filesystems-Ceph">
-        <source path="https://download.opensuse.org/repositories/filesystems:/ceph/openSUSE_Tumbleweed/"/>
-    </repository>
     <packages type="image">
         <package name="live-add-yast-repos"/>
         <!-- Apparently zypper (?) doesn't like having multiple patterns with the same name,


### PR DESCRIPTION
Packages from filesystems:ceph build against openSUSE:Factory, which may include updates that haven't made it to the Tumbleweed updates repo yet, e.g.: a recent glibc update to v2.33 meant python3-ceph from filesystems:ceph wasn't installable, because only glibc v2.32 was actually available in the wild.

Signed-off-by: Tim Serong <tserong@suse.com>