### PR TITLE
Add containerized build environment for the MicroOS Vagrant box

### DIFF
--- a/images/microOS_build_env/Dockerfile
+++ b/images/microOS_build_env/Dockerfile
@@ -1,0 +1,9 @@
+FROM registry.opensuse.org/opensuse/leap:15.2
+MAINTAINER Volker Theile <vtheile@suse.com>
+
+RUN zypper ref && zypper --non-interactive install zsh git \
+    python3 python3-pip python3-rados python3-kiwi nodejs-common \
+    vagrant vagrant-libvirt npm sudo which gptfdisk kpartx \
+    btrfsprogs dosfstools e2fsprogs
+
+CMD ["zsh"]

--- a/images/microOS_build_env/README.md
+++ b/images/microOS_build_env/README.md
@@ -1,0 +1,19 @@
+# About this Docker container
+This Docker container is meant to be used on systems that are not based
+on openSUSE to be able to build the MicroOS based Vagrant box.
+
+# Build the container
+To build the container run the following command.
+```
+$ cd /<GIT_REPO>/aquarium/images/microOS_build_env
+$ docker build -t aquarium-dev-docker .
+```
+
+# Run the container
+The `Aquarium` git repository will be mounted to `/srv/aquarium` in the container.
+```
+$ docker run -itd -v /<GIT_REPO>/aquarium:/srv/aquarium --hostname=aquarium-dev-docker --privileged aquarium-dev-docker
+```
+
+# Build the MicroOS Vagrant box
+Please consult the `doc/from-zero-to-hacking.md` document for more information.

--- a/tests/vagrant/setup.sh
+++ b/tests/vagrant/setup.sh
@@ -64,9 +64,9 @@ done
   echo "error: setup with name '${setup_name} already exists" && \
   exit 1
 
-
+echo "=> Searching for Vagrant box '${box}' ..."
 if ! vagrant box list | grep -q "^${box}[ ]\+" ; then
-  echo "=> vagrant box '${box}' not found, searching for existing build"
+  echo "=> Vagrant box '${box}' not found, searching for existing build"
 
   imgdir=$(realpath ${basedir}/../../images)
 
@@ -88,6 +88,8 @@ if ! vagrant box list | grep -q "^${box}[ ]\+" ; then
     exit 1
 
   vagrant box add ${box} ${img} || exit 1
+else
+  echo "=> Vagrant box '${box}' already exists"
 fi
 
 sdir=${setupdir}/${setup_name}

--- a/tools/setup-dev.sh
+++ b/tools/setup-dev.sh
@@ -45,12 +45,12 @@ while [[ $# -gt 0 ]]; do
   shift 1
 done
 
-osid=$(grep '^ID=' /etc/os-release)
+osid=$(grep '^ID=' /etc/os-release | sed -e 's/^ID="\(.\+\)"/\1/')
 
 if ${show_dependencies} ; then
 
   case $osid in
-    *opensuse-tumbleweed*)
+    opensuse-tumbleweed | opensuse-leap)
       echo "  > ${dependencies_opensuse_tumbleweed[*]}"
       ;;
     *)
@@ -67,7 +67,7 @@ fi
 if ! ${skip_install_deps} ; then
 
   case $osid in
-    *opensuse-tumbleweed*)
+    opensuse-tumbleweed | opensuse-leap)
       echo "=> try installing dependencies"
       sudo zypper --non-interactive install ${dependencies_opensuse_tumbleweed[*]} || exit 1
       ;;


### PR DESCRIPTION
Add a Dockerfile that creates a container to be able to build the MicroOS Vagrant box on non openSUSE systems.

Signed-off-by: Volker Theile <vtheile@suse.com>