### PR TITLE
glass: fix bug when fetching devices

### DIFF
--- a/src/glass/src/app/pages/deployment-page/deployment-page.component.ts
+++ b/src/glass/src/app/pages/deployment-page/deployment-page.component.ts
@@ -41,6 +41,7 @@ export class DeploymentPageComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
+    this.startBlockUI('Please wait, fetching device information ...');
     this.getDevices(0);
     this.updateCephfsList();
   }
@@ -51,7 +52,6 @@ export class DeploymentPageComponent implements OnInit {
 
   getDevices(attempt: number): void {
     const maxAttempts = 5;
-    this.startBlockUI('Please wait, fetching device information ...');
     of(true)
       .pipe(
         delay(5000),


### PR DESCRIPTION
Do not only check if there is a HostDevice
object. Do also check (5 times) if any
device is returned by the API.

Signed-off-by: Tatjana Dehler <tdehler@suse.com>