### PR TITLE
tests/vagrant: listen all host ips for older vagrant versions

### DIFF
--- a/tests/vagrant/Vagrantfile.tmpl
+++ b/tests/vagrant/Vagrantfile.tmpl
@@ -10,7 +10,7 @@ Vagrant.configure("2") do |config|
 
     config.vm.define :"node01", primary: true do |node|
         node.vm.hostname = "node01"
-        node.vm.network "forwarded_port", guest: 1337, host: 1337
+        node.vm.network "forwarded_port", guest: 1337, host: 1337, host_ip: "*"
 
         node.vm.provider "libvirt" do |lv|
             lv.memory = 4096
@@ -24,7 +24,7 @@ Vagrant.configure("2") do |config|
 
     config.vm.define :"node02" do |node|
         node.vm.hostname = "node02"
-        node.vm.network "forwarded_port", guest: 1337, host: 1338
+        node.vm.network "forwarded_port", guest: 1337, host: 1338, host_ip: "*"
 
         node.vm.provider "libvirt" do |lv|
             lv.memory = 4096


### PR DESCRIPTION
According to the recent docs of vagrant:

  host_ip (string) - The IP on the host you want to bind the forwarded port to.
  If not specified, it will be bound to every IP. By default, this is empty.

This is not the case for Leap 15.2 where vagrant version is 2.2.7 and
forwarded ports are bound only to localhost ip addresses.
While Tumbleweed has vagrant version 2.2.14 and does not have this
issue.

Signed-off-by: Kyr Shatskyy <kyrylo.shatskyy@suse.com>