### PR TITLE
gravel: refactor service module unittests

### DIFF
--- a/src/gravel/controllers/tests/test_services.py
+++ b/src/gravel/controllers/tests/test_services.py
@@ -2,8 +2,7 @@
 # Copyright (C) 2021 SUSE, LLC.
 
 from typing import Any, List
-import unittest
-import unittest.mock
+from unittest import mock, TestCase
 
 
 def mock_save(cls: Any) -> None:
@@ -22,18 +21,18 @@ def mock_exists_conf(cls: Any) -> bool:
     return True
 
 
-class MockConfig(unittest.mock.MagicMock):
+class MockConfig(mock.MagicMock):
     pass
 
 
-class MockStorage(unittest.mock.MagicMock):
+class MockStorage(mock.MagicMock):
     available = 2000
 
 
-with unittest.mock.patch(
+with mock.patch(
         "gravel.controllers.config.Config",
         MockConfig):
-    with unittest.mock.patch(
+    with mock.patch(
             "gravel.controllers.resources.storage", MockStorage
     ):
         from gravel.controllers.services import \
@@ -42,10 +41,10 @@ with unittest.mock.patch(
             UnknownServiceError
 
 
-@unittest.mock.patch.object(Services, "_save", new=mock_save)
-@unittest.mock.patch.object(Services, "_load", new=mock_load)
-@unittest.mock.patch.object(Services, "_create_service", new=mock_create)
-class TestServices(unittest.TestCase):
+@mock.patch.object(Services, "_save", new=mock_save)
+@mock.patch.object(Services, "_load", new=mock_load)
+@mock.patch.object(Services, "_create_service", new=mock_create)
+class TestServices(TestCase):
 
     def test_create(self):
 

--- a/src/gravel/controllers/tests/test_services.py
+++ b/src/gravel/controllers/tests/test_services.py
@@ -1,6 +1,7 @@
 # project aquarium's backend
 # Copyright (C) 2021 SUSE, LLC.
 
+from contextlib import contextmanager
 from typing import Any, List
 from unittest import mock, TestCase
 
@@ -21,127 +22,146 @@ class MockStorage(mock.MagicMock):
     available = 2000
 
 
-with mock.patch('gravel.controllers.config.Config'):
-    with mock.patch(
-            "gravel.controllers.resources.storage", MockStorage
-    ):
-        from gravel.controllers.services import \
-            Services, ServiceModel, ServiceTypeEnum, \
-            NotEnoughSpaceError, ServiceExistsError, \
-            UnknownServiceError
+@contextmanager
+def with_services_module():
+    with mock.patch('gravel.controllers.services.Services._save', new=mock_save), \
+            mock.patch('gravel.controllers.services.Services._load', new=mock_load), \
+            mock.patch('gravel.controllers.services.Services._create_service', new=mock_create):
+
+        from gravel.controllers.services import Services
+        services = Services()
+        yield services
 
 
-@mock.patch.object(Services, "_save", new=mock_save)
-@mock.patch.object(Services, "_load", new=mock_load)
-@mock.patch.object(Services, "_create_service", new=mock_create)
 class TestServices(TestCase):
 
     def test_create(self):
+        from gravel.controllers.services import ServiceTypeEnum
 
-        services = Services()
-        svc = services.create("foobar", ServiceTypeEnum.CEPHFS, 1000, 2)
-        self.assertEqual(svc.name, "foobar")
-        self.assertEqual(svc.type, ServiceTypeEnum.CEPHFS)
-        self.assertEqual(svc.reservation, 1000)
-        self.assertEqual(svc.replicas, 2)
-        self.assertIn(
-            "foobar",
-            services._services  # pyright: reportPrivateUsage=false
-        )
-        pass
+        with with_services_module() as services:
+            svc = services.create("foobar", ServiceTypeEnum.CEPHFS, 1000, 2)
+            self.assertEqual(svc.name, "foobar")
+            self.assertEqual(svc.type, ServiceTypeEnum.CEPHFS)
+            self.assertEqual(svc.reservation, 1000)
+            self.assertEqual(svc.replicas, 2)
+            self.assertIn(
+                "foobar",
+                services._services  # pyright: reportPrivateUsage=false
+            )
+            pass
 
     def test_create_fail_reservation(self):
-        services = Services()
-        try:
-            services.create("foobar", ServiceTypeEnum.CEPHFS, 3000, 2)
-        except NotEnoughSpaceError:
-            return True
-        self.fail("expected reservation error")
+        from gravel.controllers.services import \
+            ServiceTypeEnum, NotEnoughSpaceError
+
+        with with_services_module() as services:
+            try:
+                services.create("foobar", ServiceTypeEnum.CEPHFS, 3000, 2)
+            except NotEnoughSpaceError:
+                return True
+            self.fail("expected reservation error")
 
     def test_create_exists(self):
-        services = Services()
-        services.create("foobar", ServiceTypeEnum.CEPHFS, 1000, 1)
-        try:
-            services.create("foobar", ServiceTypeEnum.CEPHFS, 1, 1)
-        except ServiceExistsError:
-            return True
-        self.fail("expected service to exist")
+        from gravel.controllers.services import \
+            ServiceTypeEnum, ServiceExistsError
+
+        with with_services_module() as services:
+            services.create("foobar", ServiceTypeEnum.CEPHFS, 1000, 1)
+            try:
+                services.create("foobar", ServiceTypeEnum.CEPHFS, 1, 1)
+            except ServiceExistsError:
+                return True
+            self.fail("expected service to exist")
 
     def test_create_over_reserved(self):
-        services = Services()
-        services.create("foobar", ServiceTypeEnum.CEPHFS, 1000, 2)
-        try:
-            services.create("barbaz", ServiceTypeEnum.CEPHFS, 1, 1)
-        except NotEnoughSpaceError:
-            return True
-        self.fail("expected reservation error")
+        from gravel.controllers.services import \
+            ServiceTypeEnum, NotEnoughSpaceError
+
+        with with_services_module() as services:
+            services.create("foobar", ServiceTypeEnum.CEPHFS, 1000, 2)
+            try:
+                services.create("barbaz", ServiceTypeEnum.CEPHFS, 1, 1)
+            except NotEnoughSpaceError:
+                return True
+            self.fail("expected reservation error")
 
     def test_remove(self):
         pass
 
     def test_ls(self):
-        services = Services()
-        services.create("foobar", ServiceTypeEnum.CEPHFS, 1, 1)
-        services.create("barbaz", ServiceTypeEnum.CEPHFS, 1, 1)
+        from gravel.controllers.services import \
+            ServiceModel, ServiceTypeEnum
 
-        lst: List[ServiceModel] = services.ls()
-        names = [x.name for x in lst]
-        self.assertIn("foobar", names)
-        self.assertIn("barbaz", names)
+        with with_services_module() as services:
+            services.create("foobar", ServiceTypeEnum.CEPHFS, 1, 1)
+            services.create("barbaz", ServiceTypeEnum.CEPHFS, 1, 1)
+
+            lst: List[ServiceModel] = services.ls()
+            names = [x.name for x in lst]
+            self.assertIn("foobar", names)
+            self.assertIn("barbaz", names)
 
     def test_reservations(self):
-        services = Services()
-        services.create("foobar", ServiceTypeEnum.CEPHFS, 20, 1)
-        services.create("barbaz", ServiceTypeEnum.CEPHFS, 100, 2)
+        from gravel.controllers.services import ServiceTypeEnum
 
-        self.assertEqual(services.total_reservation, 120)
-        self.assertEqual(services.total_raw_reservation, 220)
+        with with_services_module() as services:
+            services.create("foobar", ServiceTypeEnum.CEPHFS, 20, 1)
+            services.create("barbaz", ServiceTypeEnum.CEPHFS, 100, 2)
+
+            self.assertEqual(services.total_reservation, 120)
+            self.assertEqual(services.total_raw_reservation, 220)
 
     def test_get(self):
-        services = Services()
-        try:
-            services.get("foobar")
-        except UnknownServiceError:
-            pass
-        else:
-            self.fail("expected unknown service")
+        from gravel.controllers.services import \
+            ServiceTypeEnum, UnknownServiceError
 
-        services.create("barbaz", ServiceTypeEnum.CEPHFS, 1, 1)
-        try:
-            services.get("barbaz")
-        except UnknownServiceError:
-            self.fail("expected service to exist")
+        with with_services_module() as services:
+            try:
+                services.get("foobar")
+            except UnknownServiceError:
+                pass
+            else:
+                self.fail("expected unknown service")
 
+            services.create("barbaz", ServiceTypeEnum.CEPHFS, 1, 1)
+            try:
+                services.get("barbaz")
+            except UnknownServiceError:
+                self.fail("expected service to exist")
+
+    @mock.patch('gravel.controllers.resources.storage', MockStorage)
     def test_check_requirements(self):
-        services = Services()
-        feasible, req = services.check_requirements(1000, 1)
-        self.assertTrue(feasible)
-        self.assertEqual(req.required, 1000)
-        self.assertEqual(req.available, 2000)
-        self.assertEqual(req.reserved, 0)
+        from gravel.controllers.services import ServiceTypeEnum
 
-        feasible, req = services.check_requirements(1000, 3)
-        self.assertFalse(feasible)
-        self.assertEqual(req.required, 3000)
-        self.assertEqual(req.available, 2000)
-        self.assertEqual(req.reserved, 0)
+        with with_services_module() as services:
+            feasible, req = services.check_requirements(1000, 1)
+            self.assertTrue(feasible)
+            self.assertEqual(req.required, 1000)
+            self.assertEqual(req.available, 2000)
+            self.assertEqual(req.reserved, 0)
 
-        services.create("foobar", ServiceTypeEnum.CEPHFS, 1000, 1)
-        feasible, req = services.check_requirements(1000, 1)
-        self.assertTrue(feasible)
-        self.assertEqual(req.required, 1000)
-        self.assertEqual(req.available, 2000)
-        self.assertEqual(req.reserved, 1000)
+            feasible, req = services.check_requirements(1000, 3)
+            self.assertFalse(feasible)
+            self.assertEqual(req.required, 3000)
+            self.assertEqual(req.available, 2000)
+            self.assertEqual(req.reserved, 0)
 
-        feasible, req = services.check_requirements(1000, 2)
-        self.assertFalse(feasible)
-        self.assertEqual(req.required, 2000)
-        self.assertEqual(req.available, 2000)
-        self.assertEqual(req.reserved, 1000)
+            services.create("foobar", ServiceTypeEnum.CEPHFS, 1000, 1)
+            feasible, req = services.check_requirements(1000, 1)
+            self.assertTrue(feasible)
+            self.assertEqual(req.required, 1000)
+            self.assertEqual(req.available, 2000)
+            self.assertEqual(req.reserved, 1000)
 
-        services.create("barbaz", ServiceTypeEnum.CEPHFS, 1000, 1)
-        feasible, req = services.check_requirements(1000, 1)
-        self.assertFalse(feasible)
-        self.assertEqual(req.required, 1000)
-        self.assertEqual(req.available, 2000)
-        self.assertEqual(req.reserved, 2000)
+            feasible, req = services.check_requirements(1000, 2)
+            self.assertFalse(feasible)
+            self.assertEqual(req.required, 2000)
+            self.assertEqual(req.available, 2000)
+            self.assertEqual(req.reserved, 1000)
+
+            services.create("barbaz", ServiceTypeEnum.CEPHFS, 1000, 1)
+            feasible, req = services.check_requirements(1000, 1)
+            self.assertFalse(feasible)
+            self.assertEqual(req.required, 1000)
+            self.assertEqual(req.available, 2000)
+            self.assertEqual(req.reserved, 2000)

--- a/src/gravel/controllers/tests/test_services.py
+++ b/src/gravel/controllers/tests/test_services.py
@@ -6,6 +6,7 @@ from typing import List
 from unittest import mock, TestCase
 
 
+# TODO: this should be a PropertyMock??
 class MockStorage(mock.MagicMock):
     available = 2000
 
@@ -74,6 +75,7 @@ class TestServices(TestCase):
             self.fail("expected reservation error")
 
     def test_remove(self):
+        # TODO: add missing tests
         pass
 
     def test_ls(self):

--- a/src/gravel/controllers/tests/test_services.py
+++ b/src/gravel/controllers/tests/test_services.py
@@ -2,20 +2,8 @@
 # Copyright (C) 2021 SUSE, LLC.
 
 from contextlib import contextmanager
-from typing import Any, List
+from typing import List
 from unittest import mock, TestCase
-
-
-def mock_save(cls: Any) -> None:
-    pass
-
-
-def mock_load(cls: Any) -> None:
-    pass
-
-
-def mock_create(cls: Any, svc: Any) -> None:
-    pass
 
 
 class MockStorage(mock.MagicMock):
@@ -24,9 +12,9 @@ class MockStorage(mock.MagicMock):
 
 @contextmanager
 def with_services_module():
-    with mock.patch('gravel.controllers.services.Services._save', new=mock_save), \
-            mock.patch('gravel.controllers.services.Services._load', new=mock_load), \
-            mock.patch('gravel.controllers.services.Services._create_service', new=mock_create):
+    with mock.patch('gravel.controllers.services.Services._save'), \
+            mock.patch('gravel.controllers.services.Services._load'), \
+            mock.patch('gravel.controllers.services.Services._create_service'):
 
         from gravel.controllers.services import Services
         services = Services()

--- a/src/gravel/controllers/tests/test_services.py
+++ b/src/gravel/controllers/tests/test_services.py
@@ -17,21 +17,11 @@ def mock_create(cls: Any, svc: Any) -> None:
     pass
 
 
-def mock_exists_conf(cls: Any) -> bool:
-    return True
-
-
-class MockConfig(mock.MagicMock):
-    pass
-
-
 class MockStorage(mock.MagicMock):
     available = 2000
 
 
-with mock.patch(
-        "gravel.controllers.config.Config",
-        MockConfig):
+with mock.patch('gravel.controllers.config.Config'):
     with mock.patch(
             "gravel.controllers.resources.storage", MockStorage
     ):


### PR DESCRIPTION
Moves unittest mocks into a contextmanager.

Mock patching at the import level causes unintended side effects on other unittests.

Signed-off-by: Michael Fritch <mfritch@suse.com>