### PR TITLE
glass: Hide node specific widgets by default

### DIFF
--- a/src/glass/src/app/pages/dashboard-page/dashboard-page.component.ts
+++ b/src/glass/src/app/pages/dashboard-page/dashboard-page.component.ts
@@ -11,7 +11,7 @@ import { LocalStorageService } from '~/app/shared/services/local-storage.service
   styleUrls: ['./dashboard-page.component.scss']
 })
 export class DashboardPageComponent implements OnInit {
-  enabled: string[] = ['health', 'capacity', 'services', 'volumes', 'sysInfo', 'hosts'];
+  enabled: string[] = ['health', 'capacity', 'services', 'hosts'];
 
   // New dashboard widgets must be added here. Don't forget to enhance
   // the template to render the new widget.


### PR DESCRIPTION
Do not show node specific dashboard widgets (e.g. system information, volumes) by default.

Signed-off-by: Volker Theile <vtheile@suse.com>