### PR TITLE
gravel: ctrl/services: expose services space usage

### DIFF
--- a/src/gravel/api/services.py
+++ b/src/gravel/api/services.py
@@ -12,7 +12,7 @@
 # GNU General Public License for more details.
 
 from logging import Logger
-from typing import List
+from typing import Dict, List
 from fastapi.logger import logger as fastapi_logger
 from fastapi.routing import APIRouter
 from fastapi import HTTPException, status
@@ -24,6 +24,7 @@ from gravel.controllers.services import (
     ServiceError,
     ServiceModel,
     ServiceRequirementsModel,
+    ServiceStorageModel,
     ServiceTypeEnum,
     Services
 )
@@ -114,3 +115,18 @@ async def create_service(req: CreateRequest) -> CreateReply:
         raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR,
                             detail=str(e))
     return CreateReply(success=True)
+
+
+@router.get(
+    "/stats",
+    name="Obtain services statistics",
+    response_model=Dict[str, ServiceStorageModel]
+)
+async def get_statistics() -> Dict[str, ServiceStorageModel]:
+    """
+    Returns a dictionary of service names to a dictionary containing the
+    allocated space for said service and how much space is being used, along
+    with the service's space utilization.
+    """
+    services = Services()
+    return services.get_stats()

--- a/src/gravel/controllers/resources/storage.py
+++ b/src/gravel/controllers/resources/storage.py
@@ -94,7 +94,7 @@ class Storage(Ticker):
     def total(self) -> int:
         return self._state.stats.total
 
-    async def usage(self) -> StorageModel:
+    def usage(self) -> StorageModel:
         return self._state
 
     async def _update(self) -> None:


### PR DESCRIPTION
Through an API endpoint at '/services/stats' we will expose a dictionary
of service names to service statistics, including allocated space and
how much space is being used by the service.

Signed-off-by: Joao Eduardo Luis \<joao@suse.com>