### PR TITLE
Add kiwi boxbuild for distro other than openSUSE

### DIFF
--- a/tools/setup-dev.sh
+++ b/tools/setup-dev.sh
@@ -11,6 +11,7 @@ dependencies_opensuse_tumbleweed=(
   "npm"
   "vagrant"
   "vagrant-libvirt"
+  "libvirt-daemon"
 )
 
 dependencies_debian=(
@@ -20,9 +21,11 @@ dependencies_debian=(
   "python3-pip"
   "python3-rados"
   "python3-kiwi"
+  "python3-kiwi-boxed-plugin"
   "python3-venv"
   "nodejs"
   "vagrant"
+  "libvirt-daemon"
 )
 
 dependencies_ubuntu=(
@@ -32,9 +35,11 @@ dependencies_ubuntu=(
   "python3-pip"
   "python3-rados"
   "python3-kiwi"
+  "python3-kiwi-boxed-plugin"
   "python3-venv"
   "nodejs"
   "vagrant"
+  "libvirt-daemon"
 )
 
 usage() {


### PR DESCRIPTION
Adding python3-kiwi-boxed-plugin so distribution other than openSUSE could use boxbuild to create an image without adjusting the image creation process. Meaning other distributions will be downloading an openSUSE build env to create microOS, instead of building the image with native env. It provides a cross distributions build script without modifying the kiwi config one by one.
The downside of using boxbuild in other distribution is that requires downloading around 600MB of build environment and the kiwi build will be running in a qemu environment. 

Update the build script for Debian and Ubuntu to use the boxbuild option with kiwi-ng 

Signed-off-by: AvengerMoJo Alex <alau@suse.com>