### PR TITLE
glass: Check node is initialized before bootstrapping

### DIFF
--- a/src/glass/src/app/pages/bootstrap-page/bootstrap-page.component.html
+++ b/src/glass/src/app/pages/bootstrap-page/bootstrap-page.component.html
@@ -24,7 +24,7 @@
           <mat-icon svgIcon="mdi:arrow-left"></mat-icon>
         </button>
         <button mat-button
-                (click)="doBootstrap()">
+                (click)="onStart()">
           <span translate>Start</span>
         </button>
       </mat-card-actions>

--- a/src/glass/src/app/shared/services/poll.service.ts
+++ b/src/glass/src/app/shared/services/poll.service.ts
@@ -11,6 +11,19 @@ import { translate } from '~/app/i18n.helper';
 export class PollService {
   constructor() {}
 
+  /**
+   * Poll the specified service until the given callback function
+   * returns `false`.
+   *
+   * @param isActive The callback function. Must return `false` to
+   *   stop polling.
+   * @param maxAttempts The maximum number of attempts. Defaults
+   *   to `Infinity`.
+   * @param errorMessage The error message thrown when the maximum
+   *   number of attempts have been reached.
+   * @param interval The poll interval in milliseconds.
+   * @param retLastResult Return the last result? Defaults to `true`.
+   */
   poll<T>(
     isActive: (res: T) => boolean,
     maxAttempts: number = Infinity,


### PR DESCRIPTION
Before the system can be bootstrapped it must be initialized. This process might take some time. In the meantime the bootstrapping process will not be started.

![Peek 2021-03-19 12-41](https://user-images.githubusercontent.com/1897962/111776482-5960bb80-88b2-11eb-9cc4-2975c93ed1b2.gif)

Signed-off-by: Volker Theile <vtheile@suse.com>