### PR TITLE
gravel: adjust crush rulesets depending on number of nodes

### DIFF
--- a/src/gravel/controllers/nodes/mgr.py
+++ b/src/gravel/controllers/nodes/mgr.py
@@ -407,6 +407,10 @@ class NodeMgr:
             logger.error("unable to disable redundancy warning")
             logger.debug(str(e))
 
+        res: bool = mon.set_default_ruleset()
+        if not res:
+            logger.error("unable to set default ruleset")
+
     @property
     def bootstrapper_stage(self) -> BootstrapStage:
         if not self._bootstrapper:

--- a/src/gravel/controllers/nodes/mgr.py
+++ b/src/gravel/controllers/nodes/mgr.py
@@ -695,6 +695,13 @@ class NodeMgr:
         if not orch.host_add(node.hostname, node.address):
             logger.error("handle ready > failed adding host to orch")
 
+        # reset default crush ruleset, and adjust pools to use a multi-node
+        # ruleset, spreading replicas across hosts rather than osds.
+        mon = Mon()
+        if not mon.set_replicated_ruleset():
+            logger.error(
+                "handle ready to add > unable to set replicated ruleset")
+
 
 _nodemgr: Optional[NodeMgr] = None
 

--- a/src/gravel/controllers/orch/models.py
+++ b/src/gravel/controllers/orch/models.py
@@ -147,6 +147,7 @@ class CephOSDPoolEntryModel(BaseModel):
     pool_name: str
     size: int
     min_size: int
+    crush_rule: int
 
 
 class CephOSDMapModel(BaseModel):


### PR DESCRIPTION
When we create a single-node deployment, we should enable the user to have a healthy system out of the box; with that in mind, we must ensure that our replicas are properly replicated across OSDs, instead of the default, hosts.

With this patchset we first ensure that we create a single-node ruleset, and set it as the default for new pools upon bootstrap and before we start creating pools; then we ensure that we reset the default to `replicated_rule` upon join of a new node, as well as adjusting the existing pools' rulesets.

Resolves #103 

Signed-off-by: Joao Eduardo Luis \<joao@suse.com>