### PR TITLE
glass: Services dashboard widget

### DIFF
--- a/src/glass/src/app/core/dashboard/dashboard.module.ts
+++ b/src/glass/src/app/core/dashboard/dashboard.module.ts
@@ -5,6 +5,7 @@ import { FlexLayoutModule } from '@angular/flex-layout';
 
 import { CapacityDashboardWidgetComponent } from '~/app/core/dashboard/widgets/capacity-dashboard-widget/capacity-dashboard-widget.component';
 import { HealthDashboardWidgetComponent } from '~/app/core/dashboard/widgets/health-dashboard-widget/health-dashboard-widget.component';
+import { ServicesDashboardWidgetComponent } from '~/app/core/dashboard/widgets/services-dashboard-widget/services-dashboard-widget.component';
 import { VolumesDashboardWidgetComponent } from '~/app/core/dashboard/widgets/volumes-dashboard-widget/volumes-dashboard-widget.component';
 import { MaterialModule } from '~/app/material.modules';
 import { SharedModule } from '~/app/shared/shared.module';
@@ -13,12 +14,14 @@ import { SharedModule } from '~/app/shared/shared.module';
   declarations: [
     CapacityDashboardWidgetComponent,
     VolumesDashboardWidgetComponent,
-    HealthDashboardWidgetComponent
+    HealthDashboardWidgetComponent,
+    ServicesDashboardWidgetComponent
   ],
   exports: [
     CapacityDashboardWidgetComponent,
     VolumesDashboardWidgetComponent,
-    HealthDashboardWidgetComponent
+    HealthDashboardWidgetComponent,
+    ServicesDashboardWidgetComponent
   ],
   imports: [CommonModule, FlexLayoutModule, MaterialModule, SharedModule]
 })

--- a/src/glass/src/app/core/dashboard/widgets/services-dashboard-widget/services-dashboard-widget.component.html
+++ b/src/glass/src/app/core/dashboard/widgets/services-dashboard-widget/services-dashboard-widget.component.html
@@ -1,0 +1,51 @@
+<mat-card class="glass-services-dashboard-widget"
+     [ngClass]="{'error': error}"
+     fxFlex
+     fxLayout="row"
+     fxLayoutAlign="center center">
+  <div *ngIf="!error && firstLoadComplete && data.length === 0">
+    <p>No services deployed yet.</p>
+    <button mat-raised-button routerLink="/installer/create/deployment">Deploy a service</button>
+  </div>
+  <div *ngIf="!error"
+       class="glass-services-dashboard-widget-table"
+       fxFlex
+       fxLayout="column">
+    <div class="glass-services-dashboard-widget-loader" *ngIf="!firstLoadComplete">
+      <mat-progress-bar *ngIf="loading"
+                        mode="indeterminate">
+      </mat-progress-bar>
+    </div>
+    <table mat-table
+           *ngIf="firstLoadComplete && data.length > 0"
+           [dataSource]="data">
+      <ng-container matColumnDef="name">
+        <th mat-header-cell *matHeaderCellDef>Name</th>
+        <td mat-cell *matCellDef="let element">{{element.name}}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="type">
+        <th mat-header-cell *matHeaderCellDef>Type</th>
+        <td mat-cell *matCellDef="let element">{{element.type}}</td>
+      </ng-container>
+
+      <!-- Not available ATM therefore hidden -->
+      <ng-container matColumnDef="space">
+        <th mat-header-cell *matHeaderCellDef>Space</th>
+        <td mat-cell *matCellDef="let element">na</td>
+      </ng-container>
+
+      <!-- Not available ATM therefore hidden -->
+      <ng-container matColumnDef="redundancy">
+        <th mat-header-cell *matHeaderCellDef>Redundancy Level</th>
+        <td mat-cell *matCellDef="let element">na</td>
+      </ng-container>
+
+      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+    </table>
+  </div>
+  <mat-icon *ngIf="error"
+            svgIcon="mdi:lan-disconnect">
+  </mat-icon>
+</mat-card>

--- a/src/glass/src/app/core/dashboard/widgets/services-dashboard-widget/services-dashboard-widget.component.scss
+++ b/src/glass/src/app/core/dashboard/widgets/services-dashboard-widget/services-dashboard-widget.component.scss
@@ -1,0 +1,20 @@
+@import 'styles.scss';
+
+.glass-services-dashboard-widget {
+  .glass-services-dashboard-widget-table {
+    .glass-services-dashboard-widget-loader {
+      height: 4px;
+    }
+
+    table {
+      width: 100%;
+    }
+  }
+  .mat-card {
+    padding: 24px;
+  }
+}
+.glass-services-dashboard-widget.error {
+  @extend .glass-color-theme-error;
+  height: 50px;
+}

--- a/src/glass/src/app/core/dashboard/widgets/services-dashboard-widget/services-dashboard-widget.component.spec.ts
+++ b/src/glass/src/app/core/dashboard/widgets/services-dashboard-widget/services-dashboard-widget.component.spec.ts
@@ -1,0 +1,26 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DashboardModule } from '~/app/core/dashboard/dashboard.module';
+import { ServicesDashboardWidgetComponent } from '~/app/core/dashboard/widgets/services-dashboard-widget/services-dashboard-widget.component';
+
+describe('cephfsDashboardWidgetComponent', () => {
+  let component: ServicesDashboardWidgetComponent;
+  let fixture: ComponentFixture<ServicesDashboardWidgetComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DashboardModule, HttpClientTestingModule]
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ServicesDashboardWidgetComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/glass/src/app/core/dashboard/widgets/services-dashboard-widget/services-dashboard-widget.component.ts
+++ b/src/glass/src/app/core/dashboard/widgets/services-dashboard-widget/services-dashboard-widget.component.ts
@@ -1,0 +1,24 @@
+import { Component } from '@angular/core';
+import { Observable } from 'rxjs';
+
+import { AbstractDashboardWidget } from '~/app/core/dashboard/widgets/abstract-dashboard-widget';
+import { ServiceDesc, ServicesService } from '~/app/shared/services/api/services.service';
+
+@Component({
+  selector: 'glass-services-dashboard-widget',
+  templateUrl: './services-dashboard-widget.component.html',
+  styleUrls: ['./services-dashboard-widget.component.scss']
+})
+export class ServicesDashboardWidgetComponent extends AbstractDashboardWidget<ServiceDesc[]> {
+  data: ServiceDesc[] = [];
+  displayedColumns: string[] = ['name', 'type'];
+
+  constructor(private service: ServicesService) {
+    super();
+    console.log(this.service);
+  }
+
+  loadData(): Observable<ServiceDesc[]> {
+    return this.service.list();
+  }
+}

--- a/src/glass/src/app/pages/dashboard-page/dashboard-page.component.html
+++ b/src/glass/src/app/pages/dashboard-page/dashboard-page.component.html
@@ -28,6 +28,9 @@
             <ng-template [ngSwitchCase]="'health'">
               <glass-health-dashboard-widget></glass-health-dashboard-widget>
             </ng-template>
+            <ng-template [ngSwitchCase]="'services'">
+              <glass-services-dashboard-widget></glass-services-dashboard-widget>
+            </ng-template>
           </mat-card-content>
         </mat-card>
       </ng-container>

--- a/src/glass/src/app/pages/dashboard-page/dashboard-page.component.ts
+++ b/src/glass/src/app/pages/dashboard-page/dashboard-page.component.ts
@@ -10,22 +10,26 @@ import { LocalStorageService } from '~/app/shared/services/local-storage.service
   styleUrls: ['./dashboard-page.component.scss']
 })
 export class DashboardPageComponent implements OnInit {
-  enabled: string[] = ['capacity', 'volumes', 'health'];
+  enabled: string[] = ['health', 'capacity', 'services', 'volumes'];
 
   // New dashboard widgets must be added here. Don't forget to enhance
   // the template to render the new widget.
   readonly widgets: DashboardWidgetConfig[] = [
     {
+      id: 'health',
+      title: 'Health'
+    },
+    {
       id: 'capacity',
       title: 'Capacity'
     },
     {
-      id: 'volumes',
-      title: 'Volumes'
+      id: 'services',
+      title: 'Services'
     },
     {
-      id: 'health',
-      title: 'Health'
+      id: 'volumes',
+      title: 'Volumes'
     }
   ];
 

--- a/src/glass/src/app/shared/services/api/services.service.spec.ts
+++ b/src/glass/src/app/shared/services/api/services.service.spec.ts
@@ -1,12 +1,15 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 
-import { ServicesService } from '~/app/shared/services/api/services.service';
+import { ServicesService } from './services.service';
 
 describe('ServicesService', () => {
   let service: ServicesService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule]
+    });
     service = TestBed.inject(ServicesService);
   });
 


### PR DESCRIPTION
Simple widget to only currently show the name and the type of the share
as some useful information is missing in the current API. It will route
to the deployment page if no service is found.

Signed-off-by: Stephan Müller <smueller@suse.com>