### PR TITLE
glass: Relocate CSS definition

### DIFF
--- a/src/glass/src/app/pages/dashboard-page/dashboard-page.component.scss
+++ b/src/glass/src/app/pages/dashboard-page/dashboard-page.component.scss
@@ -1,11 +1,3 @@
 .glass-dashboard-page-content {
   margin: 24px;
-
-  .glass-dashboard-widget {
-    padding: unset;
-
-    .mat-card-title-group {
-      padding: 16px 16px 8px 16px;
-    }
-  }
 }

--- a/src/glass/src/app/shared/components/widget/widget.component.scss
+++ b/src/glass/src/app/shared/components/widget/widget.component.scss
@@ -1,5 +1,12 @@
 @import 'styles.scss';
 
+.glass-dashboard-widget {
+  padding: unset;
+
+  .mat-card-title-group {
+    padding: 16px 16px 8px 16px;
+  }
+}
 .glass-dashboard-widget.error {
   @extend .glass-color-theme-error;
 }


### PR DESCRIPTION
The missing CSS causes flex layout to show a scroll bar and renders the widgets with an incorrect padding.

Signed-off-by: Volker Theile <vtheile@suse.com>