### PR TITLE
gravel: expose bootstrap progress

### DIFF
--- a/src/gravel/api/bootstrap.py
+++ b/src/gravel/api/bootstrap.py
@@ -48,6 +48,7 @@ class StartReplyModel(BaseModel):
 
 class StatusReplyModel(BaseModel):
     stage: BootstrapStage = Field(title="Current bootstrapping stage")
+    progress: int = Field(0, Field="Bootstrap progress (percent)")
 
 
 @router.post("/start", response_model=StartReplyModel)
@@ -60,7 +61,8 @@ async def start_bootstrap() -> StartReplyModel:
 @router.get("/status", response_model=StatusReplyModel)
 async def get_status() -> StatusReplyModel:
     stage: BootstrapStage = await bootstrap.get_stage()
-    return StatusReplyModel(stage=stage)
+    percent: int = await bootstrap.get_progress()
+    return StatusReplyModel(stage=stage, progress=percent)
 
 
 @router.post("/finished", response_model=bool)

--- a/src/gravel/controllers/bootstrap.py
+++ b/src/gravel/controllers/bootstrap.py
@@ -49,9 +49,11 @@ class BootstrapStage(int, Enum):
 class Bootstrap:
 
     stage: BootstrapStage
+    progress: int
 
     def __init__(self):
         self.stage = BootstrapStage.NONE
+        self.progress = 0
         pass
 
     async def _should_bootstrap(self) -> bool:
@@ -91,6 +93,9 @@ class Bootstrap:
     async def get_stage(self) -> BootstrapStage:
         return self.stage
 
+    async def get_progress(self) -> int:
+        return self.progress
+
     async def _do_bootstrap(self) -> None:
         mgr: NodeMgr = get_node_mgr()
         address = mgr.address
@@ -104,10 +109,14 @@ class Bootstrap:
 
         self.stage = BootstrapStage.RUNNING
 
+        def progress_cb(percent: int) -> None:
+            logger.debug(f"bootstrap > {percent}")
+            self.progress = percent
+
         retcode: int = 0
         try:
             cephadm: Cephadm = Cephadm()
-            _, _, retcode = await cephadm.bootstrap(address)
+            _, _, retcode = await cephadm.bootstrap(address, progress_cb)
         except Exception as e:
             raise BootstrapError(e) from e
 

--- a/src/gravel/tests/unit/cephadm/test_cephadm.py
+++ b/src/gravel/tests/unit/cephadm/test_cephadm.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 import json
 import os
 import pytest
@@ -14,7 +14,7 @@ DATA_DIR = os.path.join(os.path.dirname(__file__), 'data')
 @pytest.mark.asyncio
 async def test_bootstrap(mocker):
 
-    async def mock_call(cmd: str) -> Tuple[str, str, int]:
+    async def mock_call(cmd: str, cb: Optional[Any]) -> Tuple[str, str, int]:
         return "foo", "bar", 0
 
     cephadm = Cephadm()


### PR DESCRIPTION
This is extremely fragile, as we're essentially parsing cephadm's
free-form output and associating each step with a rule of thumbs
percentage. Should cephadm change their messaging, this can easily
break.

Signed-off-by: Joao Eduardo Luis \<joao@suse.com>