### PR TITLE
glass: Code cleanup and improvements to the UI look

### DIFF
--- a/src/glass/src/app/core/dashboard/widgets/volumes-dashboard-widget/volumes-dashboard-widget.component.spec.ts
+++ b/src/glass/src/app/core/dashboard/widgets/volumes-dashboard-widget/volumes-dashboard-widget.component.spec.ts
@@ -205,7 +205,7 @@ describe('DevicesDashboardWidgetComponent', () => {
 
   it('should filter out not available devices', (done) => {
     component.loadData().subscribe((x) => {
-      expect(x.every((v) => v.available)).toBe(true);
+      expect(x.length > 0).toBe(true);
       done();
     });
   });

--- a/src/glass/src/app/core/dashboard/widgets/volumes-dashboard-widget/volumes-dashboard-widget.component.ts
+++ b/src/glass/src/app/core/dashboard/widgets/volumes-dashboard-widget/volumes-dashboard-widget.component.ts
@@ -1,6 +1,5 @@
 import { Component } from '@angular/core';
 import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
 
 import { AbstractDashboardWidget } from '~/app/core/dashboard/widgets/abstract-dashboard-widget';
 import { OrchService, Volume } from '~/app/shared/services/api/orch.service';
@@ -19,8 +18,6 @@ export class VolumesDashboardWidgetComponent extends AbstractDashboardWidget<Vol
   }
 
   loadData(): Observable<Volume[]> {
-    return this.service
-      .volumes()
-      .pipe(map((volumes) => volumes.filter((volume) => volume.available)));
+    return this.service.volumes();
   }
 }

--- a/src/glass/src/app/pages/deployment-page/deployment-page.component.html
+++ b/src/glass/src/app/pages/deployment-page/deployment-page.component.html
@@ -65,11 +65,11 @@
       <th mat-header-cell *matHeaderCellDef> Available </th>
       <td mat-cell *matCellDef="let row">
         <mat-icon *ngIf="row.available"
-                  style="color: green"
+                  class="glass-color-success"
                   svgIcon="mdi:check">
         </mat-icon>
         <mat-icon *ngIf="!row.available"
-                  style="color: red"
+                  class="glass-color-error"
                   svgIcon="mdi:close">
         </mat-icon>
       </td>
@@ -128,20 +128,21 @@
   <div class="summary">
     <div fxLayout="column"
          fxLayoutAlign="center center"
-         fxLayoutGap="5px"
+         fxLayoutGap="16px"
          fxFlexFill>
       <div>
-        <mat-icon svgIcon="mdi:check-circle-outline"
-                  class="icon-large"
-                  *ngIf="deploymentSuccessful">
+        <mat-icon *ngIf="deploymentSuccessful"
+                  class="glass-icon-large"
+                  svgIcon="mdi:check-circle-outline">
         </mat-icon>
-        <mat-icon svgIcon="mdi:close-circle-outline"
-                  class="icon-large" *ngIf="!deploymentSuccessful">
+        <mat-icon *ngIf="!deploymentSuccessful"
+                  class="glass-icon-large"
+                  svgIcon="mdi:close-circle-outline">
         </mat-icon>
       </div>
-      <div fxLayout="column"
-           fxLayoutAlign="center center"
-           *ngIf="deploymentSuccessful">
+      <div *ngIf="deploymentSuccessful"
+           fxLayout="column"
+           fxLayoutAlign="center center">
         <p>
           Your deployment was successful and is now ready to use.
         </p>

--- a/src/glass/src/app/pages/deployment-page/deployment-page.component.scss
+++ b/src/glass/src/app/pages/deployment-page/deployment-page.component.scss
@@ -77,13 +77,3 @@
 .service-panel-align .mat-form-field + .mat-form-field {
   margin-left: 8px;
 }
-
-.summary {
-  height: 220px;
-
-  .icon-large {
-    font-size: 120px;
-    width: 120px;
-    height: 120px;
-  }
-}

--- a/src/glass/src/app/pages/not-found-page/not-found-page.component.html
+++ b/src/glass/src/app/pages/not-found-page/not-found-page.component.html
@@ -2,7 +2,7 @@
      fxLayoutAlign="center center">
   <div fxLayout="column"
        fxLayoutAlign="center center">
-    <mat-icon class="big-alert-icon"
+    <mat-icon class="glass-icon-large"
               svgIcon="mdi:fishbowl-outline">
     </mat-icon>
     <h1>Sorry, we could not find what you are looking for.</h1>

--- a/src/glass/src/app/pages/not-found-page/not-found-page.component.scss
+++ b/src/glass/src/app/pages/not-found-page/not-found-page.component.scss
@@ -10,9 +10,4 @@
   background-size: cover;
   background-repeat: no-repeat;
   background-position: center center;
-
-  .big-alert-icon {
-    height: 100px;
-    width: 100px;
-  }
 }

--- a/src/glass/src/defaults.scss
+++ b/src/glass/src/defaults.scss
@@ -4,6 +4,7 @@ $glass-color-white: white;
 
 $eos-bc-red-500: #dc3545;
 $eos-bc-pine-500: #0c322c;
+$eos-bc-green-500: #30ba78;
 
 $eos-green-palette: (
   50: #e6f7ef,

--- a/src/glass/src/styles.scss
+++ b/src/glass/src/styles.scss
@@ -50,6 +50,14 @@ $glass-color-accent-complementary: white;
 .glass-color-accent {
   color: $glass-color-accent;
 }
+.glass-color-green,
+.glass-color-success {
+  color: $eos-bc-green-500;
+}
+.glass-color-red,
+.glass-color-error {
+  color: $eos-bc-red-500;
+}
 
 .glass-text-pre-wrap {
   white-space: pre-wrap;
@@ -59,6 +67,11 @@ $glass-color-accent-complementary: white;
 }
 .glass-text-center {
   text-align: center;
+}
+
+.glass-icon-large {
+  height: 100px;
+  width: 100px;
 }
 
 html,


### PR DESCRIPTION
- Use global style classes
- Use 16px for fxLayoutGap (Material default for nearly everything like that)
- Let the browser and the Material framework decide how height page content is rendered wherever possible
- Remove filter in volumes widget, otherwise no volumes are displayed after the disks have been assimilated

Signed-off-by: Volker Theile <vtheile@suse.com>