### PR TITLE
glass: Use consistent language in dashboard

### DIFF
--- a/src/glass/src/app/core/dashboard/widgets/capacity-dashboard-widget/capacity-dashboard-widget.component.ts
+++ b/src/glass/src/app/core/dashboard/widgets/capacity-dashboard-widget/capacity-dashboard-widget.component.ts
@@ -23,8 +23,8 @@ export class CapacityDashboardWidgetComponent {
 
   updateChartData($data: Reservations) {
     this.chartData = [
-      { name: translate(TEXT('Assigned')), value: $data.reserved },
-      { name: translate(TEXT('Unassigned')), value: $data.available }
+      { name: translate(TEXT('Used')), value: $data.reserved },
+      { name: translate(TEXT('Free')), value: $data.available }
     ];
   }
 

--- a/src/glass/src/app/core/dashboard/widgets/sys-info-dashboard-widget/sys-info-dashboard-widget.component.ts
+++ b/src/glass/src/app/core/dashboard/widgets/sys-info-dashboard-widget/sys-info-dashboard-widget.component.ts
@@ -16,8 +16,8 @@ export class SysInfoDashboardWidgetComponent {
   data: Facts = {} as Facts;
   memoryChartData: any[] = [];
   memoryChartColorScheme = {
-    // EOS colors: [$eos-bc-red-500, $eos-bc-green-500]
-    domain: ['#dc3545', '#30ba78']
+    // EOS colors: [$eos-bc-green-500, $eos-bc-gray-100]
+    domain: ['#30ba78', '#e0dfdf']
   };
   cpuLoadChartData: any[] = [];
   cpuLoadColorScheme = {


### PR DESCRIPTION
* Change colors in system information widget.
* Use 'Free' and 'Used' instead of 'Unassigned' and 'Assigned' in dashboard widgets because IMO these are more used and easier to understand.

Fixes: https://github.com/aquarist-labs/aquarium/issues/301
Signed-off-by: Volker Theile <vtheile@suse.com>