### PR TITLE
gravel: ctrl/svc: ignore missing pool on stats

### DIFF
--- a/src/gravel/controllers/services.py
+++ b/src/gravel/controllers/services.py
@@ -182,7 +182,11 @@ class Services:
             used_bytes: int = 0
 
             for poolid in svc.pools:
-                assert poolid in storage_pools
+                if poolid not in storage_pools:
+                    # given storage pools are updated periodically, we may not
+                    # have up-to-date statistics yet; and that means we might be
+                    # missing a pool. Jump over said pool if so.
+                    continue
                 stats = storage_pools[poolid].stats
                 used_bytes += stats.used
 


### PR DESCRIPTION
Given we obtain storage statistics periodically, it may happen that we
are trying to obtain statistics from a recently created service for
which pools we don't yet have statistics. In that case, skip the pool.

Resolves #346 

Signed-off-by: Joao Eduardo Luis \<joao@suse.com>