### PR TITLE
gravel/glass: add option to configure ntp at initial deployment

### DIFF
--- a/src/glass/src/app/app-routing.module.ts
+++ b/src/glass/src/app/app-routing.module.ts
@@ -1,3 +1,17 @@
+/*
+ * Project Aquarium's frontend (glass)
+ * Copyright (C) 2021 SUSE, LLC.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 
@@ -7,6 +21,7 @@ import { MainLayoutComponent } from '~/app/core/layouts/main-layout/main-layout.
 import { BootstrapPageComponent } from '~/app/pages/bootstrap-page/bootstrap-page.component';
 import { DashboardPageComponent } from '~/app/pages/dashboard-page/dashboard-page.component';
 import { DeploymentPageComponent } from '~/app/pages/deployment-page/deployment-page.component';
+import { InstallConfigPageComponent } from '~/app/pages/install-config-page/install-config-page.component';
 import { InstallModePageComponent } from '~/app/pages/install-mode-page/install-mode-page.component';
 import { NotFoundPageComponent } from '~/app/pages/not-found-page/not-found-page.component';
 import { RegisterPageComponent } from '~/app/pages/register-page/register-page.component';
@@ -36,6 +51,7 @@ const routes: Routes = [
       {
         path: 'create',
         children: [
+          { path: 'config', component: InstallConfigPageComponent },
           { path: 'bootstrap', component: BootstrapPageComponent },
           { path: 'deployment', component: DeploymentPageComponent }
         ]

--- a/src/glass/src/app/material.modules.ts
+++ b/src/glass/src/app/material.modules.ts
@@ -1,7 +1,22 @@
+/*
+ * Project Aquarium's frontend (glass)
+ * Copyright (C) 2021 SUSE, LLC.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
 import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
+import { MatRippleModule } from '@angular/material/core';
 import { MatDialogModule } from '@angular/material/dialog';
 import { MatExpansionModule } from '@angular/material/expansion';
 import { MatFormFieldModule } from '@angular/material/form-field';
@@ -11,6 +26,7 @@ import { MatListModule } from '@angular/material/list';
 import { MatMenuModule } from '@angular/material/menu';
 import { MatPaginatorModule } from '@angular/material/paginator';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { MatRadioModule } from '@angular/material/radio';
 import { MatSidenavModule } from '@angular/material/sidenav';
 import { MatSliderModule } from '@angular/material/slider';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
@@ -42,7 +58,9 @@ import { DomSanitizer } from '@angular/platform-browser';
     ReactiveFormsModule,
     MatListModule,
     MatSortModule,
-    MatPaginatorModule
+    MatPaginatorModule,
+    MatRadioModule,
+    MatRippleModule
   ]
 })
 export class MaterialModule {

--- a/src/glass/src/app/pages/bootstrap-page/bootstrap-page.component.html
+++ b/src/glass/src/app/pages/bootstrap-page/bootstrap-page.component.html
@@ -20,7 +20,7 @@
       <mat-card-actions>
         <button mat-icon-button
                 matTooltip="Back"
-                routerLink="/installer/install-mode">
+                routerLink="/installer/create/config">
           <mat-icon svgIcon="mdi:arrow-left"></mat-icon>
         </button>
         <button mat-button

--- a/src/glass/src/app/pages/install-config-page/install-config-page.component.html
+++ b/src/glass/src/app/pages/install-config-page/install-config-page.component.html
@@ -1,0 +1,97 @@
+<div class="glass-install-config-page"
+     fxLayout="column"
+     fxLayoutAlign="center center">
+  <mat-card>
+    <mat-card-header>
+      <mat-card-title>
+        <span translate>NTP Configuration</span>
+      </mat-card-title>
+    </mat-card-header>
+    <mat-card-content>
+      <div fxLayout="column"
+           fxLayoutGap="10px">
+        <span translate>
+          Your Aquarium environment needs to have the time synchronized with a reliable
+          time source. You do have two options in order to configure the time synchronization:
+        </span>
+        <div fxLayout="row"
+             fxLayoutGap="5px">
+          <mat-card mat-ripple
+                    (click)="selectionChange(false)"
+                    [ngClass]="{ 'selected': !useDefault }"
+                    [matRippleCentered]="true">
+            <mat-card-header>
+              <div mat-card-avatar>
+                <mat-radio-button [checked]="!useDefault"
+                                  (click)="selectionChange(false)"></mat-radio-button>
+              </div>
+              <mat-card-title>
+                <span translate>Use your own NTP host</span>
+              </mat-card-title>
+            </mat-card-header>
+            <mat-card-content class="glass-card-last-child"
+                              fxLayout="column"
+                              fxLayoutGap="10px">
+              <span translate>
+                If you do have your own NTP host configured on the network, please add it below.
+              </span>
+              <form [formGroup]="formGroup"
+                    novalidate>
+                <mat-form-field color="accent"
+                                fxFlex>
+                  <mat-label translate>NTP host IP/FQDN</mat-label>
+                  <input matInput
+                         type="text"
+                         formControlName="ntpAddress"
+                         required>
+                  <mat-hint translate>The IP address or FQDN of the NTP host.</mat-hint>
+                  <mat-error *ngIf="formGroup.invalid">
+                    <span *ngIf="formGroup.hasError('required', 'ntpAddress')"
+                          translate>
+                      This field is required.
+                    </span>
+                    <span *ngIf="formGroup.hasError('hostAddress', 'ntpAddress')"
+                          translate>
+                      This field must be an IP address or FQDN (&lt;address&gt;:&lt;port&gt;).
+                    </span>
+                  </mat-error>
+                </mat-form-field>
+              </form>
+            </mat-card-content>
+          </mat-card>
+          <mat-card mat-ripple
+                    (click)="selectionChange(true)"
+                    [ngClass]="{ 'selected': useDefault }"
+                    [matRippleCentered]="true">
+            <mat-card-header>
+              <div mat-card-avatar>
+                <mat-radio-button [checked]="useDefault"
+                                  (click)="selectionChange(true)"></mat-radio-button>
+              </div>
+              <mat-card-title>
+                <span translate>Use an NTP host on the internet</span>
+              </mat-card-title>
+            </mat-card-header>
+            <mat-card-content class="glass-card-last-child">
+              If you don't have your own NTP host configured, you can use an NTP server pool
+              ({{ ntpDefault }}) on the internet.
+              <br><b>Please note:</b> this option requires access to the internet.
+            </mat-card-content>
+          </mat-card>
+        </div>
+      </div>
+    </mat-card-content>
+    <mat-card-actions>
+      <button mat-icon-button
+              matTooltip="{{ 'Back' | translate }}"
+              routerLink="/installer/install-mode">
+        <mat-icon svgIcon="mdi:arrow-left"></mat-icon>
+      </button>
+      <button mat-button
+              (click)="next()">
+        <span translate>Next</span>
+      </button>
+    </mat-card-actions>
+  </mat-card>
+</div>
+

--- a/src/glass/src/app/pages/install-config-page/install-config-page.component.scss
+++ b/src/glass/src/app/pages/install-config-page/install-config-page.component.scss
@@ -1,0 +1,59 @@
+@import 'styles.scss';
+
+.glass-install-config-page {
+  height: 100%;
+  background-color: $glass-color-primary;
+  background-image: url('./../../../assets/images/jeremy-bishop-1braZySlEKA-unsplash.jpg');
+  background-blend-mode: multiply;
+  background-size: cover;
+  background-repeat: no-repeat;
+  background-position: center center;
+
+  ::ng-deep .mat-card {
+    width: 50%;
+    @extend .glass-color-theme-white;
+
+    ::ng-deep .mat-card-header > .mat-card-header-text {
+      margin-left: unset;
+    }
+
+    .mat-card.selected {
+      border: 1px solid $glass-color-accent;
+      color: $glass-color-white;
+      background-color: rgba($glass-color-accent, 0.1);
+
+      .mat-form-field .mat-form-field-wrapper {
+        .mat-form-field-infix .mat-form-field-label,
+        .mat-hint {
+          color: $glass-color-white;
+        }
+        .mat-form-field-underline {
+          background-color: $glass-color-white;
+        }
+      }
+    }
+
+    .mat-card {
+      border: 1px solid transparent;
+      color: $eos-bc-gray-300;
+
+      .glass-card-last-child {
+        margin-bottom: 0;
+      }
+
+      .mat-form-field .mat-form-field-wrapper {
+        .mat-form-field-infix .mat-form-field-label,
+        .mat-hint {
+          color: $eos-bc-gray-300;
+        }
+        .mat-form-field-underline {
+          background-color: $eos-bc-gray-300;
+        }
+      }
+    }
+
+    .mat-button {
+      @extend .glass-color-theme-primary;
+    }
+  }
+}

--- a/src/glass/src/app/pages/install-config-page/install-config-page.component.spec.ts
+++ b/src/glass/src/app/pages/install-config-page/install-config-page.component.spec.ts
@@ -1,0 +1,36 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { RouterTestingModule } from '@angular/router/testing';
+import { TranslateModule } from '@ngx-translate/core';
+
+import { PagesModule } from '~/app/pages/pages.module';
+
+import { InstallConfigPageComponent } from './install-config-page.component';
+
+describe('InstallConfigPageComponent', () => {
+  let component: InstallConfigPageComponent;
+  let fixture: ComponentFixture<InstallConfigPageComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        HttpClientTestingModule,
+        PagesModule,
+        NoopAnimationsModule,
+        RouterTestingModule,
+        TranslateModule.forRoot()
+      ]
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(InstallConfigPageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/glass/src/app/pages/install-config-page/install-config-page.component.ts
+++ b/src/glass/src/app/pages/install-config-page/install-config-page.component.ts
@@ -1,0 +1,76 @@
+/*
+ * Project Aquarium's frontend (glass)
+ * Copyright (C) 2021 SUSE, LLC.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+import { Component, OnInit } from '@angular/core';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { Router } from '@angular/router';
+
+import { GlassValidators } from '~/app/shared/forms/validators';
+import { OrchService } from '~/app/shared/services/api/orch.service';
+import { NotificationService } from '~/app/shared/services/notification.service';
+
+@Component({
+  selector: 'glass-install-config-page',
+  templateUrl: './install-config-page.component.html',
+  styleUrls: ['./install-config-page.component.scss']
+})
+export class InstallConfigPageComponent implements OnInit {
+  public formGroup: FormGroup;
+
+  ntpDefault = 'pool.ntp.org';
+  useDefault = false;
+
+  constructor(
+    private formBuilder: FormBuilder,
+    private router: Router,
+    private orchService: OrchService,
+    private notificationService: NotificationService
+  ) {
+    this.formGroup = this.formBuilder.group({
+      ntpAddress: [null, [Validators.required, GlassValidators.hostAddress()]]
+    });
+  }
+
+  ngOnInit(): void {}
+
+  selectionChange(selection: boolean): void {
+    if (selection) {
+      this.formGroup.reset();
+    }
+    this.useDefault = selection;
+  }
+
+  next(): void {
+    let ntp = '';
+    if (this.useDefault) {
+      ntp = this.ntpDefault;
+    } else {
+      if (this.formGroup.pristine || this.formGroup.invalid) {
+        return;
+      }
+      ntp = this.formGroup.value.ntpAddress;
+    }
+
+    this.orchService.setNtp(ntp).subscribe(
+      () => {
+        this.router.navigate(['/installer/create/bootstrap']);
+      },
+      (err) => {
+        this.notificationService.show(err.message, {
+          type: 'error'
+        });
+      }
+    );
+  }
+}

--- a/src/glass/src/app/pages/install-mode-page/install-mode-page.component.html
+++ b/src/glass/src/app/pages/install-mode-page/install-mode-page.component.html
@@ -11,7 +11,7 @@
         <div fxFlex="50"
              fxLayout="column">
           <button mat-button
-                  routerLink="/installer/create/bootstrap">
+                  routerLink="/installer/create/config">
             <mat-icon svgIcon="mdi:plus"></mat-icon>
             <span translate>Create new cluster</span>
           </button>

--- a/src/glass/src/app/pages/pages.module.ts
+++ b/src/glass/src/app/pages/pages.module.ts
@@ -9,6 +9,7 @@ import { MaterialModule } from '~/app/material.modules';
 import { BootstrapPageComponent } from '~/app/pages/bootstrap-page/bootstrap-page.component';
 import { DashboardPageComponent } from '~/app/pages/dashboard-page/dashboard-page.component';
 import { DeploymentPageComponent } from '~/app/pages/deployment-page/deployment-page.component';
+import { InstallConfigPageComponent } from '~/app/pages/install-config-page/install-config-page.component';
 import { InstallModePageComponent } from '~/app/pages/install-mode-page/install-mode-page.component';
 import { NotFoundPageComponent } from '~/app/pages/not-found-page/not-found-page.component';
 import { RegisterPageComponent } from '~/app/pages/register-page/register-page.component';
@@ -25,7 +26,8 @@ import { SharedModule } from '~/app/shared/shared.module';
     WelcomePageComponent,
     NotFoundPageComponent,
     RegisterPageComponent,
-    ServicesPageComponent
+    ServicesPageComponent,
+    InstallConfigPageComponent
   ],
   imports: [
     CommonModule,

--- a/src/glass/src/app/shared/services/api/orch.service.spec.ts
+++ b/src/glass/src/app/shared/services/api/orch.service.spec.ts
@@ -42,4 +42,10 @@ describe('OrchService', () => {
     const req = httpTesting.expectOne('api/orch/devices/all_assimilated');
     expect(req.request.method).toBe('GET');
   });
+
+  it('should call setNtp', () => {
+    service.setNtp('test.test.test').subscribe();
+    const req = httpTesting.expectOne('api/orch/ntp');
+    expect(req.request.method).toBe('PUT');
+  });
 });

--- a/src/glass/src/app/shared/services/api/orch.service.ts
+++ b/src/glass/src/app/shared/services/api/orch.service.ts
@@ -1,3 +1,17 @@
+/*
+ * Project Aquarium's frontend (glass)
+ * Copyright (C) 2021 SUSE, LLC.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
 /* eslint-disable @typescript-eslint/naming-convention */
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
@@ -23,6 +37,10 @@ export type HostDevices = {
   address: string;
   hostname: string;
   devices: Device[];
+};
+
+export type SetNtpRequest = {
+  addr: string;
 };
 
 @Injectable({
@@ -59,5 +77,15 @@ export class OrchService {
    */
   assimilateStatus(): Observable<boolean> {
     return this.http.get<boolean>(`${this.url}/devices/all_assimilated`);
+  }
+
+  /**
+   * Set NTP
+   */
+  setNtp(_addr: string): Observable<boolean> {
+    const request: SetNtpRequest = {
+      addr: _addr
+    };
+    return this.http.put<boolean>(`${this.url}/ntp`, request);
   }
 }

--- a/src/glass/src/defaults.scss
+++ b/src/glass/src/defaults.scss
@@ -8,6 +8,7 @@ $eos-bc-pine-500: #0c322c;
 $eos-bc-green-500: #30ba78;
 $eos-bc-yellow-500: #ffc107;
 $eos-bc-gray-50: #f2f2f2;
+$eos-bc-gray-300: #b6b4b4;
 $eos-bc-cerulean-900: #008acf;
 
 $eos-green-palette: (

--- a/src/gravel/api/orch.py
+++ b/src/gravel/api/orch.py
@@ -19,6 +19,7 @@ from pydantic import BaseModel
 from typing import Dict, List
 from gravel.controllers.orch.models import OrchDevicesPerHostModel
 
+from gravel.controllers.orch.ntp import set_address
 from gravel.controllers.orch.orchestrator \
     import Orchestrator
 
@@ -51,6 +52,10 @@ class HostsDevicesModel(BaseModel):
     address: str
     hostname: str
     devices: List[DeviceModel]
+
+
+class SetNtpRequest(BaseModel):
+    addr: str
 
 
 @router.get("/hosts", response_model=List[HostModel])
@@ -123,6 +128,15 @@ async def get_pubkey() -> str:
     try:
         orch = Orchestrator()
         return orch.get_public_key()
+    except Exception as e:
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                            detail=str(e))
+
+
+@router.put("/ntp", response_model=bool)
+async def set_ntp(req: SetNtpRequest) -> bool:
+    try:
+        return set_address(req.addr)
     except Exception as e:
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                             detail=str(e))

--- a/src/gravel/controllers/orch/ntp.py
+++ b/src/gravel/controllers/orch/ntp.py
@@ -1,0 +1,40 @@
+# project aquarium's backend
+# Copyright (C) 2021 SUSE, LLC.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+import os
+import subprocess
+from pathlib import Path
+
+
+def set_address(addr: str) -> bool:
+    file_path = "/etc/chrony.d"
+    config_file = "aquarium.conf"
+    Path(file_path).mkdir(parents=True, exist_ok=True)
+
+    for f in os.listdir(file_path):
+        os.remove(os.path.join(file_path, f))
+
+    ntp_server = "server {} iburst\n".format(addr)
+    with open(os.path.join(file_path, config_file), "w") as f:
+        f.write(ntp_server)
+
+    restart_cmd = ["systemctl", "restart", "chronyd.service"]
+    try:
+        subprocess.check_output(restart_cmd, stderr=subprocess.PIPE)
+    except subprocess.CalledProcessError as e:
+        raise ChronyRestartError("Unable to restart chronyd.service") from e
+    return True
+
+
+class ChronyRestartError(Exception):
+    pass


### PR DESCRIPTION
- **gravel: add PUT-method to set NTP**: Add a PUT-method to the orch endpoint in order to set the NTP server for a node.
- **glass: add option to configure NTP on initial node**

![Screenshot_2021-03-26_14-16-41](https://user-images.githubusercontent.com/8761082/112637619-a3134e00-8e3e-11eb-8dea-24b7bef8f053.png)
![Screenshot_2021-03-26_14-16-53](https://user-images.githubusercontent.com/8761082/112637401-69424780-8e3e-11eb-96f1-666ec9a435ee.png)

Signed-off-by: Tatjana Dehler <tdehler@suse.com>