### PR TITLE
gravel: pass the ceph.conf file to the Mgr/Mon class

### DIFF
--- a/src/gravel/controllers/orch/ceph.py
+++ b/src/gravel/controllers/orch/ceph.py
@@ -11,6 +11,9 @@ from pathlib import Path
 from typing import Callable, Dict, Any, List
 
 
+CEPH_CONF_FILE = '/etc/ceph/ceph.conf'
+
+
 class CephError(Exception):
     pass
 
@@ -27,13 +30,13 @@ class Ceph(ABC):
 
     cluster: rados.Rados
 
-    def __init__(self, confpath: str = "/etc/ceph/ceph.conf"):
+    def __init__(self, conf_file: str = CEPH_CONF_FILE):
 
-        path = Path(confpath)
+        path = Path(conf_file)
         if not path.exists():
-            raise FileNotFoundError(confpath)
+            raise FileNotFoundError(conf_file)
 
-        self.cluster = rados.Rados(conffile=confpath)
+        self.cluster = rados.Rados(conffile=conf_file)
         if not self.cluster:
             raise CephError("error creating cluster handle")
 
@@ -108,8 +111,8 @@ class Ceph(ABC):
 
 class Mgr(Ceph):
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, conf_file: str = CEPH_CONF_FILE):
+        super().__init__(conf_file=conf_file)
 
     def call(self, cmd: Dict[str, Any]) -> Any:
         return self.mgr(cmd)
@@ -117,8 +120,8 @@ class Mgr(Ceph):
 
 class Mon(Ceph):
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, conf_file: str = CEPH_CONF_FILE):
+        super().__init__(conf_file=conf_file)
 
     def call(self, cmd: Dict[str, Any]) -> Any:
         return self.mon(cmd)

--- a/src/gravel/controllers/orch/tests/test_ceph.py
+++ b/src/gravel/controllers/orch/tests/test_ceph.py
@@ -3,14 +3,34 @@ from pyfakefs.fake_filesystem_unittest import TestCase
 
 from gravel.controllers.orch.ceph import Mgr, Mon
 
+CEPH_CONF_FILE = '/etc/ceph/ceph.conf'
+CEPH_CONF_CONTENT = '''
+# minimal ceph.conf for 049e7b49-0c86-4373-85a4-cb9d50c374a7
+[global]
+        fsid = 049e7b49-0c86-4373-85a4-cb9d50c374a7
+        mon_host = [v2:192.168.1.1:40919/0,v1:192.168.1.1:40920/0] [v2:192.168.1.1:40921/0,v1:192.168.1.1:40922/0] [v2:192.168.1.1:40923/0,v1:192.168.1.1:40924/0]
+'''  # noqa:E501
+
 
 class TestCeph(TestCase):
 
     def setUp(self):
         self.setUpPyfakefs()
+        self.fs.create_file(CEPH_CONF_FILE, contents=CEPH_CONF_CONTENT)
 
     def test_ceph_conf(self):
-        conf_file = "ceph.conf"
+        # default location
+        Mgr()
+        Mon()
+
+        # custom location
+        conf_file = '/foo/bar/baz.conf'
+        self.fs.create_file(conf_file, contents=CEPH_CONF_CONTENT)
+        Mgr(conf_file=conf_file)
+        Mon(conf_file=conf_file)
+
+        # invalid location
+        conf_file = "missing.conf"
         with pytest.raises(FileNotFoundError, match=conf_file):
             Mgr(conf_file=conf_file)
             Mon(conf_file=conf_file)

--- a/src/gravel/controllers/orch/tests/test_ceph.py
+++ b/src/gravel/controllers/orch/tests/test_ceph.py
@@ -10,6 +10,7 @@ class TestCeph(TestCase):
         self.setUpPyfakefs()
 
     def test_ceph_conf(self):
-        with pytest.raises(FileNotFoundError, match="ceph.conf"):
-            Mgr()
-            Mon()
+        conf_file = "ceph.conf"
+        with pytest.raises(FileNotFoundError, match=conf_file):
+            Mgr(conf_file=conf_file)
+            Mon(conf_file=conf_file)


### PR DESCRIPTION
location to the `ceph.conf` file can be passed to the `Ceph` baseclass,
extend this to the Mgr/Mon classes

Signed-off-by: Michael Fritch <mfritch@suse.com>