### PR TITLE
microOS: add live ISO support

### DIFF
--- a/images/microOS/config.xml
+++ b/images/microOS/config.xml
@@ -560,7 +560,7 @@
         <type
             image="iso"
             primary="true"
-            flags="overlay"
+            flags="dmsquash"
             hybridpersistent_filesystem="ext4"
             hybridpersistent="true"
             kernelcmdline="quiet systemd.show_status=yes console=ttyS0,115200 console=tty0 net.ifnames=0 \$ignition_firstboot ignition.platform.id=qemu"

--- a/images/microOS/config.xml
+++ b/images/microOS/config.xml
@@ -557,6 +557,33 @@
                 <vmnic driver="e1000" interface="0" mode="bridged"/>
             </machine>
         </type>
+        <type
+            image="iso"
+            primary="true"
+            flags="overlay"
+            hybridpersistent_filesystem="ext4"
+            hybridpersistent="true"
+            kernelcmdline="quiet systemd.show_status=yes console=ttyS0,115200 console=tty0 net.ifnames=0 \$ignition_firstboot ignition.platform.id=qemu"
+            bootkernel="custom"
+            devicepersistency="by-uuid"
+        >
+            <systemdisk>
+                <volume name="home"/>
+                <volume name="root"/>
+                <volume name="tmp"/>
+                <volume name="opt"/>
+                <volume name="srv"/>
+                <volume name="boot/grub2/i386-pc"/>
+                <volume name="boot/grub2/x86_64-efi" mountpoint="boot/grub2/x86_64-efi"/>
+                <volume name="boot/writable"/>
+                <volume name="usr/local"/>
+                <volume name="var" copy_on_write="false"/>
+            </systemdisk>
+            <machine memory="512" guestOS="suse" HWversion="4">
+                <vmdisk id="0" controller="ide"/>
+                <vmnic driver="e1000" interface="0" mode="bridged"/>
+            </machine>
+        </type>
     </preferences>
 
     <repository type="rpm-md" alias="Tumbleweed_OSS">
@@ -662,6 +689,8 @@
     <packages type="image" profiles="SelfInstall">
         <package name="dracut-kiwi-oem-repart"/>
         <package name="dracut-kiwi-oem-dump"/>
+        <package name="dracut-kiwi-live"/>
+        <package name="syslinux"/>
         <package name="kernel-firmware-all"/> <!-- Fix choice between kernel-firmware and kernel-firmware-all -->
     </packages>
     <packages type="bootstrap">

--- a/tools/build-image.sh
+++ b/tools/build-image.sh
@@ -31,6 +31,7 @@ options:
 allowed image types:
   vagrant                   Builds a vagrant image
   self-install              Builds an image to be run on bare metal.
+  live-iso		    Builds an live iso with persistent storage on bare metal.
 EOF
 
 }
@@ -95,8 +96,9 @@ done
 
 profile=""
 case ${imgtype} in
-  vagrant) profile="Ceph-Vagrant" ;;
-  self-install) profile="Ceph" ;;
+  vagrant) profile="Ceph-Vagrant" type="oem";;
+  self-install) profile="Ceph" type="oem";;
+  live-iso) profile="Ceph" type="iso";;
   *)
     usage_error_exit "unknown image type: '${imgtype}'"
     ;;
@@ -193,7 +195,7 @@ osid=$(grep '^ID=' /etc/os-release | sed -e 's/\(ID=["]*\)\(.\+\)/\2/' | tr -d '
 case $osid in
   opensuse-tumbleweed | opensuse-leap)
     (set -o pipefail
-    sudo kiwi-ng --debug --profile=${profile} --type oem \
+    sudo kiwi-ng --debug --profile=${profile} --type ${type}\
       system build --description ${build} \
       --target-dir ${build}/_out |\
       tee ${build}/_logs/${build_name}-build.log)
@@ -201,7 +203,7 @@ case $osid in
     ;;
   debian | ubuntu)
     (set -o pipefail
-    sudo kiwi-ng --debug --profile=${profile} --type oem \
+    sudo kiwi-ng --debug --profile=${profile} --type ${type}\
       system boxbuild --box tumbleweed --no-update-check -- --description ${build} \
       --target-dir ${build}/_out |\
       tee ${build}/_logs/${build_name}-build.log)


### PR DESCRIPTION
With this we can now build an image that runs aquarium on start.

Problem so far is: bootstrapping errors out. But this is a start!

Resolves #275 

Signed-off-by: Joao Eduardo Luis \<joao@suse.com>
Signed-off-by: Alex Lau (AvengerMoJo) \<alau@suse.com>