### PR TITLE
tools/build-image.sh: move systemd unit dir

### DIFF
--- a/tools/build-image.sh
+++ b/tools/build-image.sh
@@ -124,9 +124,9 @@ build_glass() {
 bundle() {
   bundledir=${build}/bundle
   bundle_usr=${bundledir}/usr/share/aquarium
-  bundle_etc=${bundledir}/etc/systemd/system
+  bundle_unit=${bundledir}/usr/lib/systemd/system
   bundle_sbin=${bundledir}/usr/sbin
-  mkdir -p ${bundle_usr} ${bundle_etc} ${bundle_sbin} || true
+  mkdir -p ${bundle_usr} ${bundle_unit} ${bundle_sbin} || true
   build_glass || exit 1
 
   pushd ${rootdir}
@@ -143,7 +143,7 @@ bundle() {
     ./gravel/ceph.git/src/cephadm/cephadm || exit 1
   popd
 
-  cp ${rootdir}/systemd/aquarium.service ${bundle_etc} || exit 1
+  cp ${rootdir}/systemd/aquarium.service ${bundle_unit} || exit 1
 
   pushd ${build}
   tar -C ${bundledir} usr etc -cf aquarium.tar || exit 1

--- a/tools/build-image.sh
+++ b/tools/build-image.sh
@@ -122,10 +122,11 @@ build_glass() {
 }
 
 bundle() {
-  bundledir=${build}/bundle
-  bundle_usr=${bundledir}/usr/share/aquarium
-  bundle_unit=${bundledir}/usr/lib/systemd/system
-  bundle_sbin=${bundledir}/usr/sbin
+  local bundledir=${build}/bundle
+  local bundle_usr=${bundledir}/usr/share/aquarium
+  local bundle_unit=${bundledir}/usr/lib/systemd/system
+  local bundle_sbin=${bundledir}/usr/sbin
+
   mkdir -p ${bundle_usr} ${bundle_unit} ${bundle_sbin} || true
   build_glass || exit 1
 


### PR DESCRIPTION
'/etc/systemd/system/' -> '/usr/lib/systemd/system/'

Resolves: #190
Signed-off-by: Michael Fritch <mfritch@suse.com>