### PR TITLE
gravel: log to console and file; piggyback and relicense stuff

### DIFF
--- a/src/aquarium.py
+++ b/src/aquarium.py
@@ -3,19 +3,15 @@
 # project aquarium's backend
 # Copyright (C) 2021 SUSE, LLC.
 #
-# This library is free software; you can redistribute it and/or
-# modify it under the terms of the GNU Lesser General Public
-# License as published by the Free Software Foundation; either
-# version 2.1 of the License, or (at your option) any later version.
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-# This library is distributed in the hope that it will be useful,
+# This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public
-# License along with this library; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 
 import asyncio
 import logging

--- a/src/aquarium.py
+++ b/src/aquarium.py
@@ -19,13 +19,13 @@
 
 import asyncio
 import logging
+import logging.config
 import os
-from typing import cast
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
 from fastapi.logger import logger as fastapi_logger
 
-from gravel.controllers.gstate import gstate
+from gravel.controllers.gstate import gstate, setup_logging
 from gravel.controllers.nodes import mgr
 
 from gravel.api import bootstrap
@@ -43,11 +43,9 @@ api = FastAPI()
 
 @app.on_event("startup")  # type: ignore
 async def on_startup():
-    uvilogger = cast(logging.Handler, logging.getLogger("uvicorn"))
-    logger.addHandler(uvilogger)
-    if os.getenv("AQUARIUM_DEBUG"):
-        uvilogger.setLevel(logging.DEBUG)
-        logger.setLevel(logging.DEBUG)
+
+    lvl = "INFO" if not os.getenv("AQUARIUM_DEBUG") else "DEBUG"
+    setup_logging(lvl)
     logger.info("Aquarium startup!")
 
     # init node mgr

--- a/src/gravel/api/bootstrap.py
+++ b/src/gravel/api/bootstrap.py
@@ -53,7 +53,7 @@ class StatusReplyModel(BaseModel):
 @router.post("/start", response_model=StartReplyModel)
 async def start_bootstrap() -> StartReplyModel:
     res: bool = await bootstrap.bootstrap()
-    logger.debug(f"bootstrap > start (success: {res})")
+    logger.debug(f"api > start (success: {res})")
     return StartReplyModel(success=res)
 
 
@@ -79,6 +79,6 @@ async def finish_bootstrap() -> bool:
             detail="Node currently joining an existing cluster"
         )
     except NodeError:
-        logger.error("=> api -- bootstrap > unknown error on finished")
+        logger.error("api > unknown error on finished")
         return False
     return True

--- a/src/gravel/api/nodes.py
+++ b/src/gravel/api/nodes.py
@@ -40,7 +40,7 @@ class TokenReplyModel(BaseModel):
 
 @router.post("/join")
 async def node_join(req: NodeJoinRequestModel):
-    logger.debug(f"=> api -- nodes > join {req.address} with {req.token}")
+    logger.debug(f"api > join {req.address} with {req.token}")
     if not req.address or not req.token:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/src/gravel/api/orch.py
+++ b/src/gravel/api/orch.py
@@ -1,10 +1,15 @@
 # project aquarium's backend
 # Copyright (C) 2021 SUSE, LLC.
 #
-# This library is free software; you can redistribute it and/or
-# modify it under the terms of the GNU Lesser General Public
-# License as published by the Free Software Foundation; either
-# version 2.1 of the License, or (at your option) any later version.
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 
 from logging import Logger
 from fastapi.routing import APIRouter

--- a/src/gravel/api/services.py
+++ b/src/gravel/api/services.py
@@ -1,5 +1,15 @@
 # project aquarium's backend
 # Copyright (C) 2021 SUSE, LLC.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 
 from logging import Logger
 from typing import List

--- a/src/gravel/api/status.py
+++ b/src/gravel/api/status.py
@@ -13,6 +13,7 @@
 
 from logging import Logger
 from typing import Optional
+from pathlib import Path
 from fastapi.routing import APIRouter
 from fastapi.logger import logger as fastapi_logger
 from pydantic import BaseModel, Field
@@ -61,3 +62,12 @@ async def get_status() -> StatusModel:
         cluster=cluster
     )
     return status
+
+
+@router.get("/logs")
+async def get_logs() -> str:
+
+    logfile: Path = Path("/tmp/aquarium.log")
+    if not logfile.exists():
+        return ""
+    return logfile.read_text()

--- a/src/gravel/cephadm/cephadm.py
+++ b/src/gravel/cephadm/cephadm.py
@@ -1,10 +1,15 @@
 # project aquarium's backend
 # Copyright (C) 2021 SUSE, LLC.
 #
-# This library is free software; you can redistribute it and/or
-# modify it under the terms of the GNU Lesser General Public
-# License as published by the Free Software Foundation; either
-# version 2.1 of the License, or (at your option) any later version.
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 
 import asyncio
 from logging import Logger

--- a/src/gravel/cephadm/models.py
+++ b/src/gravel/cephadm/models.py
@@ -1,5 +1,15 @@
 # project aquarium's backend
 # Copyright (C) 2021 SUSE, LLC.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 
 from typing import Any, Dict, List
 from pydantic import BaseModel

--- a/src/gravel/controllers/bootstrap.py
+++ b/src/gravel/controllers/bootstrap.py
@@ -64,7 +64,7 @@ class Bootstrap:
         return nodemgr.bootstrapping
 
     async def bootstrap(self) -> bool:
-        logger.debug("bootstrap > do bootstrap")
+        logger.debug("do bootstrap")
 
         mgr: NodeMgr = get_node_mgr()
         stage: NodeStageEnum = mgr.stage
@@ -83,7 +83,7 @@ class Bootstrap:
         try:
             asyncio.create_task(self._do_bootstrap())
         except Exception as e:
-            logger.error(f"bootstrap > error starting bootstrap task: {str(e)}")
+            logger.error(f"error starting bootstrap task: {str(e)}")
             return False
 
         return True
@@ -95,7 +95,7 @@ class Bootstrap:
         mgr: NodeMgr = get_node_mgr()
         address = mgr.address
 
-        logger.info(f"=> bootstrap > address: {address}")
+        logger.info(f"address: {address}")
         assert address is not None and len(address) > 0
 
         mgr: NodeMgr = get_node_mgr()

--- a/src/gravel/controllers/gstate.py
+++ b/src/gravel/controllers/gstate.py
@@ -135,15 +135,15 @@ class GlobalState:
 
     async def tick(self) -> None:
         while not self.is_shutting_down:
-            logger.debug("=> tick")
+            logger.debug("tick")
             await asyncio.sleep(1)
             await self._do_ticks()
 
-        logger.info("=> tick shutting down")
+        logger.info("tick shutting down")
 
     async def _do_ticks(self) -> None:
         for desc, ticker in self.tickers.items():
-            logger.debug(f"=> tick {desc}")
+            logger.debug(f"tick {desc}")
             asyncio.create_task(ticker.tick())
 
     def add_ticker(self, desc: str, whom: Ticker) -> None:

--- a/src/gravel/controllers/gstate.py
+++ b/src/gravel/controllers/gstate.py
@@ -15,6 +15,7 @@ import asyncio
 import time
 from abc import ABC, abstractmethod
 from concurrent.futures.thread import ThreadPoolExecutor
+import logging.config
 from logging import Logger
 from typing import Callable, Any, Dict
 from fastapi.logger import logger as fastapi_logger
@@ -23,6 +24,52 @@ from gravel.controllers.config import Config
 
 
 logger: Logger = fastapi_logger
+
+
+def setup_logging(console_level: str) -> None:
+    logging_config = {
+        "version": 1,
+        "disable_existing_loggers": False,
+        "formatters": {
+            "simple": {
+                "format": "[%(levelname)-5s] %(asctime)s -- %(module)s -- %(message)s",
+                "datefmt": "%Y-%m-%dT%H:%M:%S"
+            },
+            "colorized": {
+                "()": "uvicorn.logging.ColourizedFormatter",
+                "format": "%(levelprefix)s %(asctime)s -- %(module)s -- %(message)s",
+                "datefmt": "%Y-%m-%d %H:%M:%S"
+            }
+        },
+        "handlers": {
+            "console": {
+                "level": console_level,
+                "class": "logging.StreamHandler",
+                "formatter": "colorized",
+            },
+            "log_file": {
+                "level": "DEBUG",
+                "class": "logging.handlers.RotatingFileHandler",
+                "formatter": "simple",
+                "filename": "/tmp/aquarium.log",
+                "maxBytes": 10485760,
+                "backupCount": 1
+            }
+        },
+        "loggers": {
+            "uvicorn": {
+                "level": "DEBUG",
+                "handlers": ["console", "log_file"],
+                "propagate": "no"
+            }
+        },
+        "root": {
+            "level": "DEBUG",
+            "handlers": ["console", "log_file"]
+        }
+    }
+
+    logging.config.dictConfig(logging_config)
 
 
 class Ticker(ABC):

--- a/src/gravel/controllers/nodes/conn.py
+++ b/src/gravel/controllers/nodes/conn.py
@@ -61,13 +61,13 @@ class ConnMgr:
         conn: IncomingConnection,
         msg: MessageModel
     ) -> None:
-        logger.debug(f"=> connmgr -- incoming recv: {conn}, {msg}")
+        logger.debug(f"connmgr -- incoming recv: {conn}, {msg}")
 
         if not self.is_started():
             raise ConnectionManagerNotStarted()
 
         await self._incoming_queue.put((conn, msg))
-        logger.debug(f"=> connmgr -- queue len: {self._incoming_queue.qsize()}")
+        logger.debug(f"connmgr -- queue len: {self._incoming_queue.qsize()}")
 
     async def wait_incoming_msg(
         self
@@ -85,7 +85,7 @@ class IncomingConnection(WebSocketEndpoint):
     _ws: Optional[WebSocket] = None
 
     async def on_connect(self, websocket: WebSocket) -> None:
-        logger.debug(f"=> connection -- from {websocket.client}")
+        logger.debug(f"incoming -- from {websocket.client}")
 
         connmgr: ConnMgr = get_conn_mgr()
         if not connmgr.is_started():
@@ -100,18 +100,18 @@ class IncomingConnection(WebSocketEndpoint):
         websocket: WebSocket,
         close_code: int
     ) -> None:
-        logger.debug(f"=> connection -- disconnect from {websocket.client}")
+        logger.debug(f"incoming -- disconnect from {websocket.client}")
         self._ws = None
 
     async def on_receive(self, websocket: WebSocket, data: Any) -> None:
-        logger.debug(f"=> connection -- recv from {websocket.client}: {data}")
+        logger.debug(f"incoming -- recv from {websocket.client}: {data}")
         connmgr: ConnMgr = get_conn_mgr()
         assert connmgr.is_started()
         msg: MessageModel = MessageModel.parse_raw(data)
         await connmgr.on_incoming_receive(self, msg)
 
     async def send_msg(self, data: MessageModel) -> None:
-        logger.debug(f"=> connection -- send to {self._ws} data {data}")
+        logger.debug(f"incoming -- send to {self._ws} data {data}")
         assert self._ws
         await self._ws.send_text(data.json())
 

--- a/src/gravel/controllers/orch/ceph.py
+++ b/src/gravel/controllers/orch/ceph.py
@@ -190,7 +190,7 @@ class Mon(Ceph):
         try:
             self.call(size_cmd)
         except CephCommandError as e:
-            logger.error("=> ceph -- mon > unable to set pool size")
+            logger.error("mon > unable to set pool size")
             logger.debug(str(e))
             logger.debug(str(size_cmd))
 
@@ -204,7 +204,7 @@ class Mon(Ceph):
         try:
             self.call(minsize_cmd)
         except CephCommandError as e:
-            logger.error("=> ceph -- mon > unable to set pool min_size")
+            logger.error("mon > unable to set pool min_size")
             logger.debug(str(e))
 
     def set_allow_pool_size_one(self) -> None:

--- a/src/gravel/controllers/orch/cephfs.py
+++ b/src/gravel/controllers/orch/cephfs.py
@@ -1,6 +1,15 @@
 # project aquarium's backend
 # Copyright (C) 2021 SUSE, LLC.
-
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 
 from typing import List
 

--- a/src/gravel/controllers/orch/models.py
+++ b/src/gravel/controllers/orch/models.py
@@ -1,5 +1,15 @@
 # project aquarium's backend
 # Copyright (C) 2021 SUSE, LLC.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 
 from typing import Any, Dict, List
 from pydantic import BaseModel

--- a/src/gravel/controllers/orch/orchestrator.py
+++ b/src/gravel/controllers/orch/orchestrator.py
@@ -1,5 +1,15 @@
 # project aquarium's backend
 # Copyright (C) 2021 SUSE, LLC.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 
 from typing import Any, Dict, List
 

--- a/src/gravel/controllers/orch/orchestrator.py
+++ b/src/gravel/controllers/orch/orchestrator.py
@@ -95,7 +95,7 @@ class Orchestrator:
             self.call(cmd)
         except CephCommandError:
             logger.error(
-                f"=> orch -- host add > unable to add {hostname} {address}"
+                f"host add > unable to add {hostname} {address}"
             )
             return False
         return True

--- a/src/gravel/controllers/resources/inventory.py
+++ b/src/gravel/controllers/resources/inventory.py
@@ -1,5 +1,15 @@
 # project aquarium's backend
 # Copyright (C) 2021 SUSE, LLC.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 
 from logging import Logger
 import time

--- a/src/gravel/controllers/resources/inventory.py
+++ b/src/gravel/controllers/resources/inventory.py
@@ -58,7 +58,7 @@ class Inventory(Ticker):
         start: int = int(time.monotonic())
         nodeinfo = await cephadm.get_node_info()
         diff: int = int(time.monotonic()) - start
-        logger.info(f"=> inventory probing took {diff} seconds")
+        logger.info(f"probing took {diff} seconds")
         self._latest = nodeinfo
         await self._publish()
 

--- a/src/gravel/controllers/resources/storage.py
+++ b/src/gravel/controllers/resources/storage.py
@@ -77,7 +77,7 @@ class Storage(Ticker):
         if stage != NodeStageEnum.BOOTSTRAPPED and \
            stage != NodeStageEnum.READY:
             logger.debug(
-                f"=> storage not ticking, not bootstrapped (current={stage})"
+                f"not ticking, not bootstrapped (current={stage})"
             )
             return False
         return True


### PR DESCRIPTION
With this patchset we are

1. introducing automatic logging to file. The log is currently being placed under `/tmp/aquarium.log`, and it's limited to 10MB.
2. providing an endpoint to obtain the log file.
3. changing a bunch of logging messages to make output not look horrible.
4. relicensing a bunch of files to gplv3

Signed-off-by: Joao Eduardo Luis \<joao@suse.com>