### PR TITLE
glass: Use a hash in router URLs

### DIFF
--- a/src/glass/src/app/app-routing.module.ts
+++ b/src/glass/src/app/app-routing.module.ts
@@ -51,7 +51,11 @@ const routes: Routes = [
 ];
 
 @NgModule({
-  imports: [RouterModule.forRoot(routes)],
+  imports: [
+    RouterModule.forRoot(routes, {
+      useHash: true
+    })
+  ],
   exports: [RouterModule]
 })
 export class AppRoutingModule {}


### PR DESCRIPTION
Use a hash in UI URLs, e.g. 'http://localhost:4242/#/installer/create/deployment' to better distinguish between UI URLs and Swagger (http://localhost:4242/api/docs) or REST API (http://localhost:4242/api/status/).

Signed-off-by: Volker Theile <vtheile@suse.com>