### PR TITLE
gravel: keep track of events

### DIFF
--- a/src/aquarium.py
+++ b/src/aquarium.py
@@ -31,7 +31,8 @@ from gravel.api import (
     services,
     nodes,
     local,
-    devices
+    devices,
+    events
 )
 
 
@@ -66,6 +67,10 @@ api_tags_metadata = [
     {
         "name": "devices",
         "description": "Obtain and perform operations on cluster devices"
+    },
+    {
+        "name": "events",
+        "description": "Obtain list of latest events"
     }
 ]
 
@@ -107,6 +112,7 @@ api.include_router(status.router)
 api.include_router(services.router)
 api.include_router(nodes.router)
 api.include_router(devices.router)
+api.include_router(events.router)
 
 
 #

--- a/src/gravel/api/events.py
+++ b/src/gravel/api/events.py
@@ -1,0 +1,42 @@
+# project aquarium's backend
+# Copyright (C) 2021 SUSE, LLC.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+from logging import Logger
+from typing import List
+from fastapi.logger import logger as fastapi_logger
+from fastapi import (
+    APIRouter
+)
+
+from gravel.controllers.events import (
+    EventMessageModel,
+    get_events_ctrl
+)
+
+
+logger: Logger = fastapi_logger
+
+router: APIRouter = APIRouter(
+    prefix="/events",
+    tags=["events"]
+)
+
+
+@router.get(
+    "/",
+    name="Obtain latest events",
+    response_model=List[EventMessageModel]
+)
+async def get_events() -> List[EventMessageModel]:
+    events_ctrl = get_events_ctrl()
+    return events_ctrl.events

--- a/src/gravel/controllers/config.py
+++ b/src/gravel/controllers/config.py
@@ -44,6 +44,12 @@ class StatusOptionsModel(BaseModel):
     probe_interval: float = Field(1.0, title="Status Probe Interval")
 
 
+class EventsOptionsModel(BaseModel):
+    tick_interval: float = Field(30.0, title="Events Probe Interval")
+    ttl: int = Field(3600, title="Number of seconds an event is valid for")
+    queue_max: int = Field(100, title="Maximum number of events to keep")
+
+
 class OptionsModel(BaseModel):
     service_state_path: Path = Field(Path(config_dir).joinpath("storage.json"),
                                      title="Path to Service State file")
@@ -51,6 +57,7 @@ class OptionsModel(BaseModel):
     storage: StorageOptionsModel = Field(StorageOptionsModel())
     devices: DevicesOptionsModel = Field(DevicesOptionsModel())
     status: StatusOptionsModel = Field(StatusOptionsModel())
+    events: EventsOptionsModel = Field(EventsOptionsModel())
 
 
 class ConfigModel(BaseModel):

--- a/src/gravel/controllers/events.py
+++ b/src/gravel/controllers/events.py
@@ -1,0 +1,120 @@
+# project aquarium's backend
+# Copyright (C) 2021 SUSE, LLC.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+from enum import Enum
+from logging import Logger
+from typing import Dict, List, Optional
+from datetime import datetime as dt
+from fastapi.logger import logger as fastapi_logger
+from pydantic import (
+    BaseModel,
+    Field
+)
+
+from gravel.controllers.nodes.mgr import (
+    NodeMgr,
+    NodeStageEnum,
+    get_node_mgr
+)
+from gravel.controllers.gstate import (
+    gstate,
+    Ticker
+)
+
+
+logger: Logger = fastapi_logger
+
+
+class EventSeverityEnum(int, Enum):
+    NONE = 0
+    INFO = 1
+    WARN = 2
+    ERROR = 3
+
+
+class EventMessageModel(BaseModel):
+    timestamp: Optional[dt] = Field(None, title="event's timestamp")
+    severity: EventSeverityEnum = Field(EventSeverityEnum.NONE,
+                                        title="event's severity")
+    message: str = Field("", title="event's message")
+
+
+class Events(Ticker):
+
+    _events: List[EventMessageModel]
+    _events_by_msg: Dict[str, EventMessageModel]
+
+    def __init__(self):
+        super().__init__(
+            "events",
+            gstate.config.options.events.tick_interval
+        )
+        self._events = []
+        self._events_by_msg = {}
+
+    async def _do_tick(self) -> None:
+
+        def _should_drop(item: EventMessageModel) -> bool:
+            assert item.timestamp
+            now: dt = dt.now()
+            diff = now - item.timestamp
+            return diff.total_seconds() >= gstate.config.options.events.ttl
+
+        if len(self._events) == 0:
+            return
+        while True:
+            first: EventMessageModel = self._events[0]
+            if _should_drop(first):
+                self._events.pop(0)
+            else:
+                break
+
+    async def _should_tick(self) -> bool:
+        nodemgr: NodeMgr = get_node_mgr()
+        return nodemgr.stage >= NodeStageEnum.BOOTSTRAPPED
+
+    async def add(self, msg: str, severity: EventSeverityEnum) -> None:
+
+        event: Optional[EventMessageModel] = self._events_by_msg.get(msg)
+        if event:
+            self._events.remove(event)
+            event.timestamp = dt.now()
+            self._events.append(event)
+            return
+
+        if len(self._events) >= gstate.config.options.events.queue_max:
+            event = self._events.pop(0)
+            del self._events_by_msg[event.message]
+
+        event = EventMessageModel(
+            timestamp=dt.now(),
+            severity=severity,
+            message=msg
+        )
+
+        self._events.append(event)
+        self._events_by_msg[msg] = event
+
+    @property
+    def events(self) -> List[EventMessageModel]:
+        lst: List[EventMessageModel] = self._events.copy()
+        lst.reverse()
+        return lst
+
+
+_events = Events()
+
+
+def get_events_ctrl() -> Events:
+    global _events
+    return _events

--- a/src/gravel/controllers/resources/status.py
+++ b/src/gravel/controllers/resources/status.py
@@ -83,7 +83,7 @@ class Status(Ticker):
             gstate.config.options.status.probe_interval
         )
         self._mon = None
-        self._latest = None
+        self._latest_cluster = None
         self._latest_pools_stats = {}
 
     async def _do_tick(self) -> None:


### PR DESCRIPTION
This is mostly meant for feedback gathering -- I'm not particularly enthused with it.

It's essentially a very dumb queue of items, added by other parts of the backend, which are supposed to be events.

Although we are doing a very, _very_ basic form of collision detection, we're not being smarter than that. Additionally, we're not providing context, we're not tracking how often a given event has been raised, and we're definitely not ordering them by severity when listing them.

It also seems a bit heavy, and is making my VMs a bit too slow. Might be the list reversal, or it might be that too much is happening in 1 second bursts -- and these are pretty light VMs.

Does anyone has thoughts on what this should look like?


Signed-off-by: Joao Eduardo Luis \<joao@suse.com>