### PR TITLE
gravel: initial support for node communication over websockets

### DIFF
--- a/src/aquarium.py
+++ b/src/aquarium.py
@@ -31,6 +31,7 @@ from gravel.api import bootstrap
 from gravel.api import orch
 from gravel.api import status
 from gravel.api import services
+from gravel.api import nodes
 
 
 logger: logging.Logger = fastapi_logger
@@ -62,6 +63,7 @@ api.include_router(bootstrap.router)
 api.include_router(orch.router)
 api.include_router(status.router)
 api.include_router(services.router)
+api.include_router(nodes.router)
 
 
 #

--- a/src/glass/src/app/pages/bootstrap-page/bootstrap-page.component.ts
+++ b/src/glass/src/app/pages/bootstrap-page/bootstrap-page.component.ts
@@ -5,6 +5,7 @@ import { BlockUI, NgBlockUI } from 'ng-block-ui';
 import {
   BootstrapBasicReply,
   BootstrapService,
+  BootstrapStageEnum,
   BootstrapStatusReply
 } from '~/app/shared/services/api/bootstrap.service';
 import { NotificationService } from '~/app/shared/services/notification.service';
@@ -33,12 +34,12 @@ export class BootstrapPageComponent implements OnInit {
     // Immediately block the UI if bootstrapping is in progress.
     this.bootstrapService.status().subscribe({
       next: (statusReply: BootstrapStatusReply) => {
-        if (statusReply.stage === 'running') {
+        if (statusReply.stage === BootstrapStageEnum.running) {
           this.visible = false;
           this.blockUI.start('Please wait, bootstrapping in progress ...');
           this.pollBootstrapStatus();
         }
-        if (statusReply.stage === 'none') {
+        if (statusReply.stage === BootstrapStageEnum.none) {
           this.visible = true;
         }
       },
@@ -82,7 +83,7 @@ export class BootstrapPageComponent implements OnInit {
       .status()
       .pipe(
         this.pollService.poll(
-          (statusReply) => statusReply.stage === 'running',
+          (statusReply) => statusReply.stage === BootstrapStageEnum.running,
           undefined,
           'Failed to bootstrap the system.'
         )
@@ -90,11 +91,11 @@ export class BootstrapPageComponent implements OnInit {
       .subscribe(
         (statusReply: BootstrapStatusReply) => {
           switch (statusReply.stage) {
-            case 'error':
+            case BootstrapStageEnum.error:
               handleError();
               break;
-            case 'none':
-            case 'done':
+            case BootstrapStageEnum.none:
+            case BootstrapStageEnum.done:
               this.blockUI.stop();
               this.router.navigate(['/installer/create/deployment']);
               break;

--- a/src/glass/src/app/shared/services/api/bootstrap.service.ts
+++ b/src/glass/src/app/shared/services/api/bootstrap.service.ts
@@ -6,8 +6,16 @@ export type BootstrapBasicReply = {
   success: boolean;
 };
 
+// eslint-disable-next-line no-shadow
+export enum BootstrapStageEnum {
+  none = 0,
+  running = 1,
+  done = 2,
+  error = 3
+}
+  
 export type BootstrapStatusReply = {
-  stage: 'none' | 'running' | 'done' | 'error';
+  stage: BootstrapStageEnum;
 };
 
 @Injectable({

--- a/src/glass/src/app/shared/services/api/status.service.ts
+++ b/src/glass/src/app/shared/services/api/status.service.ts
@@ -22,11 +22,20 @@ export interface ClusterStatus {
   health: HealthStatus;
 }
 
+// eslint-disable-next-line no-shadow
+export enum StatusStageEnum {
+  unknown = -1,
+  none = 0,
+  bootstrapping = 1,
+  bootstrapped = 2,
+  ready = 3,
+}
+
 export type Status = {
   /* eslint-disable @typescript-eslint/naming-convention */
   deployment_state: {
     last_modified: string;
-    stage: 'none' | 'bootstrapping' | 'bootstrapped' | 'ready' | 'unknown';
+    stage: StatusStageEnum;
   };
   cluster?: ClusterStatus;
 };

--- a/src/glass/src/app/shared/services/status-route-guard.service.ts
+++ b/src/glass/src/app/shared/services/status-route-guard.service.ts
@@ -11,7 +11,11 @@ import * as _ from 'lodash';
 import { Observable, of } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 
-import { Status, StatusService } from '~/app/shared/services/api/status.service';
+import {
+  StatusStageEnum,
+  Status,
+  StatusService
+} from '~/app/shared/services/api/status.service';
 
 @Injectable({
   providedIn: 'root'
@@ -30,14 +34,20 @@ export class StatusRouteGuardService implements CanActivate, CanActivateChild {
           err.preventDefault();
         }
         // eslint-disable-next-line @typescript-eslint/naming-convention
-        const res: Status = { deployment_state: { last_modified: 'now', stage: 'unknown' } };
+        const res: Status = {
+          deployment_state: {
+            last_modified: 'now',
+            stage: StatusStageEnum.unknown
+          }
+        };
         return of(res);
       }),
       map((res: Status) => {
         let url: string;
         let result: boolean | UrlTree;
+        console.info("=> deployment stage: ", res.deployment_state.stage);
         switch (res.deployment_state.stage) {
-          case 'bootstrapping':
+          case StatusStageEnum.bootstrapping:
             url = '/installer/create/bootstrap';
             if (url === state.url) {
               result = true;
@@ -45,7 +55,7 @@ export class StatusRouteGuardService implements CanActivate, CanActivateChild {
               result = this.router.parseUrl(url);
             }
             break;
-          case 'bootstrapped':
+          case StatusStageEnum.bootstrapped:
             const urls = ['/installer/create/deployment', '/dashboard'];
             if (urls.includes(state.url)) {
               result = true;
@@ -53,7 +63,7 @@ export class StatusRouteGuardService implements CanActivate, CanActivateChild {
               result = this.router.parseUrl(urls[0]);
             }
             break;
-          case 'ready':
+          case StatusStageEnum.ready:
             url = '/dashboard';
             if (url === state.url) {
               result = true;
@@ -61,7 +71,7 @@ export class StatusRouteGuardService implements CanActivate, CanActivateChild {
               result = this.router.parseUrl(url);
             }
             break;
-          case 'none':
+          case StatusStageEnum.none:
             if (
               [
                 '/installer/welcome',

--- a/src/gravel/api/nodes.py
+++ b/src/gravel/api/nodes.py
@@ -2,8 +2,10 @@
 # Copyright (C) 2021 SUSE, LLC.
 
 from logging import Logger
+from typing import Optional
 from fastapi.logger import logger as fastapi_logger
 from fastapi.routing import APIRouter
+from pydantic.main import BaseModel
 
 from gravel.controllers.nodes import IncomingConnection, get_node_mgr
 
@@ -15,10 +17,23 @@ router = APIRouter(
 )
 
 
+class TokenReplyModel(BaseModel):
+    token: str
+
+
 @router.post("/join")
 async def node_join():
     logger.debug("=> api -- nodes > join")
     return await get_node_mgr().join("127.0.0.1:1337", "foobarbaz")
+
+
+@router.get("/token", response_model=TokenReplyModel)
+async def nodes_get_token():
+    nodemgr = get_node_mgr()
+    token: Optional[str] = nodemgr.token
+    return TokenReplyModel(
+        token=(token if token is not None else "")
+    )
 
 
 router.add_websocket_route(  # pyright: reportUnknownMemberType=false

--- a/src/gravel/api/nodes.py
+++ b/src/gravel/api/nodes.py
@@ -1,0 +1,27 @@
+# project aquarium's backend
+# Copyright (C) 2021 SUSE, LLC.
+
+from logging import Logger
+from fastapi.logger import logger as fastapi_logger
+from fastapi.routing import APIRouter
+
+from gravel.controllers.nodes import IncomingConnection, get_node_mgr
+
+
+logger: Logger = fastapi_logger
+router = APIRouter(
+    prefix="/nodes",
+    tags=["nodes"]
+)
+
+
+@router.post("/join")
+async def node_join():
+    logger.debug("=> api -- nodes > join")
+    return await get_node_mgr().join("127.0.0.1:1337", "foobarbaz")
+
+
+router.add_websocket_route(  # pyright: reportUnknownMemberType=false
+    "/nodes/ws",
+    IncomingConnection
+)

--- a/src/gravel/controllers/bootstrap.py
+++ b/src/gravel/controllers/bootstrap.py
@@ -10,6 +10,7 @@ from typing import Optional, List
 from gravel.controllers.config import DeploymentStage
 from gravel.controllers.gstate import gstate
 from gravel.cephadm.cephadm import Cephadm
+from gravel.controllers.nodes import get_node_mgr
 
 
 logger: Logger = fastapi_logger  # required to provide type-hint to pylance
@@ -131,3 +132,4 @@ class Bootstrap:
 
         self.stage = BootstrapStage.DONE
         gstate.config.set_deployment_stage(DeploymentStage.bootstrapped)
+        await get_node_mgr().finish_bootstrap()

--- a/src/gravel/controllers/bootstrap.py
+++ b/src/gravel/controllers/bootstrap.py
@@ -24,11 +24,11 @@ class BootstrapError(Exception):
     pass
 
 
-class BootstrapStage(str, Enum):
-    NONE = "none"
-    RUNNING = "running"
-    DONE = "done"
-    ERROR = "error"
+class BootstrapStage(int, Enum):
+    NONE = 0
+    RUNNING = 1
+    DONE = 2
+    ERROR = 3
 
 
 class Bootstrap:
@@ -41,10 +41,7 @@ class Bootstrap:
 
     async def _should_bootstrap(self) -> bool:
         state: DeploymentStage = gstate.config.deployment_state.stage
-        if state == DeploymentStage.none or \
-           state == DeploymentStage.bootstrapping:
-            return True
-        return False
+        return state <= DeploymentStage.bootstrapping
 
     async def _is_bootstrapping(self) -> bool:
         state: DeploymentStage = gstate.config.deployment_state.stage

--- a/src/gravel/controllers/config.py
+++ b/src/gravel/controllers/config.py
@@ -54,11 +54,11 @@ class ConfigModel(BaseModel):
 class Config:
 
     def __init__(self, path: str = config_dir):
-        confdir = Path(path)
-        self.confpath = confdir.joinpath(Path("config.json"))
-        logger.debug(f'Aquarium config dir: {confdir}')
+        self._confdir = Path(path)
+        self.confpath = self._confdir.joinpath(Path("config.json"))
+        logger.debug(f'Aquarium config dir: {self._confdir}')
 
-        confdir.mkdir(0o700, parents=True, exist_ok=True)
+        self._confdir.mkdir(0o700, parents=True, exist_ok=True)
 
         if not self.confpath.exists():
             initconf: ConfigModel = ConfigModel(
@@ -90,3 +90,7 @@ class Config:
     @property
     def options(self) -> OptionsModel:
         return self.config.options
+
+    @property
+    def confdir(self) -> Path:
+        return self._confdir

--- a/src/gravel/controllers/config.py
+++ b/src/gravel/controllers/config.py
@@ -17,11 +17,11 @@ _config_dir_env = os.getenv(f"{_env_prefix}{_env_config_dir}")
 config_dir: str = _config_dir_env if _config_dir_env else '/etc/aquarium'
 
 
-class DeploymentStage(str, Enum):
-    none = "none"
-    bootstrapping = "bootstrapping"
-    bootstrapped = "bootstrapped"
-    ready = "ready"
+class DeploymentStage(int, Enum):
+    none = 0
+    bootstrapping = 1
+    bootstrapped = 2
+    ready = 3
 
 
 class DeploymentStateModel(BaseModel):

--- a/src/gravel/controllers/gstate.py
+++ b/src/gravel/controllers/gstate.py
@@ -79,7 +79,7 @@ class GlobalState:
     async def tick(self) -> None:
         while not self.is_shutting_down:
             state = self.config.deployment_state.stage
-            logger.debug(f"=> tick ({state})")
+            logger.debug(f"=> tick ({state.name})")
             await asyncio.sleep(1)
             await self._do_ticks()
 

--- a/src/gravel/controllers/nodes.py
+++ b/src/gravel/controllers/nodes.py
@@ -208,6 +208,10 @@ class NodeMgr:
     def connmgr(self) -> ConnMgr:
         return self._connmgr
 
+    @property
+    def token(self) -> Optional[str]:
+        return self._token
+
     def _load(self) -> None:
         self._state = self._load_state()
         self._manifest = self._load_manifest()

--- a/src/gravel/controllers/nodes.py
+++ b/src/gravel/controllers/nodes.py
@@ -1,0 +1,225 @@
+# project aquarium's backend
+# Copyright (C) 2021 SUSE, LLC.
+
+from __future__ import annotations
+import asyncio
+from enum import Enum
+from logging import Logger
+from typing import (
+    Any,
+    Dict,
+    List,
+    Optional, Tuple,
+    Union,
+    cast
+)
+from uuid import UUID, uuid4
+import websockets
+
+from fastapi.logger import logger as fastapi_logger
+from pydantic import BaseModel
+from starlette.endpoints import WebSocketEndpoint
+from starlette.websockets import WebSocket
+
+
+logger: Logger = fastapi_logger
+
+
+class MessageTypeEnum(int, Enum):
+    JOIN = 1
+    WELCOME = 2
+
+
+class NodeOpType(int, Enum):
+    NONE = 0
+    JOIN = 1
+
+
+class MessageModel(BaseModel):
+    type: MessageTypeEnum
+    data: Any
+
+
+class JoinMessageModel(BaseModel):
+    uuid: UUID
+    token: str
+
+
+class Peer:
+    endpoint: str
+    conn: Union[IncomingConnection, OutgoingConnection]
+
+    def __init__(self, endpoint: str, conn: Union[IncomingConnection, OutgoingConnection]):
+        self.endpoint = endpoint
+        self.conn = conn
+
+
+class ConnMgr:
+
+    _conns: List[Peer]
+    _conn_by_endpoint: Dict[str, Peer]
+
+    _passive_conns: List[Peer]
+    _active_conns: List[Peer]
+
+    _incoming_queue: asyncio.Queue[Tuple[IncomingConnection, MessageModel]]
+
+    def __init__(self):
+        self._conns = []
+        self._passive_conns = []
+        self._active_conns = []
+        self._conn_by_endpoint = {}
+        self._incoming_queue = asyncio.Queue()
+
+    def register_connect(
+        self,
+        endpoint: str,
+        conn: Union[OutgoingConnection, IncomingConnection],
+        is_passive: bool
+    ) -> None:
+        peer = Peer(endpoint=endpoint, conn=conn)
+        self._conns.append(peer)
+        self._conn_by_endpoint[endpoint] = peer
+
+        if is_passive:
+            self._passive_conns.append(peer)
+        else:
+            self._active_conns.append(peer)
+
+    async def on_incoming_receive(
+        self,
+        conn: IncomingConnection,
+        msg: MessageModel
+    ) -> None:
+        logger.debug(f"=> connmgr -- incoming recv: {conn}, {msg}")
+        await self._incoming_queue.put((conn, msg))
+        logger.debug(f"=> connmgr -- queue len: {self._incoming_queue.qsize()}")
+
+    async def wait_incoming_msg(
+        self
+    ) -> Tuple[IncomingConnection, MessageModel]:
+        return await self._incoming_queue.get()
+
+    async def connect(self, endpoint: str) -> OutgoingConnection:
+
+        if endpoint in self._conn_by_endpoint:
+            conn = self._conn_by_endpoint[endpoint].conn
+            return cast(OutgoingConnection, conn)
+
+        wsclient = await websockets.connect(endpoint)
+        conn = OutgoingConnection(wsclient)
+        self.register_connect(endpoint, conn, is_passive=False)
+        return conn
+
+
+class Mgr:
+
+    _connmgr: ConnMgr
+    _incoming_task: asyncio.Task
+    _shutting_down: bool
+
+    def __init__(self):
+        self._connmgr = ConnMgr()
+        self._shutting_down = False
+        self._incoming_task = asyncio.create_task(self._incoming_msg_task())
+
+    async def join(self, address: str, token: str) -> bool:
+        logger.debug(f"=> mgr -- join > with addr {address}, token: {token}")
+        uri: str = f"ws://{address}/api/nodes/ws"
+        conn = await self._connmgr.connect(uri)
+        logger.debug(f"=> mgr -- join > conn: {conn}")
+
+        uuid: UUID = uuid4()
+        joinmsg = JoinMessageModel(uuid=uuid, token=token)
+        msg = MessageModel(type=MessageTypeEnum.JOIN, data=joinmsg.dict())
+        await conn.send(msg)
+        reply: MessageModel = await conn.receive()
+        logger.debug(f"=> mgr -- join > recv: {reply}")
+        return True
+
+    @property
+    def connmgr(self) -> ConnMgr:
+        return self._connmgr
+
+    async def _incoming_msg_task(self) -> None:
+        while not self._shutting_down:
+            logger.debug("=> mgr -- incoming msg task > wait")
+            conn, msg = await self._connmgr.wait_incoming_msg()
+            logger.debug(f"=> mgr -- incoming msg task > {conn}, {msg}")
+            await self._handle_incoming_msg(conn, msg)
+            logger.debug("=> mgr -- incoming msg task > handled")
+
+    async def _handle_incoming_msg(
+        self,
+        conn: IncomingConnection,
+        msg: MessageModel
+    ) -> None:
+        logger.debug(f"=> mgr -- handle msg > type: {msg.type}")
+        if msg.type == MessageTypeEnum.JOIN:
+            logger.debug("=> mgr -- handle msg > join")
+            await conn.send_msg(
+                MessageModel(type=MessageTypeEnum.WELCOME, data={})
+            )
+            logger.debug("=> mgr -- handle msg > sent welcome")
+        pass
+
+
+_mgr = Mgr()
+
+
+def get_node_mgr() -> Mgr:
+    return _mgr
+
+
+def get_conn_mgr() -> ConnMgr:
+    return get_node_mgr().connmgr
+
+
+class IncomingConnection(WebSocketEndpoint):
+
+    _ws: Optional[WebSocket] = None
+
+    async def on_connect(self, websocket: WebSocket) -> None:
+        logger.debug(f"=> connection -- from {websocket.client}")
+        self._ws = websocket
+        host: str = \
+            f"{websocket.client.host}"  # pyright: reportUnknownMemberType=false
+        port: str = \
+            f"{websocket.client.port}"  # pyright: reportUnknownMemberType=false
+        endpoint: str = f"{host}:{port}"
+        await websocket.accept()
+        get_conn_mgr().register_connect(endpoint, self, is_passive=True)
+
+    async def on_disconnect(
+        self,
+        websocket: WebSocket,
+        close_code: int
+    ) -> None:
+        logger.debug(f"=> connection -- disconnect from {websocket.client}")
+        self._ws = None
+
+    async def on_receive(self, websocket: WebSocket, data: Any) -> None:
+        logger.debug(f"=> connection -- recv from {websocket.client}: {data}")
+        msg: MessageModel = MessageModel.parse_raw(data)
+        await get_conn_mgr().on_incoming_receive(self, msg)
+
+    async def send_msg(self, data: MessageModel) -> None:
+        logger.debug(f"=> connection -- send to {self._ws} data {data}")
+        assert self._ws
+        await self._ws.send_text(data.json())
+
+
+class OutgoingConnection:
+    _ws: websockets.WebSocketClientProtocol
+
+    def __init__(self, ws: websockets.WebSocketClientProtocol) -> None:
+        self._ws = ws
+
+    async def send(self, msg: MessageModel) -> None:
+        assert self._ws
+        await self._ws.send(msg.json())
+
+    async def receive(self) -> MessageModel:
+        assert self._ws
+        raw = await self._ws.recv()
+        return MessageModel.parse_raw(raw)

--- a/src/gravel/controllers/nodes.py
+++ b/src/gravel/controllers/nodes.py
@@ -135,7 +135,7 @@ class ConnMgr:
         return conn
 
 
-class Mgr:
+class NodeMgr:
 
     _connmgr: ConnMgr
     _incoming_task: asyncio.Task
@@ -241,11 +241,11 @@ class Mgr:
         pass
 
 
-_mgr = Mgr()
+_nodemgr = NodeMgr()
 
 
-def get_node_mgr() -> Mgr:
-    return _mgr
+def get_node_mgr() -> NodeMgr:
+    return _nodemgr
 
 
 def get_conn_mgr() -> ConnMgr:

--- a/src/gravel/controllers/nodes.py
+++ b/src/gravel/controllers/nodes.py
@@ -22,6 +22,7 @@ from fastapi.logger import logger as fastapi_logger
 from pydantic import BaseModel
 from starlette.endpoints import WebSocketEndpoint
 from starlette.websockets import WebSocket
+from gravel.controllers.config import DeploymentStage
 
 from gravel.controllers.gstate import gstate
 
@@ -201,6 +202,8 @@ class Mgr:
         assert confdir.is_dir()
         statefile: Path = confdir.joinpath("node.json")
         if not statefile.exists():
+            stage = gstate.config.deployment_state.stage
+            assert stage < DeploymentStage.bootstrapped
             return None
         return NodeStateModel.parse_file(statefile)
 
@@ -210,6 +213,8 @@ class Mgr:
         assert confdir.is_dir()
         manifestfile: Path = confdir.joinpath("manifest.json")
         if not manifestfile.exists():
+            stage = gstate.config.deployment_state.stage
+            assert stage < DeploymentStage.bootstrapped
             return None
         return ManifestModel.parse_file(manifestfile)
 

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -6,3 +6,4 @@ pydantic==1.7.3
 starlette==0.13.6
 uvicorn==0.13.3
 pip
+websockets==8.1


### PR DESCRIPTION
Please note:

1. Existing deployments will be broken by these changes;
2. There's been a deployment stage format change, and we are now using integers instead of strings for the enum; @votdev mind looking at the glass bits?
3. Currently missing tests because I'm not fully satisfied with the direction, and don't want to be writing and rewriting tests until I'm sure the architecture makes sense.

Signed-off-by: Joao Eduardo Luis \<joao@suse.com>