### PR TITLE
[WIP] glass: set the deployment status correctly

### DIFF
--- a/src/glass/src/app/pages/deployment-page/deployment-page.component.ts
+++ b/src/glass/src/app/pages/deployment-page/deployment-page.component.ts
@@ -27,7 +27,7 @@ export class DeploymentPageComponent implements OnInit {
   devices: Device[] = [];
   deploymentStepper!: MatStepper;
   displayInventory = true;
-  deploymentSuccessful = false;
+  deploymentSuccessful = true;
 
   constructor(
     private dialog: MatDialog,
@@ -80,6 +80,7 @@ export class DeploymentPageComponent implements OnInit {
         }
       },
       () => {
+        this.deploymentSuccessful = false;
         this.displayInventory = true;
         this.blockUI.stop();
       }
@@ -88,6 +89,7 @@ export class DeploymentPageComponent implements OnInit {
 
   pollAssimilationStatus(): void {
     const handleError = (err?: any) => {
+      this.deploymentSuccessful = false;
       this.displayInventory = true;
       this.blockUI.stop();
       this.notificationService.show('Failed to deploy disks.', {


### PR DESCRIPTION
Set the deployment status correctly in order
to show the right summary page (deployment was
successful/not successful).

Assume the deployment to be successful by default
and update it to false as soon as an error has
been returned by the API.

The PR is WIP because it might need to be updated
to the changes made by https://github.com/aquarist-labs/aquarium/pull/142 . 

Signed-off-by: Tatjana Dehler <tdehler@suse.com>