### PR TITLE
glass: Add services page

### DIFF
--- a/src/glass/src/app/app-routing.module.ts
+++ b/src/glass/src/app/app-routing.module.ts
@@ -10,6 +10,7 @@ import { DeploymentPageComponent } from '~/app/pages/deployment-page/deployment-
 import { InstallModePageComponent } from '~/app/pages/install-mode-page/install-mode-page.component';
 import { NotFoundPageComponent } from '~/app/pages/not-found-page/not-found-page.component';
 import { RegisterPageComponent } from '~/app/pages/register-page/register-page.component';
+import { ServicesPageComponent } from '~/app/pages/services-page/services-page.component';
 import { WelcomePageComponent } from '~/app/pages/welcome-page/welcome-page.component';
 import { StatusRouteGuardService } from '~/app/shared/services/status-route-guard.service';
 
@@ -19,7 +20,10 @@ const routes: Routes = [
     path: '',
     component: MainLayoutComponent,
     canActivateChild: [StatusRouteGuardService],
-    children: [{ path: 'dashboard', component: DashboardPageComponent }]
+    children: [
+      { path: 'dashboard', component: DashboardPageComponent },
+      { path: 'services', component: ServicesPageComponent }
+    ]
   },
   {
     path: 'installer',

--- a/src/glass/src/app/core/navigation-bar/navigation-bar.component.ts
+++ b/src/glass/src/app/core/navigation-bar/navigation-bar.component.ts
@@ -15,6 +15,11 @@ export class NavigationBarComponent implements OnInit {
       name: TEXT('Dashboard'),
       icon: 'mdi:apps',
       route: '/dashboard'
+    },
+    {
+      name: TEXT('Services'),
+      icon: 'mdi:share-variant',
+      route: '/services'
     }
   ];
   /* Subitem example. Can be removed as soon as we

--- a/src/glass/src/app/pages/pages.module.ts
+++ b/src/glass/src/app/pages/pages.module.ts
@@ -13,6 +13,7 @@ import { DeploymentPageComponent } from '~/app/pages/deployment-page/deployment-
 import { InstallModePageComponent } from '~/app/pages/install-mode-page/install-mode-page.component';
 import { NotFoundPageComponent } from '~/app/pages/not-found-page/not-found-page.component';
 import { RegisterPageComponent } from '~/app/pages/register-page/register-page.component';
+import { ServicesPageComponent } from '~/app/pages/services-page/services-page.component';
 import { WelcomePageComponent } from '~/app/pages/welcome-page/welcome-page.component';
 import { SharedModule } from '~/app/shared/shared.module';
 
@@ -25,7 +26,8 @@ import { SharedModule } from '~/app/shared/shared.module';
     WelcomePageComponent,
     NotFoundPageComponent,
     CephfsModalComponent,
-    RegisterPageComponent
+    RegisterPageComponent,
+    ServicesPageComponent
   ],
   imports: [
     CommonModule,

--- a/src/glass/src/app/pages/services-page/services-page.component.html
+++ b/src/glass/src/app/pages/services-page/services-page.component.html
@@ -1,0 +1,28 @@
+<div class="glass-services-page"
+     fxLayout="column">
+  <div class="glass-services-page-actions"
+       fxLayout="row"
+       fxLayoutAlign="start center">
+    <button mat-flat-button
+            [matMenuTriggerFor]="servicesMenu">
+      <span translate>Add</span>
+    </button>
+  </div>
+  <div class="glass-services-page-content">
+    <mat-card>
+      <mat-progress-bar *ngIf="!firstLoadComplete && loading"
+                        mode="indeterminate">
+      </mat-progress-bar>
+      <glass-datatable [data]="data"
+                       [columns]="columns">
+      </glass-datatable>
+    </mat-card>
+  </div>
+</div>
+
+<mat-menu #servicesMenu="matMenu">
+  <button mat-menu-item
+          (click)="onAddService('cephfs')">
+    <span translate>CephFS Share</span>
+  </button>
+</mat-menu>

--- a/src/glass/src/app/pages/services-page/services-page.component.scss
+++ b/src/glass/src/app/pages/services-page/services-page.component.scss
@@ -1,0 +1,17 @@
+@import 'styles.scss';
+
+.glass-services-page {
+  margin: 24px;
+
+  .glass-services-page-actions {
+    margin-bottom: 8px;
+    button {
+      @extend .glass-color-theme-primary;
+    }
+  }
+  .glass-services-page-content {
+    .mat-card {
+      padding: unset;
+    }
+  }
+}

--- a/src/glass/src/app/pages/services-page/services-page.component.spec.ts
+++ b/src/glass/src/app/pages/services-page/services-page.component.spec.ts
@@ -1,0 +1,33 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { TranslateModule } from '@ngx-translate/core';
+
+import { PagesModule } from '~/app/pages/pages.module';
+import { ServicesPageComponent } from '~/app/pages/services-page/services-page.component';
+
+describe('ServicesPageComponent', () => {
+  let component: ServicesPageComponent;
+  let fixture: ComponentFixture<ServicesPageComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        HttpClientTestingModule,
+        NoopAnimationsModule,
+        PagesModule,
+        TranslateModule.forRoot()
+      ]
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ServicesPageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/glass/src/app/pages/services-page/services-page.component.ts
+++ b/src/glass/src/app/pages/services-page/services-page.component.ts
@@ -1,0 +1,81 @@
+import { Component, OnInit } from '@angular/core';
+import { marker as TEXT } from '@biesbjerg/ngx-translate-extract-marker';
+
+import { DatatableColumn } from '~/app/shared/models/datatable-column.type';
+import { BytesToSizePipe } from '~/app/shared/pipes/bytes-to-size.pipe';
+import { RedundancyLevelPipe } from '~/app/shared/pipes/redundancy-level.pipe';
+import { ServiceDesc, ServicesService } from '~/app/shared/services/api/services.service';
+import { DialogService } from '~/app/shared/services/dialog.service';
+
+@Component({
+  selector: 'glass-services-page',
+  templateUrl: './services-page.component.html',
+  styleUrls: ['./services-page.component.scss']
+})
+export class ServicesPageComponent implements OnInit {
+  loading = false;
+  firstLoadComplete = false;
+  data: ServiceDesc[] = [];
+  columns: DatatableColumn[];
+
+  constructor(
+    private service: ServicesService,
+    private bytesToSizePipe: BytesToSizePipe,
+    private redundancyLevelPipe: RedundancyLevelPipe,
+    private dialog: DialogService
+  ) {
+    this.columns = [
+      {
+        name: TEXT('Name'),
+        prop: 'name',
+        sortable: true
+      },
+      {
+        name: TEXT('Type'),
+        prop: 'type',
+        sortable: true
+      },
+      {
+        name: TEXT('Allocated Size'),
+        prop: 'reservation',
+        pipe: this.bytesToSizePipe,
+        sortable: true
+      },
+      {
+        name: TEXT('Raw Size'),
+        prop: 'raw_size',
+        pipe: this.bytesToSizePipe,
+        sortable: true
+      },
+      {
+        name: TEXT('Flavor'),
+        prop: 'replicas',
+        pipe: this.redundancyLevelPipe,
+        sortable: true
+      }
+    ];
+    this.loadData();
+  }
+
+  ngOnInit(): void {}
+
+  onAddService(type: string): void {
+    switch (type) {
+      case 'cephfs':
+        this.dialog.openCephfs((res) => {
+          if (res) {
+            this.loadData();
+          }
+        });
+        break;
+    }
+  }
+
+  loadData(): void {
+    this.loading = true;
+    this.service.list().subscribe((data) => {
+      this.data = data;
+      this.loading = this.firstLoadComplete = true;
+    });
+  }
+}

--- a/src/glass/src/app/shared/pipes/redundancy-level.pipe.ts
+++ b/src/glass/src/app/shared/pipes/redundancy-level.pipe.ts
@@ -30,7 +30,10 @@ export class RedundancyLevelPipe implements PipeTransform {
     }
   };
 
-  transform(level: number | undefined | null, option: 'flavor' | 'short' | 'long'): string {
+  transform(
+    level: number | undefined | null,
+    option: 'flavor' | 'short' | 'long' = 'flavor'
+  ): string {
     if (!(level && option) || level < 1 || level > 3) {
       return '';
     }

--- a/src/glass/src/app/shared/services/status-route-guard.service.ts
+++ b/src/glass/src/app/shared/services/status-route-guard.service.ts
@@ -83,7 +83,7 @@ export class StatusRouteGuardService implements CanActivate, CanActivateChild {
       stageAndUrl(StatusStageEnum.bootstrapping, ['/installer/create/bootstrap']) ||
       stageAndUrl(StatusStageEnum.bootstrapped, ['/installer/create/deployment', '/dashboard']) ||
       stageAndUrl(StatusStageEnum.joining, ['/installer/join/register']) ||
-      stageAndUrl(StatusStageEnum.ready, ['/dashboard'])
+      stageAndUrl(StatusStageEnum.ready, ['/dashboard', '/services'])
     );
   }
 }

--- a/src/glass/src/app/shared/shared.module.ts
+++ b/src/glass/src/app/shared/shared.module.ts
@@ -11,7 +11,7 @@ import { RelativeDatePipe } from './pipes/relative-date.pipe';
 
 @NgModule({
   declarations: [BytesToSizePipe, SortByPipe, RelativeDatePipe, RedundancyLevelPipe],
-  providers: [BytesToSizePipe, SortByPipe, RelativeDatePipe],
+  providers: [BytesToSizePipe, SortByPipe, RelativeDatePipe, RedundancyLevelPipe],
   exports: [BytesToSizePipe, ComponentsModule, SortByPipe, RelativeDatePipe, RedundancyLevelPipe],
   imports: [CommonModule, ComponentsModule, MaterialModule]
 })


### PR DESCRIPTION
![Bildschirmfoto vom 2021-03-18 16-48-25](https://user-images.githubusercontent.com/1897962/111655328-da17ad00-8809-11eb-9b2b-ca856862319f.png)

This is the core service page. In follow up PRs the ability to edit/delete them will be added. It is also planned to enhance the visualized data per service.

Signed-off-by: Volker Theile <vtheile@suse.com>