### PR TITLE
test/vagrant: Always add new Vagrant box

### DIFF
--- a/tests/vagrant/setup.sh
+++ b/tests/vagrant/setup.sh
@@ -64,33 +64,32 @@ done
   echo "error: setup with name '${setup_name} already exists" && \
   exit 1
 
-echo "=> Searching for Vagrant box '${box}' ..."
-if ! vagrant box list | grep -q "^${box}[ ]\+" ; then
-  echo "=> Vagrant box '${box}' not found, searching for existing build"
-
-  imgdir=$(realpath ${basedir}/../../images)
-
-  [[ ! -e "${imgdir}" ]] && \
-    echo "error: unable to find images directory" && \
-    exit 1
-
-  [[ ! -e "${imgdir}/build" ]] && \
-    echo "error: unable to find images build directory" && \
-    exit 1
-
-  [[ ! -e "${imgdir}/build/${box}" ]] && \
-    echo "error: unable to find build directory for '${box}'" && \
-    exit 1
-
-  img=$(ls ${imgdir}/build/${box}/_out/*.vagrant.libvirt.box 2>/dev/null)
-  [[ -z "${img}" ]] && \
-    echo "error: unable to find vagrant libvirt image for '${box}'" && \
-    exit 1
-
-  vagrant box add ${box} ${img} || exit 1
-else
-  echo "=> Vagrant box '${box}' already exists"
+if vagrant box list | grep -q "^${box}[ ]\+" ; then
+  echo "=> Removing existing Vagrant box '${box}'"
+  vagrant box remove ${box}
 fi
+
+imgdir=$(realpath ${basedir}/../../images)
+
+[[ ! -e "${imgdir}" ]] && \
+  echo "error: unable to find images directory" && \
+  exit 1
+
+[[ ! -e "${imgdir}/build" ]] && \
+  echo "error: unable to find images build directory" && \
+  exit 1
+
+[[ ! -e "${imgdir}/build/${box}" ]] && \
+  echo "error: unable to find build directory for '${box}'" && \
+  exit 1
+
+img=$(ls ${imgdir}/build/${box}/_out/*.vagrant.libvirt.box 2>/dev/null)
+[[ -z "${img}" ]] && \
+  echo "error: unable to find vagrant libvirt image for '${box}'" && \
+  exit 1
+
+echo "=> Adding new Vagrant box '${box}'"
+vagrant box add ${box} ${img} || exit 1
 
 sdir=${setupdir}/${setup_name}
 mkdir -p ${sdir} || exit 1


### PR DESCRIPTION
The first time you run `tests/vagrant/setup.sh`, it adds a new Vagrant box.  That's fine.  But if you later make some changes and build a new image, then run `tests/vagrant/setup.sh` *again*, you end up using the old box, because something with that name already exists.  Let's delete that thing if it exists, so we're always using the latest and greatest.

Signed-off-by: Tim Serong <tserong@suse.com>