### PR TITLE
gravel: provide device info, per host, with utilization, via API

### DIFF
--- a/src/aquarium.py
+++ b/src/aquarium.py
@@ -63,8 +63,14 @@ api_tags_metadata = [
 ]
 
 
-app = FastAPI()
-api = FastAPI(openapi_tags=api_tags_metadata)
+app = FastAPI(docs_url=None)
+api = FastAPI(
+    title="Project Aquarium",
+    description="Project Aquarium is a SUSE-sponsored open source project " +
+                "aiming at becoming an easy to use, rock solid storage " +
+                "appliance based on Ceph.",
+    version="1.0.0",
+    openapi_tags=api_tags_metadata)
 
 
 @app.on_event("startup")  # type: ignore

--- a/src/aquarium.py
+++ b/src/aquarium.py
@@ -24,12 +24,15 @@ from fastapi.logger import logger as fastapi_logger
 from gravel.controllers.gstate import gstate, setup_logging
 from gravel.controllers.nodes import mgr
 
-from gravel.api import bootstrap
-from gravel.api import orch
-from gravel.api import status
-from gravel.api import services
-from gravel.api import nodes
-from gravel.api import local
+from gravel.api import (
+    bootstrap,
+    orch,
+    status,
+    services,
+    nodes,
+    local,
+    devices
+)
 
 
 logger: logging.Logger = fastapi_logger
@@ -59,6 +62,10 @@ api_tags_metadata = [
     {
         "name": "nodes",
         "description": "Perform Aquarium Cluster node operations"
+    },
+    {
+        "name": "devices",
+        "description": "Obtain and perform operations on cluster devices"
     }
 ]
 
@@ -99,6 +106,7 @@ api.include_router(orch.router)
 api.include_router(status.router)
 api.include_router(services.router)
 api.include_router(nodes.router)
+api.include_router(devices.router)
 
 
 #

--- a/src/gravel/api/devices.py
+++ b/src/gravel/api/devices.py
@@ -1,0 +1,38 @@
+# project aquarium's backend
+# Copyright (C) 2021 SUSE, LLC.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+from logging import Logger
+from typing import Dict
+from fastapi.logger import logger as fastapi_logger
+from fastapi.routing import APIRouter
+
+from gravel.controllers.resources.devices import (
+    DeviceHostModel,
+    get_devices
+)
+
+logger: Logger = fastapi_logger
+
+router: APIRouter = APIRouter(
+    prefix="/devices",
+    tags=["devices"]
+)
+
+
+@router.get(
+    "/",
+    name="Obtain devices being used for storage, per host",
+    response_model=Dict[str, DeviceHostModel]
+)
+def get_per_host_devices() -> Dict[str, DeviceHostModel]:
+    return get_devices().devices_per_host

--- a/src/gravel/controllers/config.py
+++ b/src/gravel/controllers/config.py
@@ -36,11 +36,16 @@ class StorageOptionsModel(BaseModel):
     probe_interval: float = Field(30.0, title="Storage Probe Interval")
 
 
+class DevicesOptionsModel(BaseModel):
+    probe_interval: float = Field(30.0, title="Devices Probe Interval")
+
+
 class OptionsModel(BaseModel):
     service_state_path: Path = Field(Path(config_dir).joinpath("storage.json"),
                                      title="Path to Service State file")
     inventory: InventoryOptionsModel = Field(InventoryOptionsModel())
     storage: StorageOptionsModel = Field(StorageOptionsModel())
+    devices: DevicesOptionsModel = Field(DevicesOptionsModel())
 
 
 class ConfigModel(BaseModel):

--- a/src/gravel/controllers/orch/ceph.py
+++ b/src/gravel/controllers/orch/ceph.py
@@ -26,6 +26,7 @@ from logging import Logger
 from fastapi.logger import logger as fastapi_logger
 from gravel.controllers.orch.models import (
     CephDFModel,
+    CephOSDDFModel,
     CephOSDMapModel,
     CephOSDPoolEntryModel,
     CephStatusModel
@@ -165,6 +166,14 @@ class Mon(Ceph):
         }
         result: Dict[str, Any] = self.call(cmd)
         return CephDFModel.parse_obj(result)
+
+    def osd_df(self) -> CephOSDDFModel:
+        cmd: Dict[str, str] = {
+            "prefix": "osd df",
+            "format": "json"
+        }
+        result: Dict[str, Any] = self.call(cmd)
+        return CephOSDDFModel.parse_obj(result)
 
     def get_osdmap(self) -> CephOSDMapModel:
         cmd: Dict[str, str] = {

--- a/src/gravel/controllers/orch/models.py
+++ b/src/gravel/controllers/orch/models.py
@@ -98,6 +98,47 @@ class CephDFModel(BaseModel):
     pools: List[CephDFPoolModel]
 
 
+class CephOSDDFEntryModel(BaseModel):
+    id: int
+    device_class: str
+    name: str
+    type: str
+    type_id: int
+    crush_weight: float
+    depth: int
+    pool_weights: Dict[str, Any]
+    reweight: int
+    kb: int
+    kb_used: int
+    kb_used_data: int
+    kb_used_omap: int
+    kb_used_meta: int
+    kb_avail: int
+    utilization: float
+    var: float
+    pgs: int
+    status: str
+
+
+class CephOSDDFSummaryModel(BaseModel):
+    total_kb: int
+    total_kb_used: int
+    total_kb_used_data: int
+    total_kb_used_meta: int
+    total_kb_avail: int
+    average_utilization: float
+    min_var: float
+    max_var: float
+    dev: float
+
+
+class CephOSDDFModel(BaseModel):
+    """ Result from 'osd df' """
+    nodes: List[CephOSDDFEntryModel]
+    stray: List[Any]
+    summary: CephOSDDFSummaryModel
+
+
 class CephOSDPoolEntryModel(BaseModel):
     pool: int
     pool_name: str

--- a/src/gravel/controllers/resources/devices.py
+++ b/src/gravel/controllers/resources/devices.py
@@ -1,0 +1,183 @@
+# project aquarium's backend
+# Copyright (C) 2021 SUSE, LLC.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+from logging import Logger
+from typing import (
+    Dict,
+    List
+)
+from fastapi.logger import logger as fastapi_logger
+from pydantic import (
+    Field,
+    BaseModel
+)
+
+from gravel.controllers.gstate import (
+    Ticker,
+    gstate
+)
+from gravel.controllers.nodes.mgr import (
+    NodeMgr,
+    get_node_mgr
+)
+from gravel.controllers.orch.ceph import Mon
+from gravel.cephadm.models import VolumeDeviceModel
+from gravel.controllers.orch.models import (
+    CephOSDDFModel,
+    OrchDevicesPerHostModel
+)
+from gravel.controllers.orch.orchestrator import Orchestrator
+
+
+logger: Logger = fastapi_logger
+
+
+class DeviceUtilizationModel(BaseModel):
+    total_kb: int = Field(0, title="Device's total size (KB)")
+    avail_kb: int = Field(0, title="Device's available size (KB)")
+    used_kb: int = Field(0, title="Device's used size (KB)")
+    utilization: float = Field(0, title="Device's utilization")
+
+
+class DeviceModel(BaseModel):
+    host: str
+    osd_id: int
+    path: str
+    rotational: bool
+    vendor: str
+    model: str
+    utilization: DeviceUtilizationModel = Field(DeviceUtilizationModel())
+
+
+class DeviceHostModel(BaseModel):
+    utilization: DeviceUtilizationModel = Field(DeviceUtilizationModel(),
+                                                title="Host's utilization")
+    devices: List[DeviceModel] = Field([], title="Host's devices")
+
+
+class Devices(Ticker):
+
+    _osds_per_host: Dict[str, List[int]] = {}
+    _osd_entries: Dict[int, DeviceModel] = {}
+
+    def __init__(self):
+        super().__init__(
+            "devices",
+            gstate.config.options.devices.probe_interval
+        )
+
+    async def _do_tick(self) -> None:
+        await self.probe()
+
+    async def _should_tick(self) -> bool:
+        nodemgr: NodeMgr = get_node_mgr()
+        return nodemgr.ready
+
+    async def probe(self) -> None:
+
+        logger.debug("probe devices")
+
+        orch: Orchestrator = Orchestrator()
+        mon: Mon = Mon()
+        device_lst: List[OrchDevicesPerHostModel] = orch.devices_ls()
+        osd_df: CephOSDDFModel = mon.osd_df()
+
+        if len(device_lst) == 0 or len(osd_df.nodes) == 0:
+            logger.debug("probe > no devices to probe")
+            return
+
+        osds_per_host: Dict[str, List[int]] = {}
+        osd_entries: Dict[int, DeviceModel] = {}
+        for hostdevs in device_lst:
+            host: str = hostdevs.name
+            devs: List[VolumeDeviceModel] = hostdevs.devices
+
+            osds: List[int] = []
+            for dev in devs:
+                if dev.available or len(dev.lvs) == 0:
+                    continue
+
+                for lv in dev.lvs:
+                    osd_entries[lv.osd_id] = DeviceModel(
+                        host=host,
+                        osd_id=lv.osd_id,
+                        path=dev.path,
+                        rotational=dev.sys_api.rotational,
+                        vendor=dev.sys_api.vendor,
+                        model=dev.sys_api.model
+                    )
+                    osds.append(lv.osd_id)
+
+            osds_per_host[host] = osds
+
+        for osd in osd_df.nodes:
+            if osd.id not in osd_entries:
+                continue
+
+            osd_entries[osd.id].utilization = DeviceUtilizationModel(
+                total_kb=osd.kb,
+                avail_kb=osd.kb_avail,
+                used_kb=osd.kb_used,
+                utilization=osd.utilization
+            )
+
+        self._osds_per_host = osds_per_host
+        self._osd_entries = osd_entries
+
+    @property
+    def devices_per_host(self) -> Dict[str, DeviceHostModel]:
+        devs_per_host: Dict[str, DeviceHostModel] = {}
+
+        for host, osdid_lst in self._osds_per_host.items():
+
+            total_kb: int = 0
+            avail_kb: int = 0
+            used_kb: int = 0
+            raw_utilization: float = 0.0
+            devices: List[DeviceModel] = []
+
+            for osdid in osdid_lst:
+                assert osdid in self._osd_entries
+                device_entry: DeviceModel = self._osd_entries[osdid]
+                total_kb += device_entry.utilization.total_kb
+                avail_kb += device_entry.utilization.avail_kb
+                used_kb += device_entry.utilization.used_kb
+                raw_utilization += device_entry.utilization.utilization
+
+                devices.append(self._osd_entries[osdid])
+
+            utilization = 0.0
+            if len(devices) > 0:
+                utilization = raw_utilization / len(devices)
+
+            host_utilization = DeviceUtilizationModel(
+                total_kb=total_kb,
+                avail_kb=avail_kb,
+                used_kb=used_kb,
+                utilization=utilization
+            )
+            host_entry = DeviceHostModel(
+                utilization=host_utilization,
+                devices=devices
+            )
+            devs_per_host[host] = host_entry
+
+        return devs_per_host
+
+
+_devices = Devices()
+
+
+def get_devices() -> Devices:
+    global _devices
+    return _devices


### PR DESCRIPTION
Provides device information, including utilization (total, avail, used KB, etc), on a per-host basis.

The device information includes device-specific information.

As an example, the output should be similar to this:

```
{
  "node01": {
    "utilization": {
      "total_kb": 33538048,
      "avail_kb": 33515012,
      "used_kb": 23036,
      "utilization": 0.06868616802027358
    },
    "devices": [
      {
        "host": "node01",
        "osd_id": 0,
        "path": "/dev/vdb",
        "rotational": true,
        "vendor": "0x1af4",
        "model": "",
        "utilization": {
          "total_kb": 8384512,
          "avail_kb": 8378720,
          "used_kb": 5792,
          "utilization": 0.06907975085490962
        }
      },
     ...
```

Signed-off-by: Joao Eduardo Luis \<joao@suse.com>