### PR TITLE
glass: Colorize 'Next' button

### DIFF
--- a/src/glass/src/app/pages/deployment-page/deployment-page.component.html
+++ b/src/glass/src/app/pages/deployment-page/deployment-page.component.html
@@ -38,6 +38,7 @@
             </ng-template>
             <ng-container [ngTemplateOutlet]="services"></ng-container>
             <button mat-button
+                    class="mat-stepper-next"
                     (click)="markDeploymentFinished()">
               <span translate>Next</span>
             </button>


### PR DESCRIPTION
Change color of the 'next' button to primary color like it is done in chooser step 1 and 3.

Signed-off-by: Volker Theile <vtheile@suse.com>