### PR TITLE
glass: Fix Angular warning message

### DIFF
--- a/src/glass/angular.json
+++ b/src/glass/angular.json
@@ -20,6 +20,7 @@
         "build": {
           "builder": "@angular-devkit/build-angular:browser",
           "options": {
+            "allowedCommonJsDependencies": ["lodash"],
             "outputPath": "dist/",
             "index": "src/index.html",
             "main": "src/main.ts",
@@ -37,13 +38,9 @@
                 "output": "./assets"
               }
             ],
-            "styles": [
-              "src/styles.scss"
-            ],
+            "styles": ["src/styles.scss"],
             "stylePreprocessorOptions": {
-              "includePaths": [
-                "src"
-              ]
+              "includePaths": ["src"]
             },
             "scripts": []
           },
@@ -101,23 +98,15 @@
             "polyfills": "src/polyfills.ts",
             "tsConfig": "tsconfig.spec.json",
             "karmaConfig": "",
-            "assets": [
-              "src/favicon.ico",
-              "src/assets"
-            ],
-            "styles": [
-              "src/styles.scss"
-            ],
+            "assets": ["src/favicon.ico", "src/assets"],
+            "styles": ["src/styles.scss"],
             "scripts": []
           }
         },
         "lint": {
           "builder": "@angular-eslint/builder:lint",
           "options": {
-            "lintFilePatterns": [
-              "src/**/*.ts",
-              "src/**/*.html"
-            ]
+            "lintFilePatterns": ["src/**/*.ts", "src/**/*.html"]
           }
         },
         "e2e": {


### PR DESCRIPTION
Adapt configuration to prevent the message ".../dashboard-page.component.ts depends on 'lodash'. CommonJS or AMD dependencies can cause optimization bailouts.".

Signed-off-by: Volker Theile <vtheile@suse.com>