### PR TITLE
gravel: tox: have flake8 ignoring cephadm.bin

### DIFF
--- a/src/tox.ini
+++ b/src/tox.ini
@@ -31,7 +31,8 @@ exclude =
     *.pyc,
     templates,
     .eggs,
-    ceph.git
+    ceph.git,
+    cephadm.bin
 
 [autopep8]
 addopts =


### PR DESCRIPTION
Signed-off-by: Joao Eduardo Luis \<joao@suse.com>