### PR TITLE
gravel: Add check before calling realpath

### DIFF
--- a/run_aquarium.sh
+++ b/run_aquarium.sh
@@ -45,7 +45,9 @@ $has_config && [[ -z "${config_path}" ]] && \
   echo "error: must specify a PATH with '--config'" && \
   exit 1
 
-config_path=$(realpath ${config_path})
+if [ -n "${config_path}" ]; then
+  config_path=$(realpath ${config_path})
+fi
 
 $has_config && $is_new && [[ -e "${config_path}" ]] && \
   ( rm -fr ${config_path} || exit 1 )


### PR DESCRIPTION
This will prevent the following error:
```
node01:/srv/aquarium # ./run_aquarium.sh --debug
realpath: missing operand
Try 'realpath --help' for more information.
```

Signed-off-by: Volker Theile <vtheile@suse.com>