### PR TITLE
tools/build-image.sh: use /sbin/mkfs.btrfs instead of sudo

### DIFF
--- a/tools/build-image.sh
+++ b/tools/build-image.sh
@@ -85,7 +85,7 @@ if ! kiwi-ng --version &>/dev/null ; then
   error_exit "missing kiwi-ng"
 fi
 
-if ! sudo mkfs.btrfs --version &>/dev/null ; then
+if ! /sbin/mkfs.btrfs --version &>/dev/null ; then
   echo "error: missing btrfstools"
   exit 1
 fi


### PR DESCRIPTION
We don't need to be root to check if mkfs.btrfs is present.

Signed-off-by: Tim Serong <tserong@suse.com>