### PR TITLE
glass: Add dashboard widget to display system facts

### DIFF
--- a/src/glass/package-lock.json
+++ b/src/glass/package-lock.json
@@ -20,6 +20,7 @@
         "@angular/router": "11.2.0",
         "@mdi/angular-material": "5.9.55",
         "@swimlane/ngx-charts": "^17.0.0",
+        "dayjs": "^1.10.4",
         "lodash": "4.17.20",
         "ng-block-ui": "3.0.2",
         "rxjs": "6.6.0",
@@ -7373,6 +7374,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.4.tgz",
+      "integrity": "sha512-RI/Hh4kqRc1UKLOAf/T5zdMMX5DQIlDxwUe3wSyMMnEbGunnpENCdbUgM+dW7kXidZqCttBrmw7BhN4TMddkCw=="
     },
     "node_modules/debug": {
       "version": "4.3.1",
@@ -32578,6 +32584,11 @@
         "whatwg-mimetype": "^2.3.0",
         "whatwg-url": "^8.0.0"
       }
+    },
+    "dayjs": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.4.tgz",
+      "integrity": "sha512-RI/Hh4kqRc1UKLOAf/T5zdMMX5DQIlDxwUe3wSyMMnEbGunnpENCdbUgM+dW7kXidZqCttBrmw7BhN4TMddkCw=="
     },
     "debug": {
       "version": "4.3.1",

--- a/src/glass/package.json
+++ b/src/glass/package.json
@@ -45,6 +45,7 @@
     "@angular/router": "11.2.0",
     "@mdi/angular-material": "5.9.55",
     "@swimlane/ngx-charts": "^17.0.0",
+    "dayjs": "^1.10.4",
     "lodash": "4.17.20",
     "ng-block-ui": "3.0.2",
     "rxjs": "6.6.0",

--- a/src/glass/src/app/core/dashboard/dashboard.module.ts
+++ b/src/glass/src/app/core/dashboard/dashboard.module.ts
@@ -7,6 +7,7 @@ import { NgxChartsModule } from '@swimlane/ngx-charts';
 import { CapacityDashboardWidgetComponent } from '~/app/core/dashboard/widgets/capacity-dashboard-widget/capacity-dashboard-widget.component';
 import { HealthDashboardWidgetComponent } from '~/app/core/dashboard/widgets/health-dashboard-widget/health-dashboard-widget.component';
 import { ServicesDashboardWidgetComponent } from '~/app/core/dashboard/widgets/services-dashboard-widget/services-dashboard-widget.component';
+import { SysInfoDashboardWidgetComponent } from '~/app/core/dashboard/widgets/sys-info-dashboard-widget/sys-info-dashboard-widget.component';
 import { VolumesDashboardWidgetComponent } from '~/app/core/dashboard/widgets/volumes-dashboard-widget/volumes-dashboard-widget.component';
 import { MaterialModule } from '~/app/material.modules';
 import { SharedModule } from '~/app/shared/shared.module';
@@ -16,13 +17,15 @@ import { SharedModule } from '~/app/shared/shared.module';
     CapacityDashboardWidgetComponent,
     VolumesDashboardWidgetComponent,
     HealthDashboardWidgetComponent,
-    ServicesDashboardWidgetComponent
+    ServicesDashboardWidgetComponent,
+    SysInfoDashboardWidgetComponent
   ],
   exports: [
     CapacityDashboardWidgetComponent,
     VolumesDashboardWidgetComponent,
     HealthDashboardWidgetComponent,
-    ServicesDashboardWidgetComponent
+    ServicesDashboardWidgetComponent,
+    SysInfoDashboardWidgetComponent
   ],
   imports: [CommonModule, FlexLayoutModule, MaterialModule, NgxChartsModule, SharedModule]
 })

--- a/src/glass/src/app/core/dashboard/widgets/capacity-dashboard-widget/capacity-dashboard-widget.component.html
+++ b/src/glass/src/app/core/dashboard/widgets/capacity-dashboard-widget/capacity-dashboard-widget.component.html
@@ -1,14 +1,16 @@
 <div class="glass-capacity-dashboard-widget"
      [ngClass]="{'error': error}"
-     fxFlex
      fxLayout="row"
      fxLayoutAlign="center center">
-  <ngx-charts-advanced-pie-chart
-  [scheme]="colorScheme"
-  [results]="chartData"
-  [animations]="false"
-  [tooltipDisabled]="true"
-  [valueFormatting]="valueFormatting.bind(this)"
-  >
-  </ngx-charts-advanced-pie-chart>
+  <ng-container *ngIf="!error">
+    <ngx-charts-advanced-pie-chart [scheme]="colorScheme"
+                                   [results]="chartData"
+                                   [animations]="false"
+                                   [tooltipDisabled]="true"
+                                   [valueFormatting]="valueFormatting.bind(this)">
+    </ngx-charts-advanced-pie-chart>
+  </ng-container>
+  <mat-icon *ngIf="error"
+            svgIcon="mdi:lan-disconnect">
+  </mat-icon>
 </div>

--- a/src/glass/src/app/core/dashboard/widgets/capacity-dashboard-widget/capacity-dashboard-widget.component.scss
+++ b/src/glass/src/app/core/dashboard/widgets/capacity-dashboard-widget/capacity-dashboard-widget.component.scss
@@ -1,14 +1,6 @@
 @import 'styles.scss';
 
 .glass-capacity-dashboard-widget {
-  width: 100%;
-  height: 100%;
-  display: inline-block;
-  position: relative;
-
-  canvas.error {
-    display: none !important;
-  }
 }
 .glass-capacity-dashboard-widget.error {
   @extend .glass-color-theme-error;

--- a/src/glass/src/app/core/dashboard/widgets/capacity-dashboard-widget/capacity-dashboard-widget.component.ts
+++ b/src/glass/src/app/core/dashboard/widgets/capacity-dashboard-widget/capacity-dashboard-widget.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Component, OnDestroy } from '@angular/core';
 import { Observable, Subscription } from 'rxjs';
 
 import { AbstractDashboardWidget } from '~/app/core/dashboard/widgets/abstract-dashboard-widget';
@@ -12,14 +12,13 @@ import { Reservations, ServicesService } from '~/app/shared/services/api/service
 })
 export class CapacityDashboardWidgetComponent
   extends AbstractDashboardWidget<Reservations>
-  implements OnInit, OnDestroy {
+  implements OnDestroy {
   data: Reservations = { reserved: 0, available: 0 };
 
   // Options for chart
-  // @ts-ignore
-  chartData: any[];
+  chartData: any[] = [];
   colorScheme = {
-    // See default.scss -> [$eos-bc-green-500, $eos-bc-red-500]
+    // EOS colors: [$eos-bc-green-500, $eos-bc-red-500]
     domain: ['#30ba78', '#dc3545']
   };
 
@@ -34,10 +33,6 @@ export class CapacityDashboardWidgetComponent
         { name: 'Unassigned', value: this.data.reserved }
       ];
     });
-  }
-
-  ngOnInit(): void {
-    super.ngOnInit();
   }
 
   valueFormatting(c: any) {

--- a/src/glass/src/app/core/dashboard/widgets/health-dashboard-widget/health-dashboard-widget.component.html
+++ b/src/glass/src/app/core/dashboard/widgets/health-dashboard-widget/health-dashboard-widget.component.html
@@ -2,7 +2,6 @@
      [class.glass-color-theme-ok]="isOkay && !error"
      [class.glass-color-theme-error]="isError || !hasStatus || error"
      [class.glass-color-theme-warn]="isWarn && !error"
-     fxFlex
      fxLayout="row"
      fxLayoutAlign="center center">
   <mat-icon *ngIf="isOkay && !error"

--- a/src/glass/src/app/core/dashboard/widgets/services-dashboard-widget/services-dashboard-widget.component.html
+++ b/src/glass/src/app/core/dashboard/widgets/services-dashboard-widget/services-dashboard-widget.component.html
@@ -1,6 +1,5 @@
 <div class="glass-services-dashboard-widget"
      [ngClass]="{'error': error}"
-     fxFlex
      fxLayout="row"
      fxLayoutAlign="center center">
   <div *ngIf="!error && firstLoadComplete && data.length === 0">
@@ -21,6 +20,7 @@
       </mat-progress-bar>
     </div>
     <table mat-table
+           fxFlexFill
            *ngIf="firstLoadComplete && data.length > 0"
            [dataSource]="data">
       <ng-container matColumnDef="name">

--- a/src/glass/src/app/core/dashboard/widgets/services-dashboard-widget/services-dashboard-widget.component.scss
+++ b/src/glass/src/app/core/dashboard/widgets/services-dashboard-widget/services-dashboard-widget.component.scss
@@ -5,10 +5,6 @@
     .glass-services-dashboard-widget-loader {
       height: 4px;
     }
-
-    table {
-      width: 100%;
-    }
   }
 }
 .glass-services-dashboard-widget.error {

--- a/src/glass/src/app/core/dashboard/widgets/sys-info-dashboard-widget/sys-info-dashboard-widget.component.html
+++ b/src/glass/src/app/core/dashboard/widgets/sys-info-dashboard-widget/sys-info-dashboard-widget.component.html
@@ -1,0 +1,61 @@
+<div class="glass-sys-info-dashboard-widget"
+     [ngClass]="{'error': error}"
+     fxLayout="row"
+     fxLayoutAlign="center center">
+  <div *ngIf="!error"
+       fxFlexFill
+       fxLayout="row wrap">
+    <div class="glass-sys-info-dashboard-widget-cell"
+         fxFlex="50">
+      <div class="glass-text-bold">Hostname</div>
+      <div>{{ data?.hostname }}</div>
+    </div>
+    <div class="glass-sys-info-dashboard-widget-cell"
+         fxFlex="50">
+      <div class="glass-text-bold">Operating System</div>
+      <div>{{ data?.operating_system }}</div>
+    </div>
+    <div class="glass-sys-info-dashboard-widget-cell"
+         fxFlex="50">
+      <div class="glass-text-bold">Kernel</div>
+      <div>{{ data?.kernel }}</div>
+    </div>
+    <div class="glass-sys-info-dashboard-widget-cell"
+         fxFlex="50">
+      <div class="glass-text-bold">Architecture</div>
+      <div>{{ data?.arch }}</div>
+    </div>
+    <div class="glass-sys-info-dashboard-widget-cell"
+         fxFlex="50">
+      <div class="glass-text-bold">Uptime</div>
+      <div>{{ data?.system_uptime | relativeDate:true }}</div>
+    </div>
+    <div class="glass-sys-info-dashboard-widget-cell"
+         fxFlex="100"
+         fxLayout="column">
+      <div class="glass-text-bold">Memory</div>
+      <div fxFlex>
+        <ngx-charts-advanced-pie-chart [scheme]="memoryChartColorScheme"
+                                       [results]="memoryChartData"
+                                       [animations]="false"
+                                       [tooltipDisabled]="true"
+                                       [valueFormatting]="valueFormatting.bind(this)">
+        </ngx-charts-advanced-pie-chart>
+      </div>
+    </div>
+    <div class="glass-sys-info-dashboard-widget-cell"
+         fxFlex="100"
+         fxLayout="column">
+      <div class="glass-text-bold">CPU Load</div>
+      <div fxFlex>
+        <ngx-charts-number-card [scheme]="cpuLoadColorScheme"
+                                [results]="cpuLoadChartData"
+                                [animations]="false">
+        </ngx-charts-number-card>
+      </div>
+    </div>
+  </div>
+  <mat-icon *ngIf="error"
+            svgIcon="mdi:lan-disconnect">
+  </mat-icon>
+</div>

--- a/src/glass/src/app/core/dashboard/widgets/sys-info-dashboard-widget/sys-info-dashboard-widget.component.scss
+++ b/src/glass/src/app/core/dashboard/widgets/sys-info-dashboard-widget/sys-info-dashboard-widget.component.scss
@@ -1,0 +1,16 @@
+@import 'styles.scss';
+
+.glass-sys-info-dashboard-widget {
+  padding-left: 24px;
+  padding-right: 24px;
+  padding-bottom: 24px;
+
+  .glass-sys-info-dashboard-widget-cell {
+    margin-bottom: 8px;
+  }
+}
+.glass-sys-info-dashboard-widget.error {
+  @extend .glass-color-theme-error;
+  padding: unset;
+  height: 50px;
+}

--- a/src/glass/src/app/core/dashboard/widgets/sys-info-dashboard-widget/sys-info-dashboard-widget.component.spec.ts
+++ b/src/glass/src/app/core/dashboard/widgets/sys-info-dashboard-widget/sys-info-dashboard-widget.component.spec.ts
@@ -1,0 +1,28 @@
+/* eslint-disable max-len */
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
+import { DashboardModule } from '~/app/core/dashboard/dashboard.module';
+import { SysInfoDashboardWidgetComponent } from '~/app/core/dashboard/widgets/sys-info-dashboard-widget/sys-info-dashboard-widget.component';
+
+describe('SysInfoDashboardWidgetComponent', () => {
+  let component: SysInfoDashboardWidgetComponent;
+  let fixture: ComponentFixture<SysInfoDashboardWidgetComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DashboardModule, HttpClientTestingModule, BrowserAnimationsModule]
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SysInfoDashboardWidgetComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/glass/src/app/core/dashboard/widgets/sys-info-dashboard-widget/sys-info-dashboard-widget.component.ts
+++ b/src/glass/src/app/core/dashboard/widgets/sys-info-dashboard-widget/sys-info-dashboard-widget.component.ts
@@ -1,0 +1,53 @@
+import { Component } from '@angular/core';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+import { AbstractDashboardWidget } from '~/app/core/dashboard/widgets/abstract-dashboard-widget';
+import { BytesToSizePipe } from '~/app/shared/pipes/bytes-to-size.pipe';
+import { Facts, OrchService } from '~/app/shared/services/api/orch.service';
+
+@Component({
+  selector: 'glass-sys-info-dashboard-widget',
+  templateUrl: './sys-info-dashboard-widget.component.html',
+  styleUrls: ['./sys-info-dashboard-widget.component.scss']
+})
+export class SysInfoDashboardWidgetComponent extends AbstractDashboardWidget<Facts> {
+  memoryChartData: any[] = [];
+  memoryChartColorScheme = {
+    // EOS colors: [$eos-bc-red-500, $eos-bc-green-500]
+    domain: ['#dc3545', '#30ba78']
+  };
+  cpuLoadChartData: any[] = [];
+  cpuLoadColorScheme = {
+    // EOS colors: [$eos-bc-yellow-100, $eos-bc-yellow-500, $eos-bc-yellow-900]
+    domain: ['#ffecb5', '#ffc107', '#ff9e02']
+  };
+
+  constructor(private bytesToSizePipe: BytesToSizePipe, private orchService: OrchService) {
+    super();
+  }
+
+  valueFormatting(c: any) {
+    return this.bytesToSizePipe.transform(c);
+  }
+
+  loadData(): Observable<Facts> {
+    return this.orchService.facts().pipe(
+      map((facts: Facts) => {
+        this.memoryChartData = [
+          { name: 'Used', value: facts.memory_total_kb * 1024 - facts.memory_free_kb * 1024 },
+          { name: 'Free', value: facts.memory_free_kb * 1024 }
+        ];
+        this.cpuLoadChartData = [
+          { name: '1min', value: facts.cpu_load['1min'] },
+          { name: '5min', value: facts.cpu_load['5min'] },
+          { name: '15min', value: facts.cpu_load['15min'] }
+        ];
+        // Modify the uptime value to allow the `relativeDate` pipe
+        // to calculate the correct time to display.
+        facts.system_uptime = facts.system_uptime * -1;
+        return facts;
+      })
+    );
+  }
+}

--- a/src/glass/src/app/core/dashboard/widgets/volumes-dashboard-widget/volumes-dashboard-widget.component.html
+++ b/src/glass/src/app/core/dashboard/widgets/volumes-dashboard-widget/volumes-dashboard-widget.component.html
@@ -1,6 +1,5 @@
 <div class="glass-volumes-dashboard-widget"
      [ngClass]="{'error': error}"
-     fxFlex
      fxLayout="row"
      fxLayoutAlign="center center">
   <div *ngIf="!error"
@@ -14,6 +13,7 @@
       </mat-progress-bar>
     </div>
     <table mat-table
+           fxFlexFill
            *ngIf="firstLoadComplete"
            [dataSource]="data">
       <ng-container matColumnDef="path">

--- a/src/glass/src/app/core/dashboard/widgets/volumes-dashboard-widget/volumes-dashboard-widget.component.scss
+++ b/src/glass/src/app/core/dashboard/widgets/volumes-dashboard-widget/volumes-dashboard-widget.component.scss
@@ -5,10 +5,6 @@
     .glass-volumes-dashboard-widget-loader {
       height: 4px;
     }
-
-    table {
-      width: 100%;
-    }
   }
 }
 .glass-volumes-dashboard-widget.error {

--- a/src/glass/src/app/pages/dashboard-page/dashboard-page.component.html
+++ b/src/glass/src/app/pages/dashboard-page/dashboard-page.component.html
@@ -7,14 +7,12 @@
       <mat-icon svgIcon="mdi:apps"></mat-icon>
     </button>
   </mat-toolbar>
-  <div fxLayout="row wrap"
-       fxLayout.lt-lg="column">
-    <div *ngFor="let widget of enabledWidgets"
-         fxFlex="50"
-         fxFlex.gt-lg="33"
-         fxFlex.lt-sm="100">
+  <div class="glass-dashboard-page-content"
+       gdGap="24px"
+       gdColumns="repeat(auto-fit, minmax(400px, 1fr))">
+    <div *ngFor="let widget of enabledWidgets" class="widget">
       <ng-container [ngSwitch]="widget.id">
-        <mat-card>
+        <mat-card class="glass-dashboard-widget">
           <mat-card-title-group>
             <mat-card-title>{{ widget.title }}</mat-card-title>
           </mat-card-title-group>
@@ -30,6 +28,9 @@
             </ng-template>
             <ng-template [ngSwitchCase]="'services'">
               <glass-services-dashboard-widget></glass-services-dashboard-widget>
+            </ng-template>
+            <ng-template [ngSwitchCase]="'sysInfo'">
+              <glass-sys-info-dashboard-widget></glass-sys-info-dashboard-widget>
             </ng-template>
           </mat-card-content>
         </mat-card>

--- a/src/glass/src/app/pages/dashboard-page/dashboard-page.component.scss
+++ b/src/glass/src/app/pages/dashboard-page/dashboard-page.component.scss
@@ -1,8 +1,11 @@
-.mat-card {
+.glass-dashboard-page-content {
   margin: 24px;
-  padding: unset;
 
-  .mat-card-title-group {
-    padding: 16px 16px 8px 16px;
+  .glass-dashboard-widget {
+    padding: unset;
+
+    .mat-card-title-group {
+      padding: 16px 16px 8px 16px;
+    }
   }
 }

--- a/src/glass/src/app/pages/dashboard-page/dashboard-page.component.ts
+++ b/src/glass/src/app/pages/dashboard-page/dashboard-page.component.ts
@@ -10,7 +10,7 @@ import { LocalStorageService } from '~/app/shared/services/local-storage.service
   styleUrls: ['./dashboard-page.component.scss']
 })
 export class DashboardPageComponent implements OnInit {
-  enabled: string[] = ['health', 'capacity', 'services', 'volumes'];
+  enabled: string[] = ['health', 'capacity', 'services', 'volumes', 'sysInfo'];
 
   // New dashboard widgets must be added here. Don't forget to enhance
   // the template to render the new widget.
@@ -30,6 +30,10 @@ export class DashboardPageComponent implements OnInit {
     {
       id: 'volumes',
       title: 'Volumes'
+    },
+    {
+      id: 'sysInfo',
+      title: 'System Information'
     }
   ];
 

--- a/src/glass/src/app/shared/pipes/relative-date.pipe.spec.ts
+++ b/src/glass/src/app/shared/pipes/relative-date.pipe.spec.ts
@@ -1,0 +1,34 @@
+import dayjs from 'dayjs';
+
+import { RelativeDatePipe } from './relative-date.pipe';
+
+describe('RelativeDatePipe', () => {
+  const pipe = new RelativeDatePipe();
+
+  it('create an instance', () => {
+    expect(pipe).toBeTruthy();
+  });
+
+  it('should transform [1]', () => {
+    expect(pipe.transform(-25)).toBe('a few seconds ago');
+  });
+
+  it('should transform [2]', () => {
+    expect(pipe.transform(-80, true)).toBe('a minute');
+  });
+
+  it('should transform [3]', () => {
+    const date = dayjs().subtract(1, 'hour');
+    expect(pipe.transform(date.toDate())).toBe('an hour ago');
+  });
+
+  it('should transform [4]', () => {
+    const date = dayjs().subtract(2, 'days');
+    expect(pipe.transform(date.toDate(), true)).toBe('2 days');
+  });
+
+  it('should transform [5]', () => {
+    const date = dayjs().subtract(1, 'month');
+    expect(pipe.transform(date.unix())).toBe('a month ago');
+  });
+});

--- a/src/glass/src/app/shared/pipes/relative-date.pipe.ts
+++ b/src/glass/src/app/shared/pipes/relative-date.pipe.ts
@@ -1,0 +1,34 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import dayjs from 'dayjs';
+import relativeTime from 'dayjs/plugin/relativeTime';
+import * as _ from 'lodash';
+
+dayjs.extend(relativeTime);
+
+@Pipe({
+  name: 'relativeDate',
+  pure: false
+})
+export class RelativeDatePipe implements PipeTransform {
+  /**
+   * @param date The date to process. This can be a Unix timestamp in
+   *   seconds since 1. Jan 1970, a string or Date object. If it is a
+   *   number < 0, then the number of seconds will be subtracted from
+   *   `now`.
+   * @param withoutSuffix If you pass true, you can get the value
+   *   without the suffix. Defaults to `false`.
+   */
+  transform(value: number | string | Date | undefined, withoutSuffix: boolean = false): string {
+    let date: dayjs.Dayjs;
+    if (_.isNumber(value)) {
+      if (value < 0) {
+        date = dayjs().add(value, 'seconds');
+      } else {
+        date = dayjs.unix(value);
+      }
+    } else {
+      date = dayjs(value);
+    }
+    return date.fromNow(withoutSuffix);
+  }
+}

--- a/src/glass/src/app/shared/services/api/orch.service.spec.ts
+++ b/src/glass/src/app/shared/services/api/orch.service.spec.ts
@@ -42,4 +42,10 @@ describe('OrchService', () => {
     const req = httpTesting.expectOne('api/orch/devices/all_assimilated');
     expect(req.request.method).toBe('GET');
   });
+
+  it('should call facts', () => {
+    service.facts().subscribe();
+    const req = httpTesting.expectOne('api/orch/facts');
+    expect(req.request.method).toBe('GET');
+  });
 });

--- a/src/glass/src/app/shared/services/api/orch.service.ts
+++ b/src/glass/src/app/shared/services/api/orch.service.ts
@@ -96,6 +96,71 @@ export type Inventory = {
   disks: Volume[];
 };
 
+export type Facts = {
+  arch: string;
+  bios_date: string;
+  bios_version: string;
+  cpu_cores: number;
+  cpu_count: number;
+  cpu_load: {
+    '15min': number;
+    '1min': number;
+    '5min': number;
+  };
+  cpu_model: string;
+  cpu_threads: number;
+  flash_capacity: string;
+  flash_capacity_bytes: number;
+  flash_count: number;
+  flash_list: Array<any>;
+  hdd_capacity: string;
+  hdd_capacity_bytes: number;
+  hdd_count: number;
+  hdd_list: Array<{
+    description: string;
+    dev_name: string;
+    disk_size_bytes: number;
+    model: string;
+    rev: string;
+    vendor: string;
+    wwid: string;
+  }>;
+  hostname: string;
+  interfaces: Record<
+    string,
+    {
+      driver: string;
+      iftype: string;
+      ipv4_address: string;
+      ipv6_address: string;
+      lower_devs_list: Array<any>;
+      mtu: number;
+      nic_type: string;
+      operstate: string;
+      speed: number;
+      upper_devs_list: Array<any>;
+    }
+  >;
+  kernel: string;
+  kernel_parameters: {
+    'net.ipv4.ip_nonlocal_bind': string;
+  };
+  kernel_security: {
+    description: string;
+    enforce: number;
+    type: string;
+  };
+  memory_available_kb: number;
+  memory_free_kb: number;
+  memory_total_kb: number;
+  model: string;
+  operating_system: string;
+  subscribed: string;
+  system_uptime: number;
+  timestamp: number;
+  vendor: string;
+};
+
 @Injectable({
   providedIn: 'root'
 })
@@ -145,5 +210,13 @@ export class OrchService {
    */
   assimilateStatus(): Observable<boolean> {
     return this.http.get<boolean>(`${this.url}/devices/all_assimilated`);
+  }
+
+  /**
+   * Get facts
+   */
+  facts(): Observable<Facts> {
+    // Inventory is much faster than the volumes endpoint
+    return this.http.get<Facts>(`${this.url}/facts`);
   }
 }

--- a/src/glass/src/app/shared/shared.module.ts
+++ b/src/glass/src/app/shared/shared.module.ts
@@ -6,10 +6,12 @@ import { ComponentsModule } from '~/app/shared/components/components.module';
 import { BytesToSizePipe } from '~/app/shared/pipes/bytes-to-size.pipe';
 import { SortByPipe } from '~/app/shared/pipes/sort-by.pipe';
 
+import { RelativeDatePipe } from './pipes/relative-date.pipe';
+
 @NgModule({
-  declarations: [BytesToSizePipe, SortByPipe],
-  providers: [BytesToSizePipe, SortByPipe],
-  exports: [BytesToSizePipe, ComponentsModule, SortByPipe],
+  declarations: [BytesToSizePipe, SortByPipe, RelativeDatePipe],
+  providers: [BytesToSizePipe, SortByPipe, RelativeDatePipe],
+  exports: [BytesToSizePipe, ComponentsModule, SortByPipe, RelativeDatePipe],
   imports: [CommonModule, ComponentsModule, MaterialModule]
 })
 export class SharedModule {}

--- a/src/glass/src/defaults.scss
+++ b/src/glass/src/defaults.scss
@@ -5,6 +5,7 @@ $glass-color-white: white;
 $eos-bc-red-500: #dc3545;
 $eos-bc-pine-500: #0c322c;
 $eos-bc-green-500: #30ba78;
+$eos-bc-yellow-500: #ffc107;
 
 $eos-green-palette: (
   50: #e6f7ef,

--- a/src/glass/src/styles.scss
+++ b/src/glass/src/styles.scss
@@ -39,7 +39,7 @@ $glass-color-accent-complementary: white;
 }
 .glass-color-theme-warn {
   color: whitesmoke;
-  background-color: orange;
+  background-color: $eos-bc-yellow-500;
 }
 
 .glass-background-color-primary {
@@ -72,6 +72,9 @@ $glass-color-accent-complementary: white;
 }
 .glass-text-center {
   text-align: center;
+}
+.glass-text-bold {
+  font-weight: bold;
 }
 
 .glass-icon-large {


### PR DESCRIPTION
![Bildschirmfoto vom 2021-02-25 12-50-29](https://user-images.githubusercontent.com/1897962/109149599-13f41700-7768-11eb-9955-b75c7baa4f92.png)

- Add a dashboard widget to display the system facts retrieved via /api/orch/facts.
- Enhance 'OrchService' to request facts.
- Add 'relativeDate' pipe.
- Cleanup code of other dashboard widgets.
- Use CSS Grid to render the dashboard widgets instead of Flexbox.

Fixes: https://github.com/aquarist-labs/aquarium/issues/200

![dashboard](https://user-images.githubusercontent.com/1897962/109163748-f29c2680-7779-11eb-8512-c10f850343bd.png)

Signed-off-by: Volker Theile <vtheile@suse.com>