### PR TITLE
glass: move the IP/FQDN validator

### DIFF
--- a/src/glass/src/app/pages/register-page/register-page.component.html
+++ b/src/glass/src/app/pages/register-page/register-page.component.html
@@ -27,7 +27,7 @@
                     translate>
                 This field is required.
               </span>
-              <span *ngIf="formGroup.hasError('address', 'address')"
+              <span *ngIf="formGroup.hasError('hostAddress', 'address')"
                     translate>
                 This field must be an IP address or FQDN (&lt;address&gt;:&lt;port&gt;).
               </span>

--- a/src/glass/src/app/pages/register-page/register-page.component.spec.ts
+++ b/src/glass/src/app/pages/register-page/register-page.component.spec.ts
@@ -33,49 +33,10 @@ describe('RegisterPageComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should validate addr [1]', () => {
-    const control = component.formGroup.get('address');
-    control?.setValue('foo.local');
-    expect(control?.valid).toBeTruthy();
-  });
-
-  it('should validate addr [2]', () => {
-    const control = component.formGroup.get('address');
-    control?.setValue('172.160.0.1');
-    expect(control?.valid).toBeTruthy();
-  });
-
-  it('should validate addr [3]', () => {
-    const control = component.formGroup.get('address');
-    control?.setValue('bar:1337');
-    expect(control?.valid).toBeTruthy();
-  });
-
-  it('should not validate addr [1]', () => {
+  it('should not validate address if empty', () => {
     const control = component.formGroup.get('address');
     control?.setValue('');
     expect(control?.errors).toEqual({ required: true });
-  });
-
-  it('should not validate addr [2]', () => {
-    const control = component.formGroup.get('address');
-    control?.setValue('123.456');
-    expect(control?.invalid).toBeTruthy();
-    expect(control?.errors).toEqual({ address: true });
-  });
-
-  it('should not validate addr [3]', () => {
-    const control = component.formGroup.get('address');
-    control?.setValue('foo.ba_z.com');
-    expect(control?.invalid).toBeTruthy();
-    expect(control?.errors).toEqual({ address: true });
-  });
-
-  it('should not validate addr [4]', () => {
-    const control = component.formGroup.get('address');
-    control?.setValue('foo:1a');
-    expect(control?.invalid).toBeTruthy();
-    expect(control?.errors).toEqual({ address: true });
   });
 
   it('should validate token [1]', () => {

--- a/src/glass/src/app/pages/register-page/register-page.component.ts
+++ b/src/glass/src/app/pages/register-page/register-page.component.ts
@@ -1,19 +1,11 @@
 import { Component, OnInit } from '@angular/core';
-import {
-  AbstractControl,
-  FormBuilder,
-  FormGroup,
-  ValidationErrors,
-  ValidatorFn,
-  Validators
-} from '@angular/forms';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
 import { marker as TEXT } from '@biesbjerg/ngx-translate-extract-marker';
-import * as _ from 'lodash';
 import { BlockUI, NgBlockUI } from 'ng-block-ui';
-import validator from 'validator';
 
 import { translate } from '~/app/i18n.helper';
+import { GlassValidators } from '~/app/shared/forms/validators';
 import {
   LocalNodeService,
   NodeStatus,
@@ -46,7 +38,7 @@ export class RegisterPageComponent implements OnInit {
     private localNodeService: LocalNodeService
   ) {
     this.formGroup = this.formBuilder.group({
-      address: [null, [Validators.required, this.addressValidator()]],
+      address: [null, [Validators.required, GlassValidators.hostAddress()]],
       token: [null, [Validators.required, Validators.pattern(TOKEN_REGEXP)]]
     });
   }
@@ -126,24 +118,5 @@ export class RegisterPageComponent implements OnInit {
         },
         () => handleError()
       );
-  }
-
-  protected addressValidator(): ValidatorFn {
-    return (control: AbstractControl): ValidationErrors | null => {
-      if (_.isEmpty(control.value)) {
-        return null;
-      }
-      const errResult = { address: true };
-      const parts = control.value.split(':');
-      if (parts.length === 2) {
-        if (!validator.isPort(parts[1])) {
-          return errResult;
-        }
-      }
-      const valid =
-        // eslint-disable-next-line @typescript-eslint/naming-convention
-        validator.isIP(parts[0]) || validator.isFQDN(parts[0], { require_tld: false });
-      return !valid ? errResult : null;
-    };
   }
 }

--- a/src/glass/src/app/shared/forms/validators.spec.ts
+++ b/src/glass/src/app/shared/forms/validators.spec.ts
@@ -1,0 +1,55 @@
+import { AbstractControl, FormControl, FormGroup } from '@angular/forms';
+
+import { GlassValidators } from '~/app/shared/forms/validators';
+
+describe('GlassValidators', () => {
+  let formGroup: FormGroup;
+
+  beforeEach(() => {
+    formGroup = new FormGroup({
+      x: new FormControl()
+    });
+  });
+
+  describe('hostAddress', () => {
+    let control: AbstractControl | null;
+
+    beforeEach(() => {
+      control = formGroup.get('x');
+      control?.setValidators(GlassValidators.hostAddress());
+    });
+
+    it('should validate addr [1]', () => {
+      control?.setValue('foo.local');
+      expect(control?.valid).toBeTruthy();
+    });
+
+    it('should validate addr [2]', () => {
+      control?.setValue('172.160.0.1');
+      expect(control?.valid).toBeTruthy();
+    });
+
+    it('should validate addr [3]', () => {
+      control?.setValue('bar:1337');
+      expect(control?.valid).toBeTruthy();
+    });
+
+    it('should not validate addr [1]', () => {
+      control?.setValue('123.456');
+      expect(control?.invalid).toBeTruthy();
+      expect(control?.errors).toEqual({ hostAddress: true });
+    });
+
+    it('should not validate addr [2]', () => {
+      control?.setValue('foo.ba_z.com');
+      expect(control?.invalid).toBeTruthy();
+      expect(control?.errors).toEqual({ hostAddress: true });
+    });
+
+    it('should not validate addr [3]', () => {
+      control?.setValue('foo:1a');
+      expect(control?.invalid).toBeTruthy();
+      expect(control?.errors).toEqual({ hostAddress: true });
+    });
+  });
+});

--- a/src/glass/src/app/shared/forms/validators.ts
+++ b/src/glass/src/app/shared/forms/validators.ts
@@ -1,0 +1,30 @@
+import { AbstractControl, ValidationErrors, ValidatorFn } from '@angular/forms';
+import * as _ from 'lodash';
+import validator from 'validator';
+
+export class GlassValidators {
+  /**
+   * Validator to check if the input is a valid IP-address or FQDN.
+   *
+   * @returns a validator function. The function returns the error `hostAddress` if the
+   * validation fails, otherwise `null`.
+   */
+  static hostAddress(): ValidatorFn {
+    return (control: AbstractControl): ValidationErrors | null => {
+      if (_.isEmpty(control.value)) {
+        return null;
+      }
+      const errResult = { hostAddress: true };
+      const parts = control.value.split(':');
+      if (parts.length === 2) {
+        if (!validator.isPort(parts[1])) {
+          return errResult;
+        }
+      }
+      const valid =
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        validator.isIP(parts[0]) || validator.isFQDN(parts[0], { require_tld: false });
+      return !valid ? errResult : null;
+    };
+  }
+}


### PR DESCRIPTION
Move the IP/FQDN validator to a more centralized place so that it can be used by other components as well.

Signed-off-by: Tatjana Dehler <tdehler@suse.com>