### PR TITLE
gravel: cephfs create: ignore output from mgr call

### DIFF
--- a/src/gravel/controllers/orch/cephfs.py
+++ b/src/gravel/controllers/orch/cephfs.py
@@ -33,14 +33,11 @@ class CephFS:
             "name": name
         }
         try:
-            res = self.mgr.call(cmd)
+            # this is expected to be a silent command
+            self.mgr.call(cmd)
         except CephCommandError as e:
             raise CephFSError(e) from e
-        # this command does not support json at this time, and will output
-        # free-form text instead. We are not going to parse it, but we'll make
-        # sure we've got something out of it.
-        assert "result" in res
-        assert len(res["result"]) > 0
+
         # schedule orchestrator to update the number of mds instances
         orch = Orchestrator()
         orch.apply_mds(name)


### PR DESCRIPTION
It seems the behavior of 'fs volume create' changed beneath us and no
longer outputs any information. Ignore any possible output, and instead
rely solely on its return code.

Resolves #230

Signed-off-by: Joao Eduardo Luis \<joao@suse.com>