### PR TITLE
run_aquarium.sh: specify config, debug on cli

### DIFF
--- a/run_aquarium.sh
+++ b/run_aquarium.sh
@@ -3,11 +3,58 @@
 SCRIPT_NAME=$(basename ${BASH_SOURCE[0]})
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
+usage() {
+  cat <<EOF
+usage: ${SCRIPT_NAME} [options]
+
+options:
+  -d|--debug        Enable debug logging to stdout
+  -c|--config PATH  Set config directory to PATH
+  -n|--new          Run as new deployment; blows config path if it exists
+  -h|--help         This message
+
+EOF
+}
+
+is_debug=false
+has_config=false
+config_path=""
+is_new=false
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -d|--debug) is_debug=true ;;
+    -c|--config) has_config=true ; config_path=$2 ; shift 1 ;;
+    -n|--new) is_new=true ;;
+    -h|--help) usage ; exit 0 ;;
+    *)
+      echo "error: unknown option '${1}'"
+      exit 1
+      ;;
+  esac
+  shift 1
+done
+
 if ! which uvicorn >&/dev/null ; then
-  echo "unable to find uvicorn in path"
+  echo "error: unable to find uvicorn in path"
   exit 1
 fi
 
+$has_config && [[ -z "${config_path}" ]] && \
+  echo "error: must specify a PATH with '--config'" && \
+  exit 1
+
+config_path=$(realpath ${config_path})
+
+$has_config && $is_new && [[ -e "${config_path}" ]] && \
+  ( rm -fr ${config_path} || exit 1 )
+
+
 pushd src &>/dev/null
-AQUARIUM_CONFIG_DIR=${SCRIPT_DIR}/conf DEBUG=1 uvicorn aquarium:app --host 0.0.0.0 --port 1337
+
+$is_debug && export DEBUG=1
+$has_config && export AQUARIUM_CONFIG_DIR=${config_path}
+
+uvicorn aquarium:app --host 0.0.0.0 --port 1337
+
 popd &>/dev/null

--- a/run_aquarium.sh
+++ b/run_aquarium.sh
@@ -52,7 +52,7 @@ $has_config && $is_new && [[ -e "${config_path}" ]] && \
 
 pushd src &>/dev/null
 
-$is_debug && export DEBUG=1
+$is_debug && export AQUARIUM_DEBUG=1
 $has_config && export AQUARIUM_CONFIG_DIR=${config_path}
 
 uvicorn aquarium:app --host 0.0.0.0 --port 1337

--- a/src/aquarium.py
+++ b/src/aquarium.py
@@ -43,7 +43,7 @@ api = FastAPI()
 async def on_startup():
     uvilogger = cast(logging.Handler, logging.getLogger("uvicorn"))
     logger.addHandler(uvilogger)
-    if os.getenv("DEBUG"):
+    if os.getenv("AQUARIUM_DEBUG"):
         uvilogger.setLevel(logging.DEBUG)
         logger.setLevel(logging.DEBUG)
     logger.info("Aquarium startup!")


### PR DESCRIPTION
Automatically inferring where to put the config file is causing a few issues:
1. people get confused as to why the config ends up in a `conf/` directory in the project's root while running in a VM; and
2. running a fresh image with an NFS mount to the repo's root containing a `conf` directory from a previous run would cause all sorts of troubles on the backend (mainly because the state in the config would not match the actual fresh status of the system).

This patchset makes the config location configurable, letting the user do whatever they want, and ensures we can specify it's a new run (via `-n|--new`) to blow away any existing configuration.

Signed-off-by: Joao Eduardo Luis \<joao@suse.com>