### PR TITLE
glass: Add a host dashboard widget

### DIFF
--- a/src/glass/src/app/core/dashboard/dashboard.module.ts
+++ b/src/glass/src/app/core/dashboard/dashboard.module.ts
@@ -6,6 +6,7 @@ import { NgxChartsModule } from '@swimlane/ngx-charts';
 
 import { CapacityDashboardWidgetComponent } from '~/app/core/dashboard/widgets/capacity-dashboard-widget/capacity-dashboard-widget.component';
 import { HealthDashboardWidgetComponent } from '~/app/core/dashboard/widgets/health-dashboard-widget/health-dashboard-widget.component';
+import { HostsDashboardWidgetComponent } from '~/app/core/dashboard/widgets/hosts-dashboard-widget/hosts-dashboard-widget.component';
 import { ServicesDashboardWidgetComponent } from '~/app/core/dashboard/widgets/services-dashboard-widget/services-dashboard-widget.component';
 import { SysInfoDashboardWidgetComponent } from '~/app/core/dashboard/widgets/sys-info-dashboard-widget/sys-info-dashboard-widget.component';
 import { VolumesDashboardWidgetComponent } from '~/app/core/dashboard/widgets/volumes-dashboard-widget/volumes-dashboard-widget.component';
@@ -18,14 +19,16 @@ import { SharedModule } from '~/app/shared/shared.module';
     VolumesDashboardWidgetComponent,
     HealthDashboardWidgetComponent,
     ServicesDashboardWidgetComponent,
-    SysInfoDashboardWidgetComponent
+    SysInfoDashboardWidgetComponent,
+    HostsDashboardWidgetComponent
   ],
   exports: [
     CapacityDashboardWidgetComponent,
     VolumesDashboardWidgetComponent,
     HealthDashboardWidgetComponent,
     ServicesDashboardWidgetComponent,
-    SysInfoDashboardWidgetComponent
+    SysInfoDashboardWidgetComponent,
+    HostsDashboardWidgetComponent
   ],
   imports: [CommonModule, FlexLayoutModule, MaterialModule, NgxChartsModule, SharedModule]
 })

--- a/src/glass/src/app/core/dashboard/widgets/hosts-dashboard-widget/hosts-dashboard-widget.component.html
+++ b/src/glass/src/app/core/dashboard/widgets/hosts-dashboard-widget/hosts-dashboard-widget.component.html
@@ -1,0 +1,42 @@
+<div class="glass-hosts-dashboard-widget"
+     [ngClass]="{'error': error}"
+     fxLayout="row"
+     fxLayoutAlign="center center">
+  <div *ngIf="!error"
+       class="glass-hosts-dashboard-widget-table"
+       fxFlex
+       fxLayout="column">
+    <div *ngIf="!firstLoadComplete"
+         class="glass-hosts-dashboard-widget-loader">
+      <mat-progress-bar *ngIf="loading"
+                        mode="indeterminate">
+      </mat-progress-bar>
+    </div>
+    <table mat-table
+           fxFlexFill
+           *ngIf="firstLoadComplete"
+           [dataSource]="data">
+      <ng-container matColumnDef="hostname">
+        <th mat-header-cell
+            *matHeaderCellDef>Hostname</th>
+        <td mat-cell
+            *matCellDef="let element">{{element.hostname}}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="address">
+        <th mat-header-cell
+            *matHeaderCellDef>Address</th>
+        <td mat-cell
+            *matCellDef="let element">{{element.address}}</td>
+      </ng-container>
+
+      <tr mat-header-row
+          *matHeaderRowDef="displayedColumns"></tr>
+      <tr mat-row
+          *matRowDef="let row; columns: displayedColumns;"></tr>
+    </table>
+  </div>
+  <mat-icon *ngIf="error"
+            svgIcon="mdi:lan-disconnect">
+  </mat-icon>
+</div>

--- a/src/glass/src/app/core/dashboard/widgets/hosts-dashboard-widget/hosts-dashboard-widget.component.scss
+++ b/src/glass/src/app/core/dashboard/widgets/hosts-dashboard-widget/hosts-dashboard-widget.component.scss
@@ -1,0 +1,13 @@
+@import 'styles.scss';
+
+.glass-hosts-dashboard-widget {
+  .glass-hosts-dashboard-widget-table {
+    .glass-hosts-dashboard-widget-loader {
+      height: 4px;
+    }
+  }
+}
+.glass-hosts-dashboard-widget.error {
+  @extend .glass-color-theme-error;
+  height: 50px;
+}

--- a/src/glass/src/app/core/dashboard/widgets/hosts-dashboard-widget/hosts-dashboard-widget.component.spec.ts
+++ b/src/glass/src/app/core/dashboard/widgets/hosts-dashboard-widget/hosts-dashboard-widget.component.spec.ts
@@ -1,0 +1,26 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DashboardModule } from '~/app/core/dashboard/dashboard.module';
+import { HostsDashboardWidgetComponent } from '~/app/core/dashboard/widgets/hosts-dashboard-widget/hosts-dashboard-widget.component';
+
+describe('HostsDashboardWidgetComponent', () => {
+  let component: HostsDashboardWidgetComponent;
+  let fixture: ComponentFixture<HostsDashboardWidgetComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DashboardModule, HttpClientTestingModule]
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(HostsDashboardWidgetComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/glass/src/app/core/dashboard/widgets/hosts-dashboard-widget/hosts-dashboard-widget.component.ts
+++ b/src/glass/src/app/core/dashboard/widgets/hosts-dashboard-widget/hosts-dashboard-widget.component.ts
@@ -1,0 +1,23 @@
+import { Component } from '@angular/core';
+import { Observable } from 'rxjs';
+
+import { AbstractDashboardWidget } from '~/app/core/dashboard/widgets/abstract-dashboard-widget';
+import { Host, OrchService } from '~/app/shared/services/api/orch.service';
+
+@Component({
+  selector: 'glass-hosts-dashboard-widget',
+  templateUrl: './hosts-dashboard-widget.component.html',
+  styleUrls: ['./hosts-dashboard-widget.component.scss']
+})
+export class HostsDashboardWidgetComponent extends AbstractDashboardWidget<Host[]> {
+  data: Host[] = [];
+  displayedColumns: string[] = ['hostname', 'address'];
+
+  constructor(private orchService: OrchService) {
+    super();
+  }
+
+  loadData(): Observable<Host[]> {
+    return this.orchService.hosts();
+  }
+}

--- a/src/glass/src/app/pages/dashboard-page/dashboard-page.component.html
+++ b/src/glass/src/app/pages/dashboard-page/dashboard-page.component.html
@@ -10,7 +10,8 @@
   <div class="glass-dashboard-page-content"
        gdGap="24px"
        gdColumns="repeat(auto-fit, minmax(400px, 1fr))">
-    <div *ngFor="let widget of enabledWidgets" class="widget">
+    <div *ngFor="let widget of enabledWidgets"
+         class="widget">
       <ng-container [ngSwitch]="widget.id">
         <mat-card class="glass-dashboard-widget">
           <mat-card-title-group>
@@ -31,6 +32,9 @@
             </ng-template>
             <ng-template [ngSwitchCase]="'sysInfo'">
               <glass-sys-info-dashboard-widget></glass-sys-info-dashboard-widget>
+            </ng-template>
+            <ng-template [ngSwitchCase]="'hosts'">
+              <glass-hosts-dashboard-widget></glass-hosts-dashboard-widget>
             </ng-template>
           </mat-card-content>
         </mat-card>

--- a/src/glass/src/app/pages/dashboard-page/dashboard-page.component.ts
+++ b/src/glass/src/app/pages/dashboard-page/dashboard-page.component.ts
@@ -10,7 +10,7 @@ import { LocalStorageService } from '~/app/shared/services/local-storage.service
   styleUrls: ['./dashboard-page.component.scss']
 })
 export class DashboardPageComponent implements OnInit {
-  enabled: string[] = ['health', 'capacity', 'services', 'volumes', 'sysInfo'];
+  enabled: string[] = ['health', 'capacity', 'services', 'volumes', 'sysInfo', 'hosts'];
 
   // New dashboard widgets must be added here. Don't forget to enhance
   // the template to render the new widget.
@@ -34,6 +34,10 @@ export class DashboardPageComponent implements OnInit {
     {
       id: 'sysInfo',
       title: 'System Information'
+    },
+    {
+      id: 'hosts',
+      title: 'Hosts'
     }
   ];
 

--- a/src/glass/src/app/shared/services/api/orch.service.ts
+++ b/src/glass/src/app/shared/services/api/orch.service.ts
@@ -172,8 +172,8 @@ export class OrchService {
   /**
    * Get host information
    */
-  hosts(): Observable<{ hosts: Host[] }> {
-    return this.http.get<{ hosts: Host[] }>(`${this.url}/hosts`);
+  hosts(): Observable<Host[]> {
+    return this.http.get<Host[]>(`${this.url}/hosts`);
   }
 
   /**

--- a/src/gravel/api/orch.py
+++ b/src/gravel/api/orch.py
@@ -34,10 +34,6 @@ class HostModel(BaseModel):
     address: str
 
 
-class HostsReplyModel(BaseModel):
-    hosts: List[HostModel]
-
-
 class DeviceModel(BaseModel):
     available: bool
     device_id: str
@@ -55,14 +51,13 @@ class HostsDevicesModel(BaseModel):
     devices: List[DeviceModel]
 
 
-@router.get("/hosts", response_model=HostsReplyModel)
-def get_hosts() -> HostsReplyModel:
+@router.get("/hosts", response_model=List[HostModel])
+def get_hosts() -> List[HostModel]:
     orch = Orchestrator()
     orch_hosts = orch.host_ls()
-    hosts: HostsReplyModel = HostsReplyModel(hosts=[])
+    hosts: List[HostModel] = []
     for h in orch_hosts:
-        hosts.hosts.append(HostModel(hostname=h.hostname, address=h.addr))
-
+        hosts.append(HostModel(hostname=h.hostname, address=h.addr))
     return hosts
 
 


### PR DESCRIPTION
![Bildschirmfoto vom 2021-02-26 12-30-44](https://user-images.githubusercontent.com/1897962/109295129-83ccd500-782e-11eb-95a4-92545dcf25e0.png)

- Add hosts dashboard widget
- Keep polling data in case of an error
- Refactored response of /orch/hosts

Fixes: https://github.com/aquarist-labs/aquarium/issues/202

Signed-off-by: Volker Theile <vtheile@suse.com>