### PR TITLE
gravel: fixup pytest warning

### DIFF
--- a/src/gravel/controllers/orch/ceph.py
+++ b/src/gravel/controllers/orch/ceph.py
@@ -55,7 +55,7 @@ class Ceph(ABC):
         self._is_connected = True
 
     def __del__(self):
-        if self.cluster:
+        if hasattr(self, 'cluster') and self.cluster:
             self.cluster.shutdown()
             self._is_connected = False
 


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "aquarium/src/gravel/controllers/orch/ceph.py", line 58, in __del__
    if self.cluster:
AttributeError: 'Mgr' object has no attribute 'cluster'
```

Signed-off-by: Michael Fritch <mfritch@suse.com>