### PR TITLE
glass: Add consumed storage by service dashboard widget

### DIFF
--- a/src/glass/src/app/core/dashboard/dashboard.module.ts
+++ b/src/glass/src/app/core/dashboard/dashboard.module.ts
@@ -3,11 +3,13 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FlexLayoutModule } from '@angular/flex-layout';
 import { RouterModule } from '@angular/router';
+import { TranslateModule } from '@ngx-translate/core';
 import { NgxChartsModule } from '@swimlane/ngx-charts';
 
 import { CapacityDashboardWidgetComponent } from '~/app/core/dashboard/widgets/capacity-dashboard-widget/capacity-dashboard-widget.component';
 import { HealthDashboardWidgetComponent } from '~/app/core/dashboard/widgets/health-dashboard-widget/health-dashboard-widget.component';
 import { HostsDashboardWidgetComponent } from '~/app/core/dashboard/widgets/hosts-dashboard-widget/hosts-dashboard-widget.component';
+import { ServicesCapacityDashboardWidgetComponent } from '~/app/core/dashboard/widgets/services-capacity-dashboard-widget/services-capacity-dashboard-widget.component';
 import { ServicesDashboardWidgetComponent } from '~/app/core/dashboard/widgets/services-dashboard-widget/services-dashboard-widget.component';
 import { SysInfoDashboardWidgetComponent } from '~/app/core/dashboard/widgets/sys-info-dashboard-widget/sys-info-dashboard-widget.component';
 import { VolumesDashboardWidgetComponent } from '~/app/core/dashboard/widgets/volumes-dashboard-widget/volumes-dashboard-widget.component';
@@ -21,7 +23,8 @@ import { SharedModule } from '~/app/shared/shared.module';
     HealthDashboardWidgetComponent,
     ServicesDashboardWidgetComponent,
     SysInfoDashboardWidgetComponent,
-    HostsDashboardWidgetComponent
+    HostsDashboardWidgetComponent,
+    ServicesCapacityDashboardWidgetComponent
   ],
   exports: [
     CapacityDashboardWidgetComponent,
@@ -29,7 +32,8 @@ import { SharedModule } from '~/app/shared/shared.module';
     HealthDashboardWidgetComponent,
     ServicesDashboardWidgetComponent,
     SysInfoDashboardWidgetComponent,
-    HostsDashboardWidgetComponent
+    HostsDashboardWidgetComponent,
+    ServicesCapacityDashboardWidgetComponent
   ],
   imports: [
     CommonModule,
@@ -37,7 +41,8 @@ import { SharedModule } from '~/app/shared/shared.module';
     MaterialModule,
     NgxChartsModule,
     SharedModule,
-    RouterModule
+    RouterModule,
+    TranslateModule.forChild()
   ]
 })
 export class DashboardModule {}

--- a/src/glass/src/app/core/dashboard/widgets/capacity-dashboard-widget/capacity-dashboard-widget.component.html
+++ b/src/glass/src/app/core/dashboard/widgets/capacity-dashboard-widget/capacity-dashboard-widget.component.html
@@ -1,5 +1,5 @@
 <glass-widget [loadData]="loadData.bind(this)"
-              title="Capacity"
+              title="{{ 'Capacity' | translate }}"
               (loadDataEvent)="updateChartData($event)">
   <div class="glass-capacity-dashboard-widget"
        fxLayout="row"

--- a/src/glass/src/app/core/dashboard/widgets/capacity-dashboard-widget/capacity-dashboard-widget.component.ts
+++ b/src/glass/src/app/core/dashboard/widgets/capacity-dashboard-widget/capacity-dashboard-widget.component.ts
@@ -19,7 +19,7 @@ export class CapacityDashboardWidgetComponent {
     domain: ['#30ba78', '#e0dfdf']
   };
 
-  constructor(public service: ServicesService, private bytesToSizePipe: BytesToSizePipe) {}
+  constructor(private service: ServicesService, private bytesToSizePipe: BytesToSizePipe) {}
 
   updateChartData($data: Reservations) {
     this.chartData = [

--- a/src/glass/src/app/core/dashboard/widgets/services-capacity-dashboard-widget/services-capacity-dashboard-widget.component.html
+++ b/src/glass/src/app/core/dashboard/widgets/services-capacity-dashboard-widget/services-capacity-dashboard-widget.component.html
@@ -1,0 +1,17 @@
+<glass-widget [loadData]="loadData.bind(this)"
+              title="{{ 'Services Capacity - Top 5' | translate }}"
+              (loadDataEvent)="updateChartData($event)">
+  <div class="glass-services-capacity-dashboard-widget"
+       fxLayout="row"
+       fxLayoutAlign="start start">
+    <ngx-charts-bar-horizontal [scheme]="colorScheme"
+                               [results]="chartData"
+                               [animations]="false"
+                               [legend]="true"
+                               [showDataLabel]="true"
+                               [dataLabelFormatting]="dataLabelFormatting.bind(this)"
+                               [roundEdges]="false"
+                               [tooltipDisabled]="true">
+    </ngx-charts-bar-horizontal>
+  </div>
+</glass-widget>

--- a/src/glass/src/app/core/dashboard/widgets/services-capacity-dashboard-widget/services-capacity-dashboard-widget.component.scss
+++ b/src/glass/src/app/core/dashboard/widgets/services-capacity-dashboard-widget/services-capacity-dashboard-widget.component.scss
@@ -1,0 +1,9 @@
+@import 'styles.scss';
+
+.glass-services-capacity-dashboard-widget {
+  max-height: 200px;
+}
+.glass-services-capacity-dashboard-widget.error {
+  @extend .glass-color-theme-error;
+  height: 50px;
+}

--- a/src/glass/src/app/core/dashboard/widgets/services-capacity-dashboard-widget/services-capacity-dashboard-widget.component.spec.ts
+++ b/src/glass/src/app/core/dashboard/widgets/services-capacity-dashboard-widget/services-capacity-dashboard-widget.component.spec.ts
@@ -1,0 +1,34 @@
+/* eslint-disable max-len */
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { TranslateModule } from '@ngx-translate/core';
+
+import { DashboardModule } from '~/app/core/dashboard/dashboard.module';
+import { ServicesCapacityDashboardWidgetComponent } from '~/app/core/dashboard/widgets/services-capacity-dashboard-widget/services-capacity-dashboard-widget.component';
+
+describe('ServicesCapacityDashboardWidgetComponent', () => {
+  let component: ServicesCapacityDashboardWidgetComponent;
+  let fixture: ComponentFixture<ServicesCapacityDashboardWidgetComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        BrowserAnimationsModule,
+        DashboardModule,
+        HttpClientTestingModule,
+        TranslateModule.forRoot()
+      ]
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ServicesCapacityDashboardWidgetComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/glass/src/app/core/dashboard/widgets/services-capacity-dashboard-widget/services-capacity-dashboard-widget.component.ts
+++ b/src/glass/src/app/core/dashboard/widgets/services-capacity-dashboard-widget/services-capacity-dashboard-widget.component.ts
@@ -1,0 +1,47 @@
+import { Component } from '@angular/core';
+import * as _ from 'lodash';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+import { ServicesService, ServiceStorage } from '~/app/shared/services/api/services.service';
+
+@Component({
+  selector: 'glass-services-capacity-dashboard-widget',
+  templateUrl: './services-capacity-dashboard-widget.component.html',
+  styleUrls: ['./services-capacity-dashboard-widget.component.scss']
+})
+export class ServicesCapacityDashboardWidgetComponent {
+  chartData: any[] = [];
+  colorScheme = {
+    domain: ['#00739c', '#fa9334', '#b54236', '#1c445c', '#00aab4']
+  };
+
+  constructor(private servicesService: ServicesService) {}
+
+  loadData(): Observable<Array<ServiceStorage>> {
+    return this.servicesService.stats().pipe(
+      map((data: Record<string, ServiceStorage>): ServiceStorage[] => {
+        const result: ServiceStorage[] = [];
+        _.forEach(data, (serviceStorage: ServiceStorage) => {
+          result.push(serviceStorage);
+        });
+        _.orderBy(result, ['utilization'], ['desc']);
+        return _.take(result, 5);
+      })
+    );
+  }
+
+  updateChartData($data: ServiceStorage[]) {
+    this.chartData = [];
+    _.forEach($data, (serviceStorage: ServiceStorage) => {
+      this.chartData.push({
+        name: serviceStorage.name,
+        value: serviceStorage.utilization
+      });
+    });
+  }
+
+  dataLabelFormatting(label: number): string {
+    return `${(label * 100).toFixed(2)}%`;
+  }
+}

--- a/src/glass/src/app/pages/dashboard-page/dashboard-page.component.html
+++ b/src/glass/src/app/pages/dashboard-page/dashboard-page.component.html
@@ -31,6 +31,9 @@
         <ng-template [ngSwitchCase]="'hosts'">
           <glass-hosts-dashboard-widget></glass-hosts-dashboard-widget>
         </ng-template>
+        <ng-template [ngSwitchCase]="'services-capacity'">
+          <glass-services-capacity-dashboard-widget></glass-services-capacity-dashboard-widget>
+        </ng-template>
       </ng-container>
     </div>
   </div>

--- a/src/glass/src/app/pages/dashboard-page/dashboard-page.component.ts
+++ b/src/glass/src/app/pages/dashboard-page/dashboard-page.component.ts
@@ -39,6 +39,10 @@ export class DashboardPageComponent implements OnInit {
     {
       id: 'hosts',
       title: TEXT('Hosts')
+    },
+    {
+      id: 'services-capacity',
+      title: TEXT('Services Capacity')
     }
   ];
 

--- a/src/glass/src/app/shared/services/api/services.service.spec.ts
+++ b/src/glass/src/app/shared/services/api/services.service.spec.ts
@@ -1,19 +1,39 @@
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 
 import { ServicesService } from '~/app/shared/services/api/services.service';
 
 describe('ServicesService', () => {
   let service: ServicesService;
+  let httpTesting: HttpTestingController;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule]
     });
     service = TestBed.inject(ServicesService);
+    httpTesting = TestBed.inject(HttpTestingController);
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  it('should call reservations', () => {
+    service.reservations().subscribe();
+    const req = httpTesting.expectOne('api/services/reservations');
+    expect(req.request.method).toBe('GET');
+  });
+
+  it('should call list', () => {
+    service.list().subscribe();
+    const req = httpTesting.expectOne('api/services/');
+    expect(req.request.method).toBe('GET');
+  });
+
+  it('should call stats', () => {
+    service.stats().subscribe();
+    const req = httpTesting.expectOne('api/services/stats');
+    expect(req.request.method).toBe('GET');
   });
 });

--- a/src/glass/src/app/shared/services/api/services.service.ts
+++ b/src/glass/src/app/shared/services/api/services.service.ts
@@ -44,6 +44,14 @@ export interface ServiceDesc {
   replicas: number;
 }
 
+export type ServiceStorage = {
+  name: string;
+  used: number;
+  avail: number;
+  allocated: number;
+  utilization: number;
+};
+
 @Injectable({
   providedIn: 'root'
 })
@@ -84,5 +92,9 @@ export class ServicesService {
 
   public list(): Observable<ServiceDesc[]> {
     return this.http.get<ServiceDesc[]>(`${this.url}/`);
+  }
+
+  public stats(): Observable<Record<string, ServiceStorage>> {
+    return this.http.get<Record<string, ServiceStorage>>(`${this.url}/stats`);
   }
 }


### PR DESCRIPTION
![Bildschirmfoto vom 2021-03-29 16-27-38](https://user-images.githubusercontent.com/1897962/112857592-4b304d80-90b1-11eb-9902-2b31aadc6a11.png)

Fixes: https://github.com/aquarist-labs/aquarium/issues/344

Signed-off-by: Volker Theile <vtheile@suse.com>