### PR TITLE
gravel: rework api endpoints, drop some, ensure we can check if node is ready to handle requests

### DIFF
--- a/src/aquarium.py
+++ b/src/aquarium.py
@@ -29,12 +29,17 @@ from gravel.api import orch
 from gravel.api import status
 from gravel.api import services
 from gravel.api import nodes
+from gravel.api import local
 
 
 logger: logging.Logger = fastapi_logger
 
 
 api_tags_metadata = [
+    {
+        "name": "local",
+        "description": "Operations local to the node where the endpoint is being invoked."
+    },
     {
         "name": "bootstrap",
         "description": "Allows creating a minimal cluster on the node."
@@ -82,6 +87,7 @@ async def on_shutdown():
     await gstate.shutdown()
 
 
+api.include_router(local.router)
 api.include_router(bootstrap.router)
 api.include_router(orch.router)
 api.include_router(status.router)

--- a/src/aquarium.py
+++ b/src/aquarium.py
@@ -33,8 +33,33 @@ from gravel.api import nodes
 
 logger: logging.Logger = fastapi_logger
 
+
+api_tags_metadata = [
+    {
+        "name": "bootstrap",
+        "description": "Allows creating a minimal cluster on the node."
+    },
+    {
+        "name": "orch",
+        "description": "Operations related to Ceph cluster orchestration."
+    },
+    {
+        "name": "status",
+        "description": "Allows obtaining operation status information."
+    },
+    {
+        "name": "services",
+        "description": "Create, destroy, and operate Aquarium Services."
+    },
+    {
+        "name": "nodes",
+        "description": "Perform Aquarium Cluster node operations"
+    }
+]
+
+
 app = FastAPI()
-api = FastAPI()
+api = FastAPI(openapi_tags=api_tags_metadata)
 
 
 @app.on_event("startup")  # type: ignore

--- a/src/glass/src/app/core/dashboard/widgets/sys-info-dashboard-widget/sys-info-dashboard-widget.component.html
+++ b/src/glass/src/app/core/dashboard/widgets/sys-info-dashboard-widget/sys-info-dashboard-widget.component.html
@@ -28,7 +28,7 @@
            fxFlex="50">
         <div class="glass-text-bold"
              translate>Architecture</div>
-        <div>{{ data?.arch }}</div>
+        <div>{{ data?.cpu?.arch }}</div>
       </div>
       <div class="glass-sys-info-dashboard-widget-cell"
            fxFlex="50">

--- a/src/glass/src/app/core/dashboard/widgets/sys-info-dashboard-widget/sys-info-dashboard-widget.component.ts
+++ b/src/glass/src/app/core/dashboard/widgets/sys-info-dashboard-widget/sys-info-dashboard-widget.component.ts
@@ -1,3 +1,17 @@
+/*
+ * Project Aquarium's frontend (glass)
+ * Copyright (C) 2021 SUSE, LLC.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
 import { Component } from '@angular/core';
 import { marker as TEXT } from '@biesbjerg/ngx-translate-extract-marker';
 import { Observable } from 'rxjs';
@@ -6,7 +20,7 @@ import { map } from 'rxjs/operators';
 import { translate } from '~/app/i18n.helper';
 import { BytesToSizePipe } from '~/app/shared/pipes/bytes-to-size.pipe';
 import {
-  Facts,
+  Inventory,
   LocalNodeService
 } from '~/app/shared/services/api/local.service';
 
@@ -16,7 +30,7 @@ import {
   styleUrls: ['./sys-info-dashboard-widget.component.scss']
 })
 export class SysInfoDashboardWidgetComponent {
-  data: Facts = {} as Facts;
+  data: Inventory = {} as Inventory;
   memoryChartData: any[] = [];
   memoryChartColorScheme = {
     // EOS colors: [$eos-bc-red-500, $eos-bc-green-500]
@@ -37,24 +51,29 @@ export class SysInfoDashboardWidgetComponent {
     return this.bytesToSizePipe.transform(c);
   }
 
-  updateData($data: Facts) {
+  updateData($data: Inventory) {
     this.data = $data;
   }
 
-  loadData(): Observable<Facts> {
-    return this.localNodeService.facts().pipe(
-      map((facts: Facts) => {
+  loadData(): Observable<Inventory> {
+    return this.localNodeService.inventory().pipe(
+      map((inventory: Inventory) => {
+        let total: number = inventory.memory.total_kb * 1024;
+        let free: number = inventory.memory.free_kb * 1024;
         this.memoryChartData = [
           {
             name: translate(TEXT('Used')),
-            value: facts.memory_total_kb * 1024 - facts.memory_free_kb * 1024
+            value: total - free
           },
-          { name: translate(TEXT('Free')), value: facts.memory_free_kb * 1024 }
+          {
+            name: translate(TEXT('Free')),
+            value: free
+          }
         ];
         /* eslint-disable @typescript-eslint/naming-convention */
-        const load_1min = Math.floor(facts.cpu_load['1min'] * 100);
-        const load_5min = Math.floor(facts.cpu_load['5min'] * 100);
-        const load_15min = Math.floor(facts.cpu_load['15min'] * 100);
+        const load_1min = Math.floor(inventory.cpu.load.one_min * 100);
+        const load_5min = Math.floor(inventory.cpu.load.five_min * 100);
+        const load_15min = Math.floor(inventory.cpu.load.fifteen_min * 100);
         this.cpuLoadChartData = [
           { name: translate(TEXT('1min')), value: `${load_1min}%` },
           { name: translate(TEXT('5min')), value: `${load_5min}%` },
@@ -62,8 +81,8 @@ export class SysInfoDashboardWidgetComponent {
         ];
         // Modify the uptime value to allow the `relativeDate` pipe
         // to calculate the correct time to display.
-        facts.system_uptime = facts.system_uptime * -1;
-        return facts;
+        inventory.system_uptime = inventory.system_uptime * -1;
+        return inventory;
       })
     );
   }

--- a/src/glass/src/app/core/dashboard/widgets/sys-info-dashboard-widget/sys-info-dashboard-widget.component.ts
+++ b/src/glass/src/app/core/dashboard/widgets/sys-info-dashboard-widget/sys-info-dashboard-widget.component.ts
@@ -58,8 +58,8 @@ export class SysInfoDashboardWidgetComponent {
   loadData(): Observable<Inventory> {
     return this.localNodeService.inventory().pipe(
       map((inventory: Inventory) => {
-        let total: number = inventory.memory.total_kb * 1024;
-        let free: number = inventory.memory.free_kb * 1024;
+        const total: number = inventory.memory.total_kb * 1024;
+        const free: number = inventory.memory.free_kb * 1024;
         this.memoryChartData = [
           {
             name: translate(TEXT('Used')),

--- a/src/glass/src/app/core/dashboard/widgets/sys-info-dashboard-widget/sys-info-dashboard-widget.component.ts
+++ b/src/glass/src/app/core/dashboard/widgets/sys-info-dashboard-widget/sys-info-dashboard-widget.component.ts
@@ -5,7 +5,10 @@ import { map } from 'rxjs/operators';
 
 import { translate } from '~/app/i18n.helper';
 import { BytesToSizePipe } from '~/app/shared/pipes/bytes-to-size.pipe';
-import { Facts, OrchService } from '~/app/shared/services/api/orch.service';
+import {
+  Facts,
+  LocalNodeService
+} from '~/app/shared/services/api/local.service';
 
 @Component({
   selector: 'glass-sys-info-dashboard-widget',
@@ -25,7 +28,10 @@ export class SysInfoDashboardWidgetComponent {
     domain: ['#ffecb5', '#ffc107', '#ff9e02']
   };
 
-  constructor(private bytesToSizePipe: BytesToSizePipe, private orchService: OrchService) {}
+  constructor(
+    private bytesToSizePipe: BytesToSizePipe,
+    private localNodeService: LocalNodeService
+  ) { }
 
   valueFormatting(c: any) {
     return this.bytesToSizePipe.transform(c);
@@ -36,7 +42,7 @@ export class SysInfoDashboardWidgetComponent {
   }
 
   loadData(): Observable<Facts> {
-    return this.orchService.facts().pipe(
+    return this.localNodeService.facts().pipe(
       map((facts: Facts) => {
         this.memoryChartData = [
           {

--- a/src/glass/src/app/core/dashboard/widgets/sys-info-dashboard-widget/sys-info-dashboard-widget.component.ts
+++ b/src/glass/src/app/core/dashboard/widgets/sys-info-dashboard-widget/sys-info-dashboard-widget.component.ts
@@ -19,10 +19,7 @@ import { map } from 'rxjs/operators';
 
 import { translate } from '~/app/i18n.helper';
 import { BytesToSizePipe } from '~/app/shared/pipes/bytes-to-size.pipe';
-import {
-  Inventory,
-  LocalNodeService
-} from '~/app/shared/services/api/local.service';
+import { Inventory, LocalNodeService } from '~/app/shared/services/api/local.service';
 
 @Component({
   selector: 'glass-sys-info-dashboard-widget',
@@ -45,7 +42,7 @@ export class SysInfoDashboardWidgetComponent {
   constructor(
     private bytesToSizePipe: BytesToSizePipe,
     private localNodeService: LocalNodeService
-  ) { }
+  ) {}
 
   valueFormatting(c: any) {
     return this.bytesToSizePipe.transform(c);

--- a/src/glass/src/app/core/dashboard/widgets/volumes-dashboard-widget/volumes-dashboard-widget.component.spec.ts
+++ b/src/glass/src/app/core/dashboard/widgets/volumes-dashboard-widget/volumes-dashboard-widget.component.spec.ts
@@ -7,10 +7,7 @@ import { of } from 'rxjs';
 
 import { DashboardModule } from '~/app/core/dashboard/dashboard.module';
 import { VolumesDashboardWidgetComponent } from '~/app/core/dashboard/widgets/volumes-dashboard-widget/volumes-dashboard-widget.component';
-import {
-  LocalNodeService,
-  Volume
-} from '~/app/shared/services/api/local.service';
+import { LocalNodeService, Volume } from '~/app/shared/services/api/local.service';
 
 describe('DevicesDashboardWidgetComponent', () => {
   let component: VolumesDashboardWidgetComponent;
@@ -205,8 +202,7 @@ describe('DevicesDashboardWidgetComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(VolumesDashboardWidgetComponent);
     component = fixture.componentInstance;
-    spyOn(TestBed.inject(LocalNodeService), 'volumes')
-    .and.returnValue(of(mockedVolumes));
+    spyOn(TestBed.inject(LocalNodeService), 'volumes').and.returnValue(of(mockedVolumes));
     fixture.detectChanges();
   });
 

--- a/src/glass/src/app/core/dashboard/widgets/volumes-dashboard-widget/volumes-dashboard-widget.component.spec.ts
+++ b/src/glass/src/app/core/dashboard/widgets/volumes-dashboard-widget/volumes-dashboard-widget.component.spec.ts
@@ -7,7 +7,10 @@ import { of } from 'rxjs';
 
 import { DashboardModule } from '~/app/core/dashboard/dashboard.module';
 import { VolumesDashboardWidgetComponent } from '~/app/core/dashboard/widgets/volumes-dashboard-widget/volumes-dashboard-widget.component';
-import { OrchService, Volume } from '~/app/shared/services/api/orch.service';
+import {
+  LocalNodeService,
+  Volume
+} from '~/app/shared/services/api/local.service';
 
 describe('DevicesDashboardWidgetComponent', () => {
   let component: VolumesDashboardWidgetComponent;
@@ -202,7 +205,8 @@ describe('DevicesDashboardWidgetComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(VolumesDashboardWidgetComponent);
     component = fixture.componentInstance;
-    spyOn(TestBed.inject(OrchService), 'volumes').and.returnValue(of(mockedVolumes));
+    spyOn(TestBed.inject(LocalNodeService), 'volumes')
+    .and.returnValue(of(mockedVolumes));
     fixture.detectChanges();
   });
 

--- a/src/glass/src/app/core/dashboard/widgets/volumes-dashboard-widget/volumes-dashboard-widget.component.ts
+++ b/src/glass/src/app/core/dashboard/widgets/volumes-dashboard-widget/volumes-dashboard-widget.component.ts
@@ -3,10 +3,7 @@ import { marker as TEXT } from '@biesbjerg/ngx-translate-extract-marker';
 import { Observable } from 'rxjs';
 
 import { DatatableColumn } from '~/app/shared/models/datatable-column.type';
-import {
-  LocalNodeService,
-  Volume
-} from '~/app/shared/services/api/local.service';
+import { LocalNodeService, Volume } from '~/app/shared/services/api/local.service';
 
 @Component({
   selector: 'glass-volumes-dashboard-widget',

--- a/src/glass/src/app/core/dashboard/widgets/volumes-dashboard-widget/volumes-dashboard-widget.component.ts
+++ b/src/glass/src/app/core/dashboard/widgets/volumes-dashboard-widget/volumes-dashboard-widget.component.ts
@@ -3,7 +3,10 @@ import { marker as TEXT } from '@biesbjerg/ngx-translate-extract-marker';
 import { Observable } from 'rxjs';
 
 import { DatatableColumn } from '~/app/shared/models/datatable-column.type';
-import { OrchService, Volume } from '~/app/shared/services/api/orch.service';
+import {
+  LocalNodeService,
+  Volume
+} from '~/app/shared/services/api/local.service';
 
 @Component({
   selector: 'glass-volumes-dashboard-widget',
@@ -40,13 +43,13 @@ export class VolumesDashboardWidgetComponent {
     }
   ];
 
-  constructor(private orchService: OrchService) {}
+  constructor(private localNodeService: LocalNodeService) {}
 
   updateData($data: Volume[]) {
     this.data = $data;
   }
 
   loadData(): Observable<Volume[]> {
-    return this.orchService.volumes();
+    return this.localNodeService.volumes();
   }
 }

--- a/src/glass/src/app/pages/register-page/register-page.component.ts
+++ b/src/glass/src/app/pages/register-page/register-page.component.ts
@@ -14,8 +14,12 @@ import { BlockUI, NgBlockUI } from 'ng-block-ui';
 import validator from 'validator';
 
 import { translate } from '~/app/i18n.helper';
+import {
+  LocalNodeService,
+  NodeStatus,
+  StatusStageEnum
+} from '~/app/shared/services/api/local.service';
 import { NodesService } from '~/app/shared/services/api/nodes.service';
-import { Status, StatusService, StatusStageEnum } from '~/app/shared/services/api/status.service';
 import { NotificationService } from '~/app/shared/services/notification.service';
 import { PollService } from '~/app/shared/services/poll.service';
 
@@ -39,7 +43,7 @@ export class RegisterPageComponent implements OnInit {
     private notificationService: NotificationService,
     private pollService: PollService,
     private router: Router,
-    private statusService: StatusService
+    private localNodeService: LocalNodeService
   ) {
     this.formGroup = this.formBuilder.group({
       address: [null, [Validators.required, this.addressValidator()]],
@@ -49,7 +53,7 @@ export class RegisterPageComponent implements OnInit {
 
   ngOnInit(): void {
     this.blockUI.resetGlobal();
-    this.statusService.status().subscribe((res: Status) => {
+    this.localNodeService.status().subscribe((res: NodeStatus) => {
       if (res.node_stage === StatusStageEnum.joining) {
         this.joining = true;
         this.blockUI.start(
@@ -97,17 +101,17 @@ export class RegisterPageComponent implements OnInit {
         type: 'error'
       });
     };
-    this.statusService
+    this.localNodeService
       .status()
       .pipe(
         this.pollService.poll(
-          (res: Status) => res.node_stage === StatusStageEnum.joining,
+          (res: NodeStatus) => res.node_stage === StatusStageEnum.joining,
           undefined,
           TEXT('Failed to join existing cluster.')
         )
       )
       .subscribe(
-        (res: Status) => {
+        (res: NodeStatus) => {
           switch (res.node_stage) {
             case StatusStageEnum.none:
             case StatusStageEnum.unknown:

--- a/src/glass/src/app/shared/services/api/local.service.spec.ts
+++ b/src/glass/src/app/shared/services/api/local.service.spec.ts
@@ -1,0 +1,29 @@
+import {
+  HttpClientTestingModule,
+  HttpTestingController
+} from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { LocalNodeService } from './local.service';
+
+describe('LocalNodeService', () => {
+  let service: LocalNodeService;
+  let httpTesting: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule]
+    });
+    service = TestBed.inject(LocalNodeService);
+    httpTesting = TestBed.inject(HttpTestingController);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should call facts', () => {
+    service.facts().subscribe();
+    const req = httpTesting.expectOne('api/local/facts');
+    expect(req.request.method).toBe('GET');
+  });
+});

--- a/src/glass/src/app/shared/services/api/local.service.spec.ts
+++ b/src/glass/src/app/shared/services/api/local.service.spec.ts
@@ -35,4 +35,9 @@ describe('LocalNodeService', () => {
     expect(service).toBeTruthy();
   });
 
+  it('should call local node status', () => {
+    service.status().subscribe();
+    const req = httpTesting.expectOne('api/local/status');
+    expect(req.request.method).toBe('GET');
+  });
 });

--- a/src/glass/src/app/shared/services/api/local.service.spec.ts
+++ b/src/glass/src/app/shared/services/api/local.service.spec.ts
@@ -1,3 +1,17 @@
+/*
+ * Project Aquarium's frontend (glass)
+ * Copyright (C) 2021 SUSE, LLC.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
 import {
   HttpClientTestingModule,
   HttpTestingController
@@ -21,9 +35,4 @@ describe('LocalNodeService', () => {
     expect(service).toBeTruthy();
   });
 
-  it('should call facts', () => {
-    service.facts().subscribe();
-    const req = httpTesting.expectOne('api/local/facts');
-    expect(req.request.method).toBe('GET');
-  });
 });

--- a/src/glass/src/app/shared/services/api/local.service.spec.ts
+++ b/src/glass/src/app/shared/services/api/local.service.spec.ts
@@ -12,11 +12,9 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  */
-import {
-  HttpClientTestingModule,
-  HttpTestingController
-} from '@angular/common/http/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
+
 import { LocalNodeService } from './local.service';
 
 describe('LocalNodeService', () => {

--- a/src/glass/src/app/shared/services/api/local.service.ts
+++ b/src/glass/src/app/shared/services/api/local.service.ts
@@ -89,71 +89,6 @@ export type Inventory = {
   disks: Volume[];
 };
 
-export type Facts = {
-  arch: string;
-  bios_date: string;
-  bios_version: string;
-  cpu_cores: number;
-  cpu_count: number;
-  cpu_load: {
-    '15min': number;
-    '1min': number;
-    '5min': number;
-  };
-  cpu_model: string;
-  cpu_threads: number;
-  flash_capacity: string;
-  flash_capacity_bytes: number;
-  flash_count: number;
-  flash_list: Array<any>;
-  hdd_capacity: string;
-  hdd_capacity_bytes: number;
-  hdd_count: number;
-  hdd_list: Array<{
-    description: string;
-    dev_name: string;
-    disk_size_bytes: number;
-    model: string;
-    rev: string;
-    vendor: string;
-    wwid: string;
-  }>;
-  hostname: string;
-  interfaces: Record<
-    string,
-    {
-      driver: string;
-      iftype: string;
-      ipv4_address: string;
-      ipv6_address: string;
-      lower_devs_list: Array<any>;
-      mtu: number;
-      nic_type: string;
-      operstate: string;
-      speed: number;
-      upper_devs_list: Array<any>;
-    }
-  >;
-  kernel: string;
-  kernel_parameters: {
-    'net.ipv4.ip_nonlocal_bind': string;
-  };
-  kernel_security: {
-    description: string;
-    enforce: number;
-    type: string;
-  };
-  memory_available_kb: number;
-  memory_free_kb: number;
-  memory_total_kb: number;
-  model: string;
-  operating_system: string;
-  subscribed: string;
-  system_uptime: number;
-  timestamp: number;
-  vendor: string;
-};
-
 
 @Injectable({
   providedIn: 'root'
@@ -180,13 +115,4 @@ export class LocalNodeService {
   public inventory(): Observable<Inventory> {
     return this.http.get<Inventory>(`${this.url}/inventory`);
   }
-
-  /**
-   * Get facts
-   */
-  public facts(): Observable<Facts> {
-    // Inventory is much faster than the volumes endpoint
-    return this.http.get<Facts>(`${this.url}/facts`);
-  }
-
 }

--- a/src/glass/src/app/shared/services/api/local.service.ts
+++ b/src/glass/src/app/shared/services/api/local.service.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/naming-convention */
 /*
  * Project Aquarium's frontend (glass)
  * Copyright (C) 2021 SUSE, LLC.
@@ -16,7 +17,6 @@ import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
-
 
 export type Volume = {
   available: boolean;
@@ -105,17 +105,13 @@ export interface NodeStatus {
   node_stage: StatusStageEnum;
 }
 
-
 @Injectable({
   providedIn: 'root'
 })
 export class LocalNodeService {
+  private url = 'api/local';
 
-  private url = "api/local";
-
-  public constructor(
-    private http: HttpClient
-  ) { }
+  public constructor(private http: HttpClient) {}
 
   /**
    * Get volumes

--- a/src/glass/src/app/shared/services/api/local.service.ts
+++ b/src/glass/src/app/shared/services/api/local.service.ts
@@ -69,6 +69,7 @@ export type Inventory = {
   system_uptime: number;
   current_time: number;
   cpu: {
+    arch: string;
     model: string;
     cores: number;
     count: number;

--- a/src/glass/src/app/shared/services/api/local.service.ts
+++ b/src/glass/src/app/shared/services/api/local.service.ts
@@ -1,0 +1,191 @@
+/*
+ * Project Aquarium's frontend (glass)
+ * Copyright (C) 2021 SUSE, LLC.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+
+export type Volume = {
+  available: boolean;
+  device_id: string;
+  human_readable_type: string;
+  lsm_data: Record<string, unknown>;
+  lvs: null[];
+  path: string;
+  rejected_reasons: string[];
+  sys_api: {
+    human_readable_size: string;
+    locked: number;
+    model: string;
+    nr_requests: number;
+    partitions: Record<string, unknown>;
+    removable: boolean;
+    rev: string;
+    ro: boolean;
+    rotational: boolean;
+    sas_address: string;
+    sas_device_handle: string;
+    scheduler_mode: string;
+    sectors: number;
+    sectorsize: number;
+    size: number;
+    support_discard: number;
+    vendor: string;
+  };
+};
+
+export type Nic = {
+  driver: string;
+  iftype: string;
+  ipv4_address: string;
+  ipv6_address: string;
+  lower_devs_list: [null];
+  mtu: number;
+  nic_type: string;
+  operstate: string;
+  speed: number;
+  upper_devs_list: [null];
+};
+
+export type Inventory = {
+  hostname: string;
+  model: string;
+  vendor: string;
+  kernel: string;
+  operating_system: string;
+  system_uptime: number;
+  current_time: number;
+  cpu: {
+    model: string;
+    cores: number;
+    count: number;
+    threads: number;
+    load: {
+      one_min: number;
+      five_min: number;
+      fifteen_min: number;
+    };
+  };
+  nics: { [hostName: string]: Nic };
+  memory: {
+    available_kb: number;
+    free_kb: number;
+    total_kb: number;
+  };
+  disks: Volume[];
+};
+
+export type Facts = {
+  arch: string;
+  bios_date: string;
+  bios_version: string;
+  cpu_cores: number;
+  cpu_count: number;
+  cpu_load: {
+    '15min': number;
+    '1min': number;
+    '5min': number;
+  };
+  cpu_model: string;
+  cpu_threads: number;
+  flash_capacity: string;
+  flash_capacity_bytes: number;
+  flash_count: number;
+  flash_list: Array<any>;
+  hdd_capacity: string;
+  hdd_capacity_bytes: number;
+  hdd_count: number;
+  hdd_list: Array<{
+    description: string;
+    dev_name: string;
+    disk_size_bytes: number;
+    model: string;
+    rev: string;
+    vendor: string;
+    wwid: string;
+  }>;
+  hostname: string;
+  interfaces: Record<
+    string,
+    {
+      driver: string;
+      iftype: string;
+      ipv4_address: string;
+      ipv6_address: string;
+      lower_devs_list: Array<any>;
+      mtu: number;
+      nic_type: string;
+      operstate: string;
+      speed: number;
+      upper_devs_list: Array<any>;
+    }
+  >;
+  kernel: string;
+  kernel_parameters: {
+    'net.ipv4.ip_nonlocal_bind': string;
+  };
+  kernel_security: {
+    description: string;
+    enforce: number;
+    type: string;
+  };
+  memory_available_kb: number;
+  memory_free_kb: number;
+  memory_total_kb: number;
+  model: string;
+  operating_system: string;
+  subscribed: string;
+  system_uptime: number;
+  timestamp: number;
+  vendor: string;
+};
+
+
+@Injectable({
+  providedIn: 'root'
+})
+export class LocalNodeService {
+
+  private url = "api/local";
+
+  public constructor(
+    private http: HttpClient
+  ) { }
+
+  /**
+   * Get volumes
+   */
+  public volumes(): Observable<Volume[]> {
+    // Inventory is much faster than the volumes endpoint
+    return this.inventory().pipe(map((i) => i.disks));
+  }
+
+  /**
+   * Get inventory
+   */
+  public inventory(): Observable<Inventory> {
+    return this.http.get<Inventory>(`${this.url}/inventory`);
+  }
+
+  /**
+   * Get facts
+   */
+  public facts(): Observable<Facts> {
+    // Inventory is much faster than the volumes endpoint
+    return this.http.get<Facts>(`${this.url}/facts`);
+  }
+
+}

--- a/src/glass/src/app/shared/services/api/local.service.ts
+++ b/src/glass/src/app/shared/services/api/local.service.ts
@@ -89,6 +89,22 @@ export type Inventory = {
   disks: Volume[];
 };
 
+// eslint-disable-next-line no-shadow
+export enum StatusStageEnum {
+  unknown = -1,
+  none = 0,
+  bootstrapping = 1,
+  bootstrapped = 2,
+  joining = 3,
+  ready = 4
+}
+
+export interface NodeStatus {
+  inited: boolean;
+  /* eslint-disable @typescript-eslint/naming-convention */
+  node_stage: StatusStageEnum;
+}
+
 
 @Injectable({
   providedIn: 'root'
@@ -114,5 +130,12 @@ export class LocalNodeService {
    */
   public inventory(): Observable<Inventory> {
     return this.http.get<Inventory>(`${this.url}/inventory`);
+  }
+
+  /**
+   * Get node's status
+   */
+  public status(): Observable<NodeStatus> {
+    return this.http.get<NodeStatus>(`${this.url}/status`);
   }
 }

--- a/src/glass/src/app/shared/services/api/orch.service.spec.ts
+++ b/src/glass/src/app/shared/services/api/orch.service.spec.ts
@@ -43,9 +43,4 @@ describe('OrchService', () => {
     expect(req.request.method).toBe('GET');
   });
 
-  it('should call facts', () => {
-    service.facts().subscribe();
-    const req = httpTesting.expectOne('api/orch/facts');
-    expect(req.request.method).toBe('GET');
-  });
 });

--- a/src/glass/src/app/shared/services/api/orch.service.spec.ts
+++ b/src/glass/src/app/shared/services/api/orch.service.spec.ts
@@ -42,5 +42,4 @@ describe('OrchService', () => {
     const req = httpTesting.expectOne('api/orch/devices/all_assimilated');
     expect(req.request.method).toBe('GET');
   });
-
 });

--- a/src/glass/src/app/shared/services/api/orch.service.ts
+++ b/src/glass/src/app/shared/services/api/orch.service.ts
@@ -2,7 +2,6 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
 
 export type Host = {
   hostname: string;
@@ -26,140 +25,6 @@ export type HostDevices = {
   devices: Device[];
 };
 
-export type Volume = {
-  available: boolean;
-  device_id: string;
-  human_readable_type: string;
-  lsm_data: Record<string, unknown>;
-  lvs: null[];
-  path: string;
-  rejected_reasons: string[];
-  sys_api: {
-    human_readable_size: string;
-    locked: number;
-    model: string;
-    nr_requests: number;
-    partitions: Record<string, unknown>;
-    removable: boolean;
-    rev: string;
-    ro: boolean;
-    rotational: boolean;
-    sas_address: string;
-    sas_device_handle: string;
-    scheduler_mode: string;
-    sectors: number;
-    sectorsize: number;
-    size: number;
-    support_discard: number;
-    vendor: string;
-  };
-};
-
-export type Nic = {
-  driver: string;
-  iftype: string;
-  ipv4_address: string;
-  ipv6_address: string;
-  lower_devs_list: [null];
-  mtu: number;
-  nic_type: string;
-  operstate: string;
-  speed: number;
-  upper_devs_list: [null];
-};
-
-export type Inventory = {
-  hostname: string;
-  model: string;
-  vendor: string;
-  kernel: string;
-  operating_system: string;
-  system_uptime: number;
-  current_time: number;
-  cpu: {
-    model: string;
-    cores: number;
-    count: number;
-    threads: number;
-    load: {
-      one_min: number;
-      five_min: number;
-      fifteen_min: number;
-    };
-  };
-  nics: { [hostName: string]: Nic };
-  memory: {
-    available_kb: number;
-    free_kb: number;
-    total_kb: number;
-  };
-  disks: Volume[];
-};
-
-export type Facts = {
-  arch: string;
-  bios_date: string;
-  bios_version: string;
-  cpu_cores: number;
-  cpu_count: number;
-  cpu_load: {
-    '15min': number;
-    '1min': number;
-    '5min': number;
-  };
-  cpu_model: string;
-  cpu_threads: number;
-  flash_capacity: string;
-  flash_capacity_bytes: number;
-  flash_count: number;
-  flash_list: Array<any>;
-  hdd_capacity: string;
-  hdd_capacity_bytes: number;
-  hdd_count: number;
-  hdd_list: Array<{
-    description: string;
-    dev_name: string;
-    disk_size_bytes: number;
-    model: string;
-    rev: string;
-    vendor: string;
-    wwid: string;
-  }>;
-  hostname: string;
-  interfaces: Record<
-    string,
-    {
-      driver: string;
-      iftype: string;
-      ipv4_address: string;
-      ipv6_address: string;
-      lower_devs_list: Array<any>;
-      mtu: number;
-      nic_type: string;
-      operstate: string;
-      speed: number;
-      upper_devs_list: Array<any>;
-    }
-  >;
-  kernel: string;
-  kernel_parameters: {
-    'net.ipv4.ip_nonlocal_bind': string;
-  };
-  kernel_security: {
-    description: string;
-    enforce: number;
-    type: string;
-  };
-  memory_available_kb: number;
-  memory_free_kb: number;
-  memory_total_kb: number;
-  model: string;
-  operating_system: string;
-  subscribed: string;
-  system_uptime: number;
-  timestamp: number;
-  vendor: string;
-};
 
 @Injectable({
   providedIn: 'root'
@@ -184,21 +49,6 @@ export class OrchService {
   }
 
   /**
-   * Get volumes
-   */
-  volumes(): Observable<Volume[]> {
-    // Inventory is much faster than the volumes endpoint
-    return this.inventory().pipe(map((i) => i.disks));
-  }
-
-  /**
-   * Get inventory
-   */
-  inventory(): Observable<Inventory> {
-    return this.http.get<Inventory>(`${this.url}/inventory`);
-  }
-
-  /**
    * Assimilate all devices
    */
   assimilateDevices(): Observable<boolean> {
@@ -212,11 +62,4 @@ export class OrchService {
     return this.http.get<boolean>(`${this.url}/devices/all_assimilated`);
   }
 
-  /**
-   * Get facts
-   */
-  facts(): Observable<Facts> {
-    // Inventory is much faster than the volumes endpoint
-    return this.http.get<Facts>(`${this.url}/facts`);
-  }
 }

--- a/src/glass/src/app/shared/services/api/orch.service.ts
+++ b/src/glass/src/app/shared/services/api/orch.service.ts
@@ -25,7 +25,6 @@ export type HostDevices = {
   devices: Device[];
 };
 
-
 @Injectable({
   providedIn: 'root'
 })
@@ -61,5 +60,4 @@ export class OrchService {
   assimilateStatus(): Observable<boolean> {
     return this.http.get<boolean>(`${this.url}/devices/all_assimilated`);
   }
-
 }

--- a/src/glass/src/app/shared/services/api/status.service.spec.ts
+++ b/src/glass/src/app/shared/services/api/status.service.spec.ts
@@ -1,3 +1,17 @@
+/*
+ * Project Aquarium's frontend (glass)
+ * Copyright (C) 2021 SUSE, LLC.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 
@@ -22,6 +36,12 @@ describe('StatusService', () => {
   it('should call status', () => {
     service.status().subscribe();
     const req = httpTesting.expectOne('api/status/');
+    expect(req.request.method).toBe('GET');
+  });
+
+  it('should call local node status', () => {
+    service.node_status().subscribe();
+    const req = httpTesting.expectOne('api/local/status');
     expect(req.request.method).toBe('GET');
   });
 });

--- a/src/glass/src/app/shared/services/api/status.service.spec.ts
+++ b/src/glass/src/app/shared/services/api/status.service.spec.ts
@@ -38,10 +38,4 @@ describe('StatusService', () => {
     const req = httpTesting.expectOne('api/status/');
     expect(req.request.method).toBe('GET');
   });
-
-  it('should call local node status', () => {
-    service.node_status().subscribe();
-    const req = httpTesting.expectOne('api/local/status');
-    expect(req.request.method).toBe('GET');
-  });
 });

--- a/src/glass/src/app/shared/services/api/status.service.ts
+++ b/src/glass/src/app/shared/services/api/status.service.ts
@@ -40,8 +40,6 @@ export type Status = {
   cluster?: ClusterStatus;
 };
 
-
-
 @Injectable({
   providedIn: 'root'
 })

--- a/src/glass/src/app/shared/services/api/status.service.ts
+++ b/src/glass/src/app/shared/services/api/status.service.ts
@@ -47,8 +47,6 @@ export enum StatusStageEnum {
 }
 
 export type Status = {
-  /* eslint-disable @typescript-eslint/naming-convention */
-  node_stage: StatusStageEnum;
   cluster?: ClusterStatus;
 };
 

--- a/src/glass/src/app/shared/services/api/status.service.ts
+++ b/src/glass/src/app/shared/services/api/status.service.ts
@@ -1,3 +1,17 @@
+/*
+ * Project Aquarium's frontend (glass)
+ * Copyright (C) 2021 SUSE, LLC.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
@@ -38,11 +52,19 @@ export type Status = {
   cluster?: ClusterStatus;
 };
 
+export interface NodeStatus {
+  inited: boolean;
+  /* eslint-disable @typescript-eslint/naming-convention */
+  node_stage: StatusStageEnum;
+}
+
+
 @Injectable({
   providedIn: 'root'
 })
 export class StatusService {
-  private url = 'api/status';
+  private cluster_status_url = 'api/status';
+  private node_local_url = 'api/local';
 
   constructor(private http: HttpClient) {}
 
@@ -50,6 +72,10 @@ export class StatusService {
    * Get the current status.
    */
   status(): Observable<Status> {
-    return this.http.get<Status>(`${this.url}/`);
+    return this.http.get<Status>(`${this.cluster_status_url}/`);
+  }
+
+  public node_status(): Observable<NodeStatus> {
+    return this.http.get<NodeStatus>(`${this.node_local_url}/status`);
   }
 }

--- a/src/glass/src/app/shared/services/api/status.service.ts
+++ b/src/glass/src/app/shared/services/api/status.service.ts
@@ -36,33 +36,17 @@ export interface ClusterStatus {
   health: HealthStatus;
 }
 
-// eslint-disable-next-line no-shadow
-export enum StatusStageEnum {
-  unknown = -1,
-  none = 0,
-  bootstrapping = 1,
-  bootstrapped = 2,
-  joining = 3,
-  ready = 4
-}
-
 export type Status = {
   cluster?: ClusterStatus;
 };
 
-export interface NodeStatus {
-  inited: boolean;
-  /* eslint-disable @typescript-eslint/naming-convention */
-  node_stage: StatusStageEnum;
-}
 
 
 @Injectable({
   providedIn: 'root'
 })
 export class StatusService {
-  private cluster_status_url = 'api/status';
-  private node_local_url = 'api/local';
+  private url = 'api/status';
 
   constructor(private http: HttpClient) {}
 
@@ -70,10 +54,6 @@ export class StatusService {
    * Get the current status.
    */
   status(): Observable<Status> {
-    return this.http.get<Status>(`${this.cluster_status_url}/`);
-  }
-
-  public node_status(): Observable<NodeStatus> {
-    return this.http.get<NodeStatus>(`${this.node_local_url}/status`);
+    return this.http.get<Status>(`${this.url}/`);
   }
 }

--- a/src/glass/src/app/shared/services/status-route-guard.service.spec.ts
+++ b/src/glass/src/app/shared/services/status-route-guard.service.spec.ts
@@ -29,7 +29,7 @@ describe('StatusRouteGuardService', () => {
     result: boolean | UrlTree,
     done: DoneCallback
   ) => {
-    spyOn(statusService, 'status').and.returnValue(of({ node_stage: status }));
+    spyOn(statusService, 'status').and.returnValue(of({ inited: true, node_stage: status }));
     service.canActivate(activatedRouteSnapshot, fakeRouterStateSnapshot(url)).subscribe((res) => {
       expect(res).toEqual(result);
       done();

--- a/src/glass/src/app/shared/services/status-route-guard.service.spec.ts
+++ b/src/glass/src/app/shared/services/status-route-guard.service.spec.ts
@@ -5,8 +5,11 @@ import { ActivatedRouteSnapshot, Router, RouterStateSnapshot, UrlTree } from '@a
 import { RouterTestingModule } from '@angular/router/testing';
 import { of } from 'rxjs';
 
-import { StatusService, StatusStageEnum } from '~/app/shared/services/api/status.service';
 import { StatusRouteGuardService } from '~/app/shared/services/status-route-guard.service';
+import {
+  LocalNodeService,
+  StatusStageEnum
+} from '~/app/shared/services/api/local.service';
 import DoneCallback = jest.DoneCallback;
 
 const fakeRouterStateSnapshot = (url: string): RouterStateSnapshot =>
@@ -16,7 +19,7 @@ const fakeRouterStateSnapshot = (url: string): RouterStateSnapshot =>
 
 describe('StatusRouteGuardService', () => {
   let service: StatusRouteGuardService;
-  let statusService: StatusService;
+  let localNodeService: LocalNodeService;
   let router: Router;
   let httpTestingController: HttpTestingController;
   let urlTree: (url: string) => UrlTree;
@@ -29,7 +32,7 @@ describe('StatusRouteGuardService', () => {
     result: boolean | UrlTree,
     done: DoneCallback
   ) => {
-    spyOn(statusService, 'status').and.returnValue(of({ inited: true, node_stage: status }));
+    spyOn(localNodeService, 'status').and.returnValue(of({ inited: true, node_stage: status }));
     service.canActivate(activatedRouteSnapshot, fakeRouterStateSnapshot(url)).subscribe((res) => {
       expect(res).toEqual(result);
       done();
@@ -43,7 +46,7 @@ describe('StatusRouteGuardService', () => {
     });
 
     service = TestBed.inject(StatusRouteGuardService);
-    statusService = TestBed.inject(StatusService);
+    localNodeService = TestBed.inject(LocalNodeService);
     router = TestBed.inject(Router);
     httpTestingController = TestBed.inject(HttpTestingController);
 
@@ -65,7 +68,7 @@ describe('StatusRouteGuardService', () => {
       done();
     });
     httpTestingController
-      .expectOne('api/status/')
+      .expectOne('api/local/status')
       .error(new ErrorEvent('Unknown Error'), { status: 500 });
     httpTestingController.verify();
   });

--- a/src/glass/src/app/shared/services/status-route-guard.service.spec.ts
+++ b/src/glass/src/app/shared/services/status-route-guard.service.spec.ts
@@ -5,10 +5,7 @@ import { ActivatedRouteSnapshot, Router, RouterStateSnapshot, UrlTree } from '@a
 import { RouterTestingModule } from '@angular/router/testing';
 import { of } from 'rxjs';
 
-import {
-  LocalNodeService,
-  StatusStageEnum
-} from '~/app/shared/services/api/local.service';
+import { LocalNodeService, StatusStageEnum } from '~/app/shared/services/api/local.service';
 import { StatusRouteGuardService } from '~/app/shared/services/status-route-guard.service';
 import DoneCallback = jest.DoneCallback;
 

--- a/src/glass/src/app/shared/services/status-route-guard.service.spec.ts
+++ b/src/glass/src/app/shared/services/status-route-guard.service.spec.ts
@@ -5,11 +5,11 @@ import { ActivatedRouteSnapshot, Router, RouterStateSnapshot, UrlTree } from '@a
 import { RouterTestingModule } from '@angular/router/testing';
 import { of } from 'rxjs';
 
-import { StatusRouteGuardService } from '~/app/shared/services/status-route-guard.service';
 import {
   LocalNodeService,
   StatusStageEnum
 } from '~/app/shared/services/api/local.service';
+import { StatusRouteGuardService } from '~/app/shared/services/status-route-guard.service';
 import DoneCallback = jest.DoneCallback;
 
 const fakeRouterStateSnapshot = (url: string): RouterStateSnapshot =>

--- a/src/glass/src/app/shared/services/status-route-guard.service.ts
+++ b/src/glass/src/app/shared/services/status-route-guard.service.ts
@@ -1,3 +1,17 @@
+/*
+ * Project Aquarium's frontend (glass)
+ * Copyright (C) 2021 SUSE, LLC.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
 import { Injectable } from '@angular/core';
 import {
   ActivatedRouteSnapshot,
@@ -11,7 +25,11 @@ import * as _ from 'lodash';
 import { Observable, of } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 
-import { Status, StatusService, StatusStageEnum } from '~/app/shared/services/api/status.service';
+import {
+  NodeStatus,
+  StatusService,
+  StatusStageEnum
+} from '~/app/shared/services/api/status.service';
 
 @Injectable({
   providedIn: 'root'
@@ -23,19 +41,20 @@ export class StatusRouteGuardService implements CanActivate, CanActivateChild {
     route: ActivatedRouteSnapshot,
     state: RouterStateSnapshot
   ): Observable<boolean | UrlTree> {
-    return this.statusService.status().pipe(
+    return this.statusService.node_status().pipe(
       catchError((err) => {
         // Do not show an error notification.
         if (_.isFunction(err.preventDefault)) {
           err.preventDefault();
         }
-        const res: Status = {
+        const res: NodeStatus = {
           /* eslint-disable @typescript-eslint/naming-convention */
+          inited: false,
           node_stage: StatusStageEnum.unknown
         };
         return of(res);
       }),
-      map((res: Status): boolean | UrlTree => {
+      map((res: NodeStatus): boolean | UrlTree => {
         const url = this.isUrlChangeNeeded(res.node_stage, state.url);
         return _.isString(url) ? this.router.parseUrl(url) : true;
       })

--- a/src/glass/src/app/shared/services/status-route-guard.service.ts
+++ b/src/glass/src/app/shared/services/status-route-guard.service.ts
@@ -26,22 +26,25 @@ import { Observable, of } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 
 import {
+  LocalNodeService,
   NodeStatus,
-  StatusService,
   StatusStageEnum
-} from '~/app/shared/services/api/status.service';
+} from '~/app/shared/services/api/local.service';
 
 @Injectable({
   providedIn: 'root'
 })
 export class StatusRouteGuardService implements CanActivate, CanActivateChild {
-  constructor(private router: Router, private statusService: StatusService) {}
+  constructor(
+    private router: Router,
+    private localNodeService: LocalNodeService
+  ) {}
 
   canActivate(
     route: ActivatedRouteSnapshot,
     state: RouterStateSnapshot
   ): Observable<boolean | UrlTree> {
-    return this.statusService.node_status().pipe(
+    return this.localNodeService.status().pipe(
       catchError((err) => {
         // Do not show an error notification.
         if (_.isFunction(err.preventDefault)) {

--- a/src/glass/src/app/shared/services/status-route-guard.service.ts
+++ b/src/glass/src/app/shared/services/status-route-guard.service.ts
@@ -35,10 +35,7 @@ import {
   providedIn: 'root'
 })
 export class StatusRouteGuardService implements CanActivate, CanActivateChild {
-  constructor(
-    private router: Router,
-    private localNodeService: LocalNodeService
-  ) {}
+  constructor(private router: Router, private localNodeService: LocalNodeService) {}
 
   canActivate(
     route: ActivatedRouteSnapshot,

--- a/src/gravel/api/local.py
+++ b/src/gravel/api/local.py
@@ -1,0 +1,114 @@
+# project aquarium's backend
+# Copyright (C) 2021 SUSE, LLC.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+from logging import Logger
+from typing import List
+from fastapi.logger import logger as fastapi_logger
+from fastapi.routing import APIRouter
+from fastapi import HTTPException, status
+
+from gravel.cephadm.cephadm import Cephadm
+from gravel.cephadm.models import (
+    HostFactsModel,
+    NodeInfoModel,
+    VolumeDeviceModel
+)
+from gravel.controllers.resources import inventory
+
+
+logger: Logger = fastapi_logger
+
+router: APIRouter = APIRouter(
+    prefix="/local",
+    tags=["local"]
+)
+
+
+@router.get(
+    "/volumes",
+    name="Obtain local volumes",
+    response_model=List[VolumeDeviceModel]
+)
+async def get_volumes() -> List[VolumeDeviceModel]:
+    """
+    List this node's volumes.
+    
+    Information is obtained via `cephadm`.
+    
+    This is a sync call to `cephadm` and may take a while to return.
+    """
+    cephadm = Cephadm()
+    return await cephadm.get_volume_inventory()
+
+
+@router.get(
+    "/nodeinfo",
+    name="Obtain local node information",
+    response_model=NodeInfoModel
+)
+async def get_node_info() -> NodeInfoModel:
+    """
+    Obtain this node's information and facts.
+
+    Lists the node's volumes (same as `/local/volumes`), and additional host
+    information, such as OS metadata, NICs, etc.
+
+    This information is obtained via `cephadm`.
+
+    This is a sync call to `cephadm` and may take a while to return.
+    """
+    cephadm = Cephadm()
+    return await cephadm.get_node_info()
+
+
+@router.get(
+    "/inventory",
+    name="Obtain local node inventory",
+    response_model=NodeInfoModel
+)
+async def get_inventory() -> NodeInfoModel:
+    """
+    Obtain this node's inventory.
+
+    Includes information about the node's devices, OS information, NICs, etc.
+
+    This information is obtained via `cephadm`, periodically, and may not be
+    100% up to date between calls to this endpoint.
+
+    This endpoint is preferred over `/local/nodeinfo` because the information
+    is cached and puts less strain on the node. If the most up to date
+    information is required, and the caller does not have constraints waiting
+    for a return, `/local/nodeinfo` should be used.
+    """
+    latest = inventory.get_inventory().latest
+    if not latest:
+        raise HTTPException(status_code=status.HTTP_425_TOO_EARLY,
+                            detail="Inventory not available")
+    return latest
+
+
+@router.get(
+    "/facts",
+    name="Obtain local node's facts",
+    response_model=HostFactsModel
+)
+async def get_facts() -> HostFactsModel:
+    """
+    Obtain this node's host facts, including OS information, NICs, etc.
+
+    This information is obtained via `cephadm`.
+
+    This is a sync call to `cephadm` and may take a while to return.
+    """
+    cephadm = Cephadm()
+    return await cephadm.gather_facts()

--- a/src/gravel/api/local.py
+++ b/src/gravel/api/local.py
@@ -19,7 +19,6 @@ from fastapi import HTTPException, status
 
 from gravel.cephadm.cephadm import Cephadm
 from gravel.cephadm.models import (
-    HostFactsModel,
     NodeInfoModel,
     VolumeDeviceModel
 )
@@ -42,9 +41,9 @@ router: APIRouter = APIRouter(
 async def get_volumes() -> List[VolumeDeviceModel]:
     """
     List this node's volumes.
-    
+
     Information is obtained via `cephadm`.
-    
+
     This is a sync call to `cephadm` and may take a while to return.
     """
     cephadm = Cephadm()
@@ -95,20 +94,3 @@ async def get_inventory() -> NodeInfoModel:
         raise HTTPException(status_code=status.HTTP_425_TOO_EARLY,
                             detail="Inventory not available")
     return latest
-
-
-@router.get(
-    "/facts",
-    name="Obtain local node's facts",
-    response_model=HostFactsModel
-)
-async def get_facts() -> HostFactsModel:
-    """
-    Obtain this node's host facts, including OS information, NICs, etc.
-
-    This information is obtained via `cephadm`.
-
-    This is a sync call to `cephadm` and may take a while to return.
-    """
-    cephadm = Cephadm()
-    return await cephadm.gather_facts()

--- a/src/gravel/api/local.py
+++ b/src/gravel/api/local.py
@@ -42,12 +42,14 @@ async def get_volumes() -> List[VolumeDeviceModel]:
     """
     List this node's volumes.
 
-    Information is obtained via `cephadm`.
-
-    This is a sync call to `cephadm` and may take a while to return.
+    This information is obtained via `cephadm`, periodically, and may not be
+    100% up to date between calls to this endpoint.
     """
-    cephadm = Cephadm()
-    return await cephadm.get_volume_inventory()
+    latest = inventory.get_inventory().latest
+    if not latest:
+        raise HTTPException(status_code=status.HTTP_425_TOO_EARLY,
+                            detail="Volume list not yet available")
+    return latest.disks
 
 
 @router.get(

--- a/src/gravel/api/orch.py
+++ b/src/gravel/api/orch.py
@@ -17,13 +17,10 @@ from fastapi.logger import logger as fastapi_logger
 from fastapi import HTTPException, status
 from pydantic import BaseModel
 from typing import Dict, List
-from gravel.cephadm.cephadm import Cephadm
-from gravel.cephadm.models import HostFactsModel, NodeInfoModel, VolumeDeviceModel
 from gravel.controllers.orch.models import OrchDevicesPerHostModel
 
 from gravel.controllers.orch.orchestrator \
     import Orchestrator
-from gravel.controllers.resources import inventory
 
 
 logger: Logger = fastapi_logger
@@ -96,33 +93,6 @@ def get_devices() -> Dict[str, HostsDevicesModel]:
         host_devs[orch_host.name] = host
 
     return host_devs
-
-
-@router.get("/facts", response_model=HostFactsModel)
-async def get_facts() -> HostFactsModel:
-    cephadm = Cephadm()
-    return await cephadm.gather_facts()
-
-
-@router.get("/volumes", response_model=List[VolumeDeviceModel])
-async def get_volumes() -> List[VolumeDeviceModel]:
-    cephadm = Cephadm()
-    return await cephadm.get_volume_inventory()
-
-
-@router.get("/nodeinfo", response_model=NodeInfoModel)
-async def get_node_info() -> NodeInfoModel:
-    cephadm = Cephadm()
-    return await cephadm.get_node_info()
-
-
-@router.get("/inventory", response_model=NodeInfoModel)
-async def get_inventory() -> NodeInfoModel:
-    latest = inventory.get_inventory().latest
-    if not latest:
-        raise HTTPException(status_code=status.HTTP_425_TOO_EARLY,
-                            detail="Inventory not available")
-    return latest
 
 
 @router.post("/devices/assimilate", response_model=bool)

--- a/src/gravel/api/status.py
+++ b/src/gravel/api/status.py
@@ -36,9 +36,7 @@ router: APIRouter = APIRouter(
 
 
 class StatusModel(BaseModel):
-    node_stage: NodeStageEnum = Field(title="Node Deployment Stage")
     cluster: Optional[CephStatusModel] = Field(title="cluster status")
-    pass
 
 
 @router.get("/", response_model=StatusModel)
@@ -58,7 +56,6 @@ async def get_status() -> StatusModel:
             pass
 
     status: StatusModel = StatusModel(
-        node_stage=stage,
         cluster=cluster
     )
     return status

--- a/src/gravel/cephadm/cephadm.py
+++ b/src/gravel/cephadm/cephadm.py
@@ -132,6 +132,7 @@ class Cephadm:
             system_uptime=facts.system_uptime,
             current_time=facts.timestamp,
             cpu=NodeCPUInfoModel(
+                arch=facts.arch,
                 model=facts.cpu_model,
                 cores=facts.cpu_cores,
                 count=facts.cpu_count,

--- a/src/gravel/cephadm/models.py
+++ b/src/gravel/cephadm/models.py
@@ -93,12 +93,23 @@ class DeviceSysInfoModel(BaseModel):
     vendor: str
 
 
+class LogicalVolumeEntryModel(BaseModel):
+    block_uuid: str
+    cluster_fsid: str
+    cluster_name: str
+    name: str
+    osd_fsid: str
+    osd_id: int
+    osdspec_affinity: str
+    type: str
+
+
 class VolumeDeviceModel(BaseModel):
     available: bool
     device_id: str
     human_readable_type: str = Field("")
     lsm_data: Dict[str, Any]
-    lvs: List[Any]
+    lvs: List[LogicalVolumeEntryModel]
     path: str
     rejected_reasons: List[str]
     sys_api: DeviceSysInfoModel

--- a/src/gravel/cephadm/models.py
+++ b/src/gravel/cephadm/models.py
@@ -122,6 +122,7 @@ class NodeCPULoadModel(BaseModel):
 
 
 class NodeCPUInfoModel(BaseModel):
+    arch: str
     model: str
     cores: int
     count: int

--- a/src/gravel/controllers/nodes/mgr.py
+++ b/src/gravel/controllers/nodes/mgr.py
@@ -363,6 +363,10 @@ class NodeMgr:
         statefile.write_text(self._state.json())
 
     @property
+    def inited(self) -> bool:
+        return self._init_stage >= NodeInitStage.PRESTART
+
+    @property
     def stage(self) -> NodeStageEnum:
         assert self._state
         return self._state.stage


### PR DESCRIPTION
With this patchset we change a few things around in the API:

* Introduce a new set of endpoints at `/api/local`, meaning these are endpoints providing information and operations about or on the node where these are being invoked. This ought to reduce confusion about where information is coming from, given these were somewhat spread across the whole API.
* Moved `/orch/volumes`, `/orch/nodeinfo`, `/orch/inventory` to `/local/`.
* Dropped `/orch/facts` altogether.
* Added some API documentation, to be expanded as we go.
* Removed `node_stage` from the result from `/api/status` given we should not mix the node's stage with a more generic _status_.
* Added a `/api/local/status` endpoint, which provides both the current `node_stage`, as well as boolean indicating whether the node has been initiated and is ready to serve requests (e.g., bootstrap, join, etc.)

Additionally, and tangential to the patchset, license notices were added.

The above changes were reflected in glass.

Resolves #296 

Signed-off-by: Joao Eduardo Luis \<joao@suse.com>