### PR TITLE
gravel: ctrl/status: fix typo on variable name

### DIFF
--- a/src/gravel/controllers/resources/status.py
+++ b/src/gravel/controllers/resources/status.py
@@ -83,7 +83,7 @@ class Status(Ticker):
             gstate.config.options.status.probe_interval
         )
         self._mon = None
-        self._latest = None
+        self._latest_cluster = None
         self._latest_pools_stats = {}
 
     async def _do_tick(self) -> None:


### PR DESCRIPTION
Signed-off-by: Joao Eduardo Luis \<joao@suse.com>