### PR TITLE
glass: Fix CPU load chart in sys info widget

### DIFF
--- a/src/glass/src/app/core/dashboard/widgets/sys-info-dashboard-widget/sys-info-dashboard-widget.component.html
+++ b/src/glass/src/app/core/dashboard/widgets/sys-info-dashboard-widget/sys-info-dashboard-widget.component.html
@@ -50,18 +50,22 @@
           </ngx-charts-advanced-pie-chart>
         </div>
       </div>
-      <div class="glass-sys-info-dashboard-widget-cell"
-           fxFlex="none"
-           fxLayoutAlign="none"
+      <div class="glass-sys-info-dashboard-widget-cell cpu-load"
+           fxFlex="100"
            fxLayout="column">
         <div class="glass-text-bold"
              translate>CPU Load</div>
-        <div fxFlex>
-          <ngx-charts-number-card [scheme]="cpuLoadColorScheme"
-                                  [results]="cpuLoadChartData"
-                                  [view]="[500,150]"
-                                  [animations]="false">
-          </ngx-charts-number-card>
+        <div fxFlex
+             fxLayoutGap="8px"
+             fxLayout="row">
+          <mat-card *ngFor="let item of cpuLoadChartData; index as i"
+                    [ngStyle]="{'backgroundColor': cpuLoadColorScheme.domain[i] }"
+                    fxFlex>
+            <mat-card-content>
+              <div class="value">{{ item.value }}</div>
+              <div>{{ item.name }}</div>
+            </mat-card-content>
+          </mat-card>
         </div>
       </div>
     </div>

--- a/src/glass/src/app/core/dashboard/widgets/sys-info-dashboard-widget/sys-info-dashboard-widget.component.scss
+++ b/src/glass/src/app/core/dashboard/widgets/sys-info-dashboard-widget/sys-info-dashboard-widget.component.scss
@@ -1,5 +1,7 @@
 @import 'styles.scss';
 
+$mat-typography-config: mat-typography-config();
+
 .glass-sys-info-dashboard-widget {
   padding-left: 24px;
   padding-right: 24px;
@@ -7,6 +9,16 @@
 
   .glass-sys-info-dashboard-widget-cell {
     margin-bottom: 8px;
+
+    &.cpu-load {
+      .mat-card {
+        padding: 8px;
+
+        .value {
+          font-size: mat-font-size($mat-typography-config, subheading-2);
+        }
+      }
+    }
   }
 }
 .glass-sys-info-dashboard-widget.error {

--- a/src/glass/src/app/core/dashboard/widgets/sys-info-dashboard-widget/sys-info-dashboard-widget.component.ts
+++ b/src/glass/src/app/core/dashboard/widgets/sys-info-dashboard-widget/sys-info-dashboard-widget.component.ts
@@ -72,9 +72,9 @@ export class SysInfoDashboardWidgetComponent {
         const load_5min = Math.floor(inventory.cpu.load.five_min * 100);
         const load_15min = Math.floor(inventory.cpu.load.fifteen_min * 100);
         this.cpuLoadChartData = [
-          { name: translate(TEXT('1min')), value: `${load_1min}%` },
-          { name: translate(TEXT('5min')), value: `${load_5min}%` },
-          { name: translate(TEXT('15min')), value: `${load_15min}%` }
+          { name: translate(TEXT('1 min')), value: `${load_1min}%` },
+          { name: translate(TEXT('5 min')), value: `${load_5min}%` },
+          { name: translate(TEXT('15 min')), value: `${load_15min}%` }
         ];
         // Modify the uptime value to allow the `relativeDate` pipe
         // to calculate the correct time to display.


### PR DESCRIPTION
Before:
![Bildschirmfoto vom 2021-03-26 15-50-22](https://user-images.githubusercontent.com/1897962/112650477-b678e600-8e4b-11eb-94db-d61ba4091079.png)

After:
![Bildschirmfoto vom 2021-03-26 15-53-53](https://user-images.githubusercontent.com/1897962/112650507-bd075d80-8e4b-11eb-8a5b-ac4aa9339e4c.png)

Signed-off-by: Volker Theile <vtheile@suse.com>