### PR TITLE
glass: Volumes widget loading

### DIFF
--- a/src/glass/src/app/core/dashboard/widgets/abstract-dashboard-widget.ts
+++ b/src/glass/src/app/core/dashboard/widgets/abstract-dashboard-widget.ts
@@ -10,13 +10,14 @@ export abstract class AbstractDashboardWidget<T> implements OnInit, OnDestroy {
   readonly loadDataEvent = new EventEmitter<T>();
 
   error = false;
+  firstLoadComplete = false;
   loading = false;
   data?: T;
 
   protected refreshDataSubscription?: Subscription;
 
   get reloadPeriod(): number {
-    return 5000;
+    return 15000;
   }
 
   ngOnInit(): void {
@@ -44,6 +45,9 @@ export abstract class AbstractDashboardWidget<T> implements OnInit, OnDestroy {
           this.error = true;
         }),
         finalize(() => {
+          if (!this.firstLoadComplete) {
+            this.firstLoadComplete = true;
+          }
           this.loading = false;
         })
       )

--- a/src/glass/src/app/core/dashboard/widgets/volumes-dashboard-widget/volumes-dashboard-widget.component.html
+++ b/src/glass/src/app/core/dashboard/widgets/volumes-dashboard-widget/volumes-dashboard-widget.component.html
@@ -7,12 +7,13 @@
        class="glass-volumes-dashboard-widget-table"
        fxFlex
        fxLayout="column">
-    <div class="glass-volumes-dashboard-widget-loader">
+    <div class="glass-volumes-dashboard-widget-loader" *ngIf="!firstLoadComplete">
       <mat-progress-bar *ngIf="loading"
                         mode="indeterminate">
       </mat-progress-bar>
     </div>
     <table mat-table
+           *ngIf="firstLoadComplete"
            [dataSource]="data">
       <ng-container matColumnDef="path">
         <th mat-header-cell *matHeaderCellDef>Path</th>

--- a/src/glass/src/app/core/dashboard/widgets/volumes-dashboard-widget/volumes-dashboard-widget.component.ts
+++ b/src/glass/src/app/core/dashboard/widgets/volumes-dashboard-widget/volumes-dashboard-widget.component.ts
@@ -18,10 +18,6 @@ export class VolumesDashboardWidgetComponent extends AbstractDashboardWidget<Vol
     super();
   }
 
-  get reloadPeriod(): number {
-    return 30000;
-  }
-
   loadData(): Observable<Volume[]> {
     return this.service
       .volumes()


### PR DESCRIPTION
![volumes_loading](https://user-images.githubusercontent.com/16167865/108183975-f3deab00-710a-11eb-91e2-3b16c4ad3f6e.gif)


Now the volumes widgets loading bar will only appear on the first load,
not on all other as it looks irritating. Set the interval for all
widgets to 15 seconds, which is still fast.

Signed-off-by: Stephan Müller <smueller@suse.com>