### PR TITLE
glass: Fix widget layout in error state

### DIFF
--- a/src/glass/src/app/shared/components/widget/widget.component.html
+++ b/src/glass/src/app/shared/components/widget/widget.component.html
@@ -12,12 +12,12 @@
       <mat-icon svgIcon="mdi:menu"></mat-icon>
     </button>
   </mat-card-title-group>
+  <div *ngIf="!firstLoadComplete && loading"
+       class="glass-hosts-dashboard-widget-loader">
+    <mat-progress-bar mode="indeterminate">
+    </mat-progress-bar>
+  </div>
   <mat-card-content>
-    <div *ngIf="!firstLoadComplete && loading"
-         class="glass-hosts-dashboard-widget-loader">
-      <mat-progress-bar mode="indeterminate">
-      </mat-progress-bar>
-    </div>
     <ng-container *ngIf="!error && firstLoadComplete">
       <ng-content></ng-content>
     </ng-container>

--- a/src/glass/src/app/shared/components/widget/widget.component.scss
+++ b/src/glass/src/app/shared/components/widget/widget.component.scss
@@ -9,5 +9,7 @@
 }
 .glass-dashboard-widget.error {
   @extend .glass-color-theme-error;
-  padding: 16px;
+  .mat-card-content {
+    padding: 16px;
+  }
 }


### PR DESCRIPTION
- The padding was set to the incorrect container
- Relocate the loading progress bar outside the content container and render it with the full size of the widget (to match the Material style).

Before:
![Bildschirmfoto vom 2021-03-18 14-51-42](https://user-images.githubusercontent.com/1897962/111639539-a33a9a80-87fb-11eb-8e77-6d59c9f7858f.png)

After:
![Bildschirmfoto vom 2021-03-18 14-57-01](https://user-images.githubusercontent.com/1897962/111639577-a9307b80-87fb-11eb-88a7-715f57a7f4b2.png)

Signed-off-by: Volker Theile <vtheile@suse.com>