### PR TITLE
gravel: add env for custom config path

### DIFF
--- a/run_aquarium.sh
+++ b/run_aquarium.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
 
+SCRIPT_NAME=$(basename ${BASH_SOURCE[0]})
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
 if ! which uvicorn >&/dev/null ; then
   echo "unable to find uvicorn in path"
   exit 1
 fi
 
 pushd src &>/dev/null
-DEBUG=1 uvicorn aquarium:app --host 0.0.0.0 --port 1337
+AQUARIUM_CONFIG_DIR=${SCRIPT_DIR}/conf DEBUG=1 uvicorn aquarium:app --host 0.0.0.0 --port 1337
 popd &>/dev/null

--- a/src/gravel/controllers/config.py
+++ b/src/gravel/controllers/config.py
@@ -1,3 +1,4 @@
+import os
 from enum import Enum
 from logging import Logger
 from pathlib import Path
@@ -8,6 +9,12 @@ from fastapi.logger import logger as fastapi_logger
 
 logger: Logger = fastapi_logger
 
+
+_env_prefix = "AQUARIUM_"
+_env_config_dir = "CONFIG_DIR"
+_config_dir_env = os.getenv(f"{_env_prefix}{_env_config_dir}")
+
+config_dir: str = _config_dir_env if _config_dir_env else '/etc/aquarium'
 
 
 class DeploymentStage(str, Enum):
@@ -25,7 +32,7 @@ class DeploymentStateModel(BaseModel):
 class OptionsModel(BaseModel):
     inventory_probe_interval: int = Field(60, title="Inventory Probe Interval")
     storage_probe_interval: float = Field(30.0, title="Storage Probe Interval")
-    service_state_path: str = Field("/etc/aquarium/storage.json",
+    service_state_path: str = Field(Path(config_dir).joinpath("storage.json"),
                                     title="Path to Service State file")
 
 
@@ -38,7 +45,7 @@ class ConfigModel(BaseModel):
 
 class Config:
 
-    def __init__(self, path: str = "/etc/aquarium"):
+    def __init__(self, path: str = config_dir):
         confdir = Path(path)
         self.confpath = confdir.joinpath(Path("config.json"))
         logger.debug(f'Aquarium config dir: {confdir}')

--- a/src/gravel/controllers/config.py
+++ b/src/gravel/controllers/config.py
@@ -1,7 +1,13 @@
 from enum import Enum
+from logging import Logger
 from pathlib import Path
 from datetime import datetime
 from pydantic import BaseModel, Field
+from fastapi.logger import logger as fastapi_logger
+
+
+logger: Logger = fastapi_logger
+
 
 
 class DeploymentStage(str, Enum):
@@ -35,6 +41,7 @@ class Config:
     def __init__(self, path: str = "/etc/aquarium"):
         confdir = Path(path)
         self.confpath = confdir.joinpath(Path("config.json"))
+        logger.debug(f'Aquarium config dir: {confdir}')
 
         confdir.mkdir(0o700, parents=True, exist_ok=True)
 
@@ -52,6 +59,7 @@ class Config:
         self.config: ConfigModel = ConfigModel.parse_file(self.confpath)
 
     def _saveConfig(self, conf: ConfigModel) -> None:
+        logger.debug(f'Writing Aquarium config: {self.confpath}')
         self.confpath.write_text(conf.json(indent=2))
 
     @property

--- a/src/gravel/controllers/tests/test_config.py
+++ b/src/gravel/controllers/tests/test_config.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from pathlib import Path
 from pyfakefs.fake_filesystem_unittest import TestCase
 
 from gravel.controllers.config \
@@ -18,3 +19,10 @@ class TestConfig(TestCase):
         ds = Config().deployment_state
         assert ds.stage == DeploymentStage.none
         assert ds.last_modified < datetime.now()
+
+    def test_config_path(self):
+        config = Config()
+        assert config.confpath == Path('/etc/aquarium/config.json')
+
+        config = Config(path='foo')
+        assert config.confpath == Path('foo/config.json')


### PR DESCRIPTION
Adds environment var `AQUARIUM_CONFIG_DIR=` for specifying a custom
location to the aquarium config files

Resolves: #160 
Signed-off-by: Michael Fritch <mfritch@suse.com>