### PR TITLE
gravel: add unit test for config options

### DIFF
--- a/src/gravel/controllers/config.py
+++ b/src/gravel/controllers/config.py
@@ -38,8 +38,8 @@ class StorageOptionsModel(BaseModel):
 
 
 class OptionsModel(BaseModel):
-    service_state_path: str = Field(Path(config_dir).joinpath("storage.json"),
-                                    title="Path to Service State file")
+    service_state_path: Path = Field(Path(config_dir).joinpath("storage.json"),
+                                     title="Path to Service State file")
     inventory: InventoryOptionsModel = Field(InventoryOptionsModel())
     storage: StorageOptionsModel = Field(StorageOptionsModel())
 
@@ -69,6 +69,7 @@ class Config:
                     stage=DeploymentStage.none
                 )
             )
+            initconf.options.service_state_path = Path(path).joinpath("storage.json")
             self._saveConfig(initconf)
 
         self.config: ConfigModel = ConfigModel.parse_file(self.confpath)

--- a/src/gravel/controllers/tests/test_config.py
+++ b/src/gravel/controllers/tests/test_config.py
@@ -20,9 +20,16 @@ class TestConfig(TestCase):
         assert ds.stage == DeploymentStage.none
         assert ds.last_modified < datetime.now()
 
+    def test_config_options(self):
+        opts = Config().options
+        assert opts.inventory.probe_interval == 60
+        assert opts.storage.probe_interval == 30.0
+
     def test_config_path(self):
         config = Config()
         assert config.confpath == Path('/etc/aquarium/config.json')
+        assert config.options.service_state_path == Path('/etc/aquarium/storage.json')
 
         config = Config(path='foo')
         assert config.confpath == Path('foo/config.json')
+        assert config.options.service_state_path == Path('foo/storage.json')

--- a/src/gravel/controllers/tests/test_config.py
+++ b/src/gravel/controllers/tests/test_config.py
@@ -33,3 +33,10 @@ class TestConfig(TestCase):
         config = Config(path='foo')
         assert config.confpath == Path('foo/config.json')
         assert config.options.service_state_path == Path('foo/storage.json')
+
+        # dirname(config.json) != dirname(storage.json)
+        config = Config(path='bar')
+        config.options.service_state_path = Path('baz')
+        config._saveConfig(config.config)
+        config = Config(path='bar')
+        assert config.options.service_state_path == Path('baz')


### PR DESCRIPTION
Test inventory and storage probe intervals, plus the location of the
service state file (storage.json).

This test exposed a bug where the service state file location is not changing
based on parameters passed when initializing the Config object. Pytest reports
the problem as follows:

>       assert config.options.service_state_path == 'foo/storage.json'
E       AssertionError: assert '/etc/aquarium/storage.json' == 'foo/storage.json'
E         - foo/storage.json
E         + /etc/aquarium/storage.json

@mgfritch provided the fix for this issue in controllers/config.py.

Signed-off-by: Mike Latimer <mlatimer@suse.com>