### PR TITLE
tools/build-image.sh: remove etc dir from tar bundle

### DIFF
--- a/tools/build-image.sh
+++ b/tools/build-image.sh
@@ -147,7 +147,7 @@ bundle() {
   cp ${rootdir}/systemd/aquarium.service ${bundle_unit} || exit 1
 
   pushd ${build}
-  tar -C ${bundledir} usr etc -cf aquarium.tar || exit 1
+  tar -C ${bundledir} usr -cf aquarium.tar || exit 1
   popd
 }
 


### PR DESCRIPTION
fix-up of 8833771

Signed-off-by: Michael Fritch <mfritch@suse.com>