### PR TITLE
gravel: make default pool size one

### DIFF
--- a/src/gravel/controllers/nodes/mgr.py
+++ b/src/gravel/controllers/nodes/mgr.py
@@ -407,6 +407,12 @@ class NodeMgr:
             logger.error("unable to disable redundancy warning")
             logger.debug(str(e))
 
+        try:
+            mon.set_default_pool_size_one()
+        except CephCommandError as e:
+            logger.error("unable to set default pool size 1")
+            logger.exception(e)
+
     @property
     def bootstrapper_stage(self) -> BootstrapStage:
         if not self._bootstrapper:

--- a/src/gravel/controllers/orch/ceph.py
+++ b/src/gravel/controllers/orch/ceph.py
@@ -242,3 +242,12 @@ class Mon(Ceph):
         }
         results: Dict[str, Any] = self.call(cmd)
         return parse_obj_as(List[CephOSDPoolStatsModel], results)
+
+    def set_default_pool_size_one(self) -> None:
+        cmd: Dict[str, str] = {
+            "prefix": "config set",
+            "who": "global",
+            "name": "osd_pool_default_size",
+            "value": "1"
+        }
+        self.call(cmd)


### PR DESCRIPTION
This is mostly meant to workaround #103, but opens all kinds of
questions. Without it though, nfs cluster creation will hang because the
'nfs-ganesha' pool will be unavailable on a single-node.

Signed-off-by: Joao Eduardo Luis \<joao@suse.com>