### PR TITLE
tools/build-image.sh: Use sudo with --clean

### DIFF
--- a/tools/build-image.sh
+++ b/tools/build-image.sh
@@ -92,13 +92,15 @@ fi
 
 build=${imgdir}/build/${build_name}
 
+if [[ -e "${build}" && "${clean}" -eq "1" ]]; then
+  echo "warning: removing existing build '${build_name}'"
+  # TODO: Figure out if there's a way of having the build directory not
+  # owned by root in the first place.
+  sudo rm -rf ${build}
+fi
+
 if [[ -e "${build}" ]]; then
-  if [[ "${clean}" -eq "1" ]]; then
-    echo "warning: removing existing build '${build_name}'"
-    rm -rf ${build}
-  else
-    error_exit "build with name '${build_name}' already exists"
-  fi
+  error_exit "build with name '${build_name}' already exists (use --clean if you want to remove it)"
 fi
 
 set -xe


### PR DESCRIPTION
Everything in images/build/$NAME/_out is owned by root:root, which means normal users can't remove that stuff :-/  I've split the
directory existence check so that in case the `sudo rm` fails (wrong password or whatever), it'll check again for the directory and bail out if it exists.

Signed-off-by: Tim Serong <tserong@suse.com>