### PR TITLE
glass: Allow bootstrapped cluster to access the dashboard

### DIFF
--- a/src/glass/src/app/shared/services/status-route-guard.service.ts
+++ b/src/glass/src/app/shared/services/status-route-guard.service.ts
@@ -46,11 +46,11 @@ export class StatusRouteGuardService implements CanActivate, CanActivateChild {
             }
             break;
           case 'bootstrapped':
-            url = '/installer/create/deployment';
-            if (url === state.url) {
+            const urls = ['/installer/create/deployment', '/dashboard'];
+            if (urls.includes(state.url)) {
               result = true;
             } else {
-              result = this.router.parseUrl(url);
+              result = this.router.parseUrl(urls[0]);
             }
             break;
           case 'ready':


### PR DESCRIPTION
Currently a cluster that is not in the "ready" state can't access the
dashboard, but this state can not be achieved yet as it's not
implemented. With a bootstrapped cluster however we can already
show data on the dashboard, this is why it should be possible to see it.

Possible means you can access it if you know the URL. It won't be made
visible to the user during the installation process yet as this is TBD.

Signed-off-by: Stephan Müller <smueller@suse.com>