### PR TITLE
gravel/glass: present constraints on service creation

### DIFF
--- a/src/glass/src/app/core/dashboard/widgets/capacity-dashboard-widget/capacity-dashboard-widget.component.ts
+++ b/src/glass/src/app/core/dashboard/widgets/capacity-dashboard-widget/capacity-dashboard-widget.component.ts
@@ -4,7 +4,7 @@ import { Observable } from 'rxjs';
 
 import { translate } from '~/app/i18n.helper';
 import { BytesToSizePipe } from '~/app/shared/pipes/bytes-to-size.pipe';
-import { Reservations, ServicesService } from '~/app/shared/services/api/services.service';
+import { Constraints, ServicesService } from '~/app/shared/services/api/services.service';
 
 @Component({
   selector: 'glass-capacity-dashboard-widget',
@@ -21,10 +21,10 @@ export class CapacityDashboardWidgetComponent {
 
   constructor(public service: ServicesService, private bytesToSizePipe: BytesToSizePipe) {}
 
-  updateChartData($data: Reservations) {
+  updateChartData($data: Constraints) {
     this.chartData = [
-      { name: translate(TEXT('Used')), value: $data.reserved },
-      { name: translate(TEXT('Free')), value: $data.available }
+      { name: translate(TEXT('Used')), value: $data.allocations.allocated },
+      { name: translate(TEXT('Free')), value: $data.allocations.available }
     ];
   }
 
@@ -32,7 +32,7 @@ export class CapacityDashboardWidgetComponent {
     return this.bytesToSizePipe.transform(c);
   }
 
-  loadData(): Observable<Reservations> {
-    return this.service.reservations();
+  loadData(): Observable<Constraints> {
+    return this.service.getConstraints();
   }
 }

--- a/src/glass/src/app/pages/deployment-page/cephfs-modal/cephfs-modal.component.html
+++ b/src/glass/src/app/pages/deployment-page/cephfs-modal/cephfs-modal.component.html
@@ -1,4 +1,20 @@
-<h1 mat-dialog-title>CephFS</h1>
+<div fxLayout="row"
+     fxLayoutAlign="start start"
+     fxLayoutGap="16px">
+  <h1 mat-dialog-title>CephFS</h1>
+  <div *ngIf="showWarning"
+       fxLayout="column"
+       fxLayoutAlign="start start">
+    <span *ngFor="let warning of showWarningText"
+          fxLayout="row"
+          fxLayoutAlign="start center"
+          fxLayoutGap="5px"
+          style="font-size: 12px;">
+      <mat-icon svgIcon="mdi:alert" style="transform: scale(0.6)"></mat-icon>
+      <span>{{warning}}</span>
+    </span>
+  </div>
+</div>
 <mat-dialog-content fxLayout="column"
                     fxLayoutAlign="none">
   <form [formGroup]="formGroup"

--- a/src/glass/src/app/pages/deployment-page/cephfs-modal/cephfs-modal.component.html
+++ b/src/glass/src/app/pages/deployment-page/cephfs-modal/cephfs-modal.component.html
@@ -4,12 +4,14 @@
   <h1 mat-dialog-title>CephFS</h1>
   <div *ngIf="showWarning"
        fxLayout="column"
-       fxLayoutAlign="start start">
+       fxLayoutAlign="start start"
+       style="width: 100%;">
     <span *ngFor="let warning of showWarningText"
           fxLayout="row"
           fxLayoutAlign="start center"
           fxLayoutGap="5px"
-          style="font-size: 12px;">
+          style="font-size: 12px; width: 100%; color: black"
+          class="glass-color-theme-warn">
       <mat-icon svgIcon="mdi:alert" style="transform: scale(0.6)"></mat-icon>
       <span>{{warning}}</span>
     </span>

--- a/src/glass/src/app/shared/services/api/services.service.ts
+++ b/src/glass/src/app/shared/services/api/services.service.ts
@@ -23,6 +23,26 @@ export interface CheckRequirementsReply {
   requirements: Requirements;
 }
 
+export interface AllocationConstraints {
+  allocated: number;
+  available: number;
+}
+
+export interface RedundancyConstraints {
+  /* eslint-disable @typescript-eslint/naming-convention */
+  max_replicas: number;
+}
+
+export interface AvailabilityConstraints {
+  hosts: number;
+}
+
+export interface Constraints {
+  allocations: AllocationConstraints;
+  redundancy: RedundancyConstraints;
+  availability: AvailabilityConstraints;
+}
+
 export declare type ServiceType = 'cephfs' | 'rbd' | 'rgw' | 'iscsi' | 'nfs';
 
 export interface CreateServiceRequest {
@@ -65,6 +85,15 @@ export class ServicesService {
       replicas: _replicas
     };
     return this.http.post<CheckRequirementsReply>(`${this.url}/check-requirements`, request);
+  }
+
+  /**
+   * Obtains current service creation constraints.
+   *
+   * @returns Observable to a Constraints object
+   */
+  public getConstraints(): Observable<Constraints> {
+    return this.http.get<Constraints>(`${this.url}/constraints`);
   }
 
   public create(

--- a/src/glass/src/app/shared/services/api/services.service.ts
+++ b/src/glass/src/app/shared/services/api/services.service.ts
@@ -72,13 +72,6 @@ export class ServicesService {
 
   constructor(private http: HttpClient) {}
 
-  /**
-   * Obtain existing service reservations in byte.
-   */
-  public reservations(): Observable<Reservations> {
-    return this.http.get<Reservations>(`${this.url}/reservations`);
-  }
-
   public checkRequirements(_size: number, _replicas: number): Observable<CheckRequirementsReply> {
     const request: CheckRequirementsRequest = {
       size: _size,

--- a/src/gravel/api/services.py
+++ b/src/gravel/api/services.py
@@ -20,6 +20,7 @@ from pydantic import BaseModel
 from pydantic.fields import Field
 
 from gravel.controllers.services import (
+    ConstraintsModel,
     NotEnoughSpaceError,
     ServiceError,
     ServiceModel,
@@ -61,6 +62,16 @@ class CreateRequest(BaseModel):
 
 class CreateResponse(BaseModel):
     success: bool
+
+
+@router.get(
+    "/constraints",
+    name="Obtain service constraints",
+    response_model=ConstraintsModel
+)
+async def get_constraints() -> ConstraintsModel:
+    services = Services()
+    return services.constraints
 
 
 @router.get("/reservations", response_model=ReservationsResponse)

--- a/src/gravel/api/services.py
+++ b/src/gravel/api/services.py
@@ -37,7 +37,7 @@ router: APIRouter = APIRouter(
 )
 
 
-class ReservationsReply(BaseModel):
+class ReservationsResponse(BaseModel):
     reserved: int = Field(0, title="Total reserved storage space (bytes)")
     available: int = Field(0, title="Available storage space (bytes)")
 
@@ -47,7 +47,7 @@ class RequirementsRequest(BaseModel):
     replicas: int = Field(0, title="Number of replicas", gt=0)
 
 
-class RequirementsReply(BaseModel):
+class RequirementsResponse(BaseModel):
     feasible: bool = Field(False, title="Requested requirements are feasible")
     requirements: ServiceRequirementsModel
 
@@ -59,14 +59,14 @@ class CreateRequest(BaseModel):
     replicas: int
 
 
-class CreateReply(BaseModel):
+class CreateResponse(BaseModel):
     success: bool
 
 
-@router.get("/reservations", response_model=ReservationsReply)
-async def get_reservations() -> ReservationsReply:
+@router.get("/reservations", response_model=ReservationsResponse)
+async def get_reservations() -> ReservationsResponse:
     services = Services()
-    return ReservationsReply(
+    return ReservationsResponse(
         reserved=services.total_raw_reservation,
         available=services.available_space
     )
@@ -78,10 +78,10 @@ async def get_services() -> List[ServiceModel]:
     return services.ls()
 
 
-@router.post("/check-requirements", response_model=RequirementsReply)
+@router.post("/check-requirements", response_model=RequirementsResponse)
 async def check_requirements(
     requirements: RequirementsRequest
-) -> RequirementsReply:
+) -> RequirementsResponse:
 
     size: int = requirements.size
     replicas: int = requirements.replicas
@@ -94,11 +94,11 @@ async def check_requirements(
 
     services = Services()
     feasible, reqs = services.check_requirements(size, replicas)
-    return RequirementsReply(feasible=feasible, requirements=reqs)
+    return RequirementsResponse(feasible=feasible, requirements=reqs)
 
 
-@router.post("/create", response_model=CreateReply)
-async def create_service(req: CreateRequest) -> CreateReply:
+@router.post("/create", response_model=CreateResponse)
+async def create_service(req: CreateRequest) -> CreateResponse:
 
     services = Services()
     try:
@@ -114,7 +114,7 @@ async def create_service(req: CreateRequest) -> CreateReply:
     except Exception as e:
         raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR,
                             detail=str(e))
-    return CreateReply(success=True)
+    return CreateResponse(success=True)
 
 
 @router.get(

--- a/src/gravel/api/services.py
+++ b/src/gravel/api/services.py
@@ -38,11 +38,6 @@ router: APIRouter = APIRouter(
 )
 
 
-class ReservationsResponse(BaseModel):
-    reserved: int = Field(0, title="Total reserved storage space (bytes)")
-    available: int = Field(0, title="Available storage space (bytes)")
-
-
 class RequirementsRequest(BaseModel):
     size: int = Field(0, title="Expected storage space (bytes)", gt=0)
     replicas: int = Field(0, title="Number of replicas", gt=0)
@@ -72,15 +67,6 @@ class CreateResponse(BaseModel):
 async def get_constraints() -> ConstraintsModel:
     services = Services()
     return services.constraints
-
-
-@router.get("/reservations", response_model=ReservationsResponse)
-async def get_reservations() -> ReservationsResponse:
-    services = Services()
-    return ReservationsResponse(
-        reserved=services.total_raw_reservation,
-        available=services.available_space
-    )
 
 
 @router.get("/", response_model=List[ServiceModel])

--- a/src/gravel/controllers/resources/devices.py
+++ b/src/gravel/controllers/resources/devices.py
@@ -81,7 +81,7 @@ class Devices(Ticker):
 
     async def _should_tick(self) -> bool:
         nodemgr: NodeMgr = get_node_mgr()
-        return nodemgr.ready
+        return (nodemgr.bootstrapped or nodemgr.ready)
 
     async def probe(self) -> None:
 


### PR DESCRIPTION
With this patchset we are now able to present certain constraints that are not able to be met when creating a service; e.g., number of hosts doesn't allow for availability in case of failures, or number of replicas cannot be met.

Unfortunately, my skills at showing those constraints on the UI came up short and, to be perfectly frank, it's quite ugly. Hopefully someone else will be able to make them more digestible once this is merged :)

Resolves #86 

Signed-off-by: Joao Eduardo Luis \<joao@suse.com>