### PR TITLE
Introduce runtime python venv for dependencies, add Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,4 @@ tests/vagrant/deployments/
 .vagrant/
 .idea/
 conf/
-
+*.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,59 @@
+# The version needs an annotated tag in the git repo in the form vX.Y.Z.
+# If such is not present, fall back to using v0.0.0 so we get a non-empty
+# version string.
+VERSION=$(shell (git describe --match 'v*' --long 2>/dev/null || echo 'v0.0.0') | sed 's/^v//')
+
+usage:
+	@echo "Try running \`make dist\` to build a tarball"
+
+submodules:
+	git submodule update --init
+
+glass:
+	cd src/glass && npm install && npx ng build --prod --output-hashing=all
+
+dist: submodules glass
+	$(eval TMPDIR := $(shell mktemp -d))
+	$(eval TAR_BASE := $(TMPDIR)/aquarium-$(VERSION))
+	$(eval TAR_USR := $(TAR_BASE)/usr/share/aquarium)
+	$(eval TAR_UNIT := $(TAR_BASE)/usr/lib/systemd/system)
+	$(eval TAR_SBIN := $(TAR_BASE)/usr/sbin)
+	mkdir -p $(TAR_USR) $(TAR_UNIT) $(TAR_SBIN)
+	# Copy gravel, glass, aquarium.py and cephadm from src/...
+	cd src && \
+	find gravel -iname '*ceph.git*' -prune -false -o -iname '*.py' | \
+		xargs cp --parents --target-directory=$(TAR_USR) && \
+	cp --target-directory=$(TAR_USR) ./aquarium.py && \
+	cp -R --parents --target-directory=$(TAR_USR) glass/dist && \
+	cp --target-directory=$(TAR_SBIN) ./gravel/ceph.git/src/cephadm/cephadm
+	# Copy aquarium service
+	cp systemd/aquarium.service $(TAR_UNIT)
+	# Create python venv for use by aquarium at runtime.  Have to explicitly
+	# specify /usr/bin/python3 here, rather than just calling python3 with
+	# no path, otherwise if we're already in a venv when running `make dist`,
+	# /usr/share/aquarium/venv/bin/python3 will point to the existing venv
+	# python on the build host, which is completely wrong.
+	/usr/bin/python3 -m venv $(TAR_USR)/venv
+	# Install requirements (note: deliberately *not* using
+	# --system-site-packages, otherwise we might accidentally not install
+	# some of our dependencies which are already present on the build host)
+	$(TAR_USR)/venv/bin/pip install -r src/requirements.txt
+	# At this point, the shebang lines for everyting in venv/bin will be
+	# absolute paths on the build host (e.g. /tmp/tmp.QoQm2t2j06/aquarium-0.1.0-0-gc28eb76/usr/share/aquarium/venv/bin/python3)
+	# but we need them to be appropriate for the host we're *installing* on,
+	# so need to strip out the leading part of the path.  Also, even though
+	# the venv was created without --system-site-packages, we actually need
+	# to set that to true now, so that python *inside* the venv will find
+	# the python rados library which is installed as a package.
+	cd $(TAR_USR)/venv ; \
+	fixfiles=$$(find -type f -not -name *.py[cox] -exec grep -Il "#\!.*$(TAR_BASE)" {} \;) ; \
+	fixfiles="$$fixfiles bin/activate*" ; \
+	for f in $$fixfiles; do \
+		echo -n "fixing path in $$f: " ; \
+		grep $(TAR_BASE) "$$f" ; \
+		sed -i -e "s;$(TAR_BASE);;" $$f ; \
+	done ; \
+	sed -i -e "s;^include-system-site-packages.*;include-system-site-packages = true;" pyvenv.cfg
+	tar -czf aquarium-$(VERSION).tar.gz -C $(TMPDIR) aquarium-$(VERSION)
+	rm -r $(TMPDIR)
+

--- a/images/microOS/config.sh
+++ b/images/microOS/config.sh
@@ -174,7 +174,6 @@ EOF
 fi
 
 if [[ "$kiwi_profiles" == *"Ceph"* ]]; then
-  pip install fastapi uvicorn
   baseInsertService aquarium
 fi
 

--- a/images/microOS/config.xml
+++ b/images/microOS/config.xml
@@ -603,12 +603,8 @@
         <package name="lvm2"/>
         <package name="chrony"/>
         <package name="tuned"/>
-        <package name="python3-pip"/>
-        <package name="python3-aiofiles"/>
-        <package name="python3-requests"/>
         <package name="python3-rados"/>
-        <package name="python3-websockets"/>
-        <archive name="aquarium.tar"/>
+        <archive name="aquarium.tar.gz"/>
     </packages>
 
     <packages type="image" profiles="kvm-and-xen,kvm-and-xen_x86_64,kvm-and-xen_aarch64,VMware,MS-HyperV,VirtualBox,Pine64,RaspberryPi,RaspberryPi2,Vagrant_x86_64,Vagrant_aarch64">

--- a/systemd/aquarium.service
+++ b/systemd/aquarium.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 User=root
 WorkingDirectory=/usr/share/aquarium
-ExecStart=/usr/local/bin/uvicorn aquarium:app --host 0.0.0.0 --port 1337
+ExecStart=/usr/share/aquarium/venv/bin/uvicorn aquarium:app --host 0.0.0.0 --port 1337
 Restart=always
 
 [Install]

--- a/tools/setup-dev.sh
+++ b/tools/setup-dev.sh
@@ -4,6 +4,7 @@ dependencies_opensuse_tumbleweed=(
   "btrfsprogs"
   "git"
   "kpartx"
+  "make"
   "python3"
   "python3-rados"
   "python3-kiwi"
@@ -17,6 +18,7 @@ dependencies_opensuse_tumbleweed=(
 dependencies_debian=(
   "btrfs-progs"
   "git"
+  "make"
   "python3"
   "python3-pip"
   "python3-rados"
@@ -31,6 +33,7 @@ dependencies_debian=(
 dependencies_ubuntu=(
   "btrfs-progs"
   "git"
+  "make"
   "python3"
   "python3-pip"
   "python3-rados"


### PR DESCRIPTION
This is work towards being able to have an actual package (rpm, deb, ...) of Aquarium (see https://github.com/aquarist-labs/aquarium/issues/91).

I've added a Makefile with a `dist` target, so you can now run `make dist` to get a tarball named something like aquarium-0.1.0-0-gc28eb76.tar.gz, which includes a built glass and all the necessary bits of gravel.  It also includes all our python dependencies (per src/requirements.txt) in /usr/share/aquarium/venv, so we don't have to worry about not having packaged versions of these things on whatever distros we deploy on.

This doesn't change the current dev workflow at all.  You still build an image by running `./tools/build-image.sh`, but that script will in turn call `make dist` to get a tarball to install in the image.  In future (once I've got a spec file and rpm build sorted out), this can be changed so that the kiwi config uses that actual package, instead of the tarball.

That said, if you *don't* want to build an image, but would rather try a manual Aquarium install on some random Linux, you could run `make dist`, then take the tarball and extract it on the system you want to deploy on.  Might be a bit of fun ;-)

Note: the version string used in the tarball name is based on the latest annotated tag in the form 'vX.Y.Z', which means I've suddenly introduced the notion of actual version numbers and releases to the project.  Sorry.

Fixes: https://github.com/aquarist-labs/aquarium/issues/277
Signed-off-by: Tim Serong <tserong@suse.com>