### PR TITLE
glass: Performance widget

### DIFF
--- a/src/glass/src/app/core/dashboard/dashboard.module.ts
+++ b/src/glass/src/app/core/dashboard/dashboard.module.ts
@@ -9,6 +9,7 @@ import { NgxChartsModule } from '@swimlane/ngx-charts';
 import { CapacityDashboardWidgetComponent } from '~/app/core/dashboard/widgets/capacity-dashboard-widget/capacity-dashboard-widget.component';
 import { HealthDashboardWidgetComponent } from '~/app/core/dashboard/widgets/health-dashboard-widget/health-dashboard-widget.component';
 import { HostsDashboardWidgetComponent } from '~/app/core/dashboard/widgets/hosts-dashboard-widget/hosts-dashboard-widget.component';
+import { PerformanceDashboardWidgetComponent } from '~/app/core/dashboard/widgets/performance-dashboard-widget/performance-dashboard-widget.component';
 import { ServicesCapacityDashboardWidgetComponent } from '~/app/core/dashboard/widgets/services-capacity-dashboard-widget/services-capacity-dashboard-widget.component';
 import { ServicesDashboardWidgetComponent } from '~/app/core/dashboard/widgets/services-dashboard-widget/services-dashboard-widget.component';
 import { SysInfoDashboardWidgetComponent } from '~/app/core/dashboard/widgets/sys-info-dashboard-widget/sys-info-dashboard-widget.component';
@@ -24,7 +25,8 @@ import { SharedModule } from '~/app/shared/shared.module';
     ServicesDashboardWidgetComponent,
     SysInfoDashboardWidgetComponent,
     HostsDashboardWidgetComponent,
-    ServicesCapacityDashboardWidgetComponent
+    ServicesCapacityDashboardWidgetComponent,
+    PerformanceDashboardWidgetComponent
   ],
   exports: [
     CapacityDashboardWidgetComponent,
@@ -33,7 +35,8 @@ import { SharedModule } from '~/app/shared/shared.module';
     ServicesDashboardWidgetComponent,
     SysInfoDashboardWidgetComponent,
     HostsDashboardWidgetComponent,
-    ServicesCapacityDashboardWidgetComponent
+    ServicesCapacityDashboardWidgetComponent,
+    PerformanceDashboardWidgetComponent
   ],
   imports: [
     CommonModule,

--- a/src/glass/src/app/core/dashboard/widgets/performance-dashboard-widget/performance-dashboard-widget.component.html
+++ b/src/glass/src/app/core/dashboard/widgets/performance-dashboard-widget/performance-dashboard-widget.component.html
@@ -1,0 +1,30 @@
+<glass-widget [loadData]="loadData.bind(this)"
+              title="Performance"
+              (loadDataEvent)="updateChartData($event)">
+  <div class="glass-capacity-dashboard-widget"
+       fxLayout="column"
+       fxLayoutAlign="center center">
+    <div fxLayout="row"
+         fxLayoutAlign="center center">
+      <ngx-charts-gauge [results]="chartDataRead"
+                        [view]="[225,225]"
+                        [showAxis]="false"
+                        [tooltipDisabled]="false"
+                        fxFlex="50"
+                        units="Read"
+                        [valueFormatting]="valueFormatting.bind(this)"
+                        [animations]="false">
+      </ngx-charts-gauge>
+      <ngx-charts-gauge [results]="chartDataWrite"
+                        [showAxis]="false"
+                        [tooltipDisabled]="false"
+                        fxFlex="50"
+                        [view]="[225,225]"
+                        units="Write"
+                        [valueFormatting]="valueFormatting.bind(this)"
+                        [animations]="false">
+      </ngx-charts-gauge>
+    </div>
+    <!-- Area chart will come below as soon as rate series are available -->
+  </div>
+</glass-widget>

--- a/src/glass/src/app/core/dashboard/widgets/performance-dashboard-widget/performance-dashboard-widget.component.spec.ts
+++ b/src/glass/src/app/core/dashboard/widgets/performance-dashboard-widget/performance-dashboard-widget.component.spec.ts
@@ -1,0 +1,34 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { TranslateModule } from '@ngx-translate/core';
+
+import { DashboardModule } from '~/app/core/dashboard/dashboard.module';
+
+import { PerformanceDashboardWidgetComponent } from './performance-dashboard-widget.component';
+
+describe('PerformanceDashboardWidgetComponent', () => {
+  let component: PerformanceDashboardWidgetComponent;
+  let fixture: ComponentFixture<PerformanceDashboardWidgetComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        DashboardModule,
+        TranslateModule.forRoot(),
+        BrowserAnimationsModule,
+        HttpClientTestingModule
+      ]
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(PerformanceDashboardWidgetComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/glass/src/app/core/dashboard/widgets/performance-dashboard-widget/performance-dashboard-widget.component.ts
+++ b/src/glass/src/app/core/dashboard/widgets/performance-dashboard-widget/performance-dashboard-widget.component.ts
@@ -1,0 +1,40 @@
+import { Component } from '@angular/core';
+import { Observable } from 'rxjs';
+
+import { BytesToSizePipe } from '~/app/shared/pipes/bytes-to-size.pipe';
+import { ClientIO, StatusService } from '~/app/shared/services/api/status.service';
+
+@Component({
+  selector: 'glass-performance-dashboard-widget',
+  templateUrl: './performance-dashboard-widget.component.html',
+  styleUrls: ['./performance-dashboard-widget.component.scss']
+})
+export class PerformanceDashboardWidgetComponent {
+  chartDataWrite: any[] = [];
+  chartDataRead: any[] = [];
+
+  constructor(public service: StatusService, private bytesToSizePipe: BytesToSizePipe) {}
+
+  updateChartData($data: ClientIO) {
+    this.chartDataWrite = this.mapServiceRate($data, 'write');
+    this.chartDataRead = this.mapServiceRate($data, 'read');
+  }
+
+  valueFormatting(c: any) {
+    return this.bytesToSizePipe.transform(c) + '/s';
+  }
+
+  loadData(): Observable<ClientIO> {
+    return this.service.clientIO();
+  }
+
+  private mapServiceRate(
+    $data: ClientIO,
+    rate: 'read' | 'write'
+  ): { name: string; value: number }[] {
+    return $data.services.map((s) => ({
+      name: `${s.service_name} (${s.service_type})`,
+      value: s.io_rate[rate]
+    }));
+  }
+}

--- a/src/glass/src/app/pages/dashboard-page/dashboard-page.component.html
+++ b/src/glass/src/app/pages/dashboard-page/dashboard-page.component.html
@@ -13,6 +13,9 @@
     <div *ngFor="let widget of enabledWidgets"
          class="widget">
       <ng-container [ngSwitch]="widget.id">
+        <ng-template [ngSwitchCase]="'performance'">
+          <glass-performance-dashboard-widget></glass-performance-dashboard-widget>
+        </ng-template>
         <ng-template [ngSwitchCase]="'capacity'">
           <glass-capacity-dashboard-widget></glass-capacity-dashboard-widget>
         </ng-template>

--- a/src/glass/src/app/pages/dashboard-page/dashboard-page.component.ts
+++ b/src/glass/src/app/pages/dashboard-page/dashboard-page.component.ts
@@ -11,7 +11,7 @@ import { LocalStorageService } from '~/app/shared/services/local-storage.service
   styleUrls: ['./dashboard-page.component.scss']
 })
 export class DashboardPageComponent implements OnInit {
-  enabled: string[] = ['health', 'capacity', 'services-capacity'];
+  enabled: string[] = ['health', 'capacity', 'performance', 'services-capacity'];
 
   // New dashboard widgets must be added here. Don't forget to enhance
   // the template to render the new widget.
@@ -23,6 +23,10 @@ export class DashboardPageComponent implements OnInit {
     {
       id: 'capacity',
       title: TEXT('Capacity')
+    },
+    {
+      id: 'performance',
+      title: TEXT('Performance')
     },
     {
       id: 'services',

--- a/src/glass/src/app/shared/services/api/status.service.spec.ts
+++ b/src/glass/src/app/shared/services/api/status.service.spec.ts
@@ -38,4 +38,10 @@ describe('StatusService', () => {
     const req = httpTesting.expectOne('api/status/');
     expect(req.request.method).toBe('GET');
   });
+
+  it('should call clientIO', () => {
+    service.clientIO().subscribe();
+    const req = httpTesting.expectOne('api/status/client-io-rates');
+    expect(req.request.method).toBe('GET');
+  });
 });

--- a/src/glass/src/app/shared/services/api/status.service.ts
+++ b/src/glass/src/app/shared/services/api/status.service.ts
@@ -40,6 +40,24 @@ export type Status = {
   cluster?: ClusterStatus;
 };
 
+export type IORate = {
+  read: number;
+  write: number;
+  read_ops: number;
+  write_ops: number;
+};
+
+export type ServiceIO = {
+  service_name: string;
+  service_type: string;
+  io_rate: IORate;
+};
+
+export type ClientIO = {
+  cluster: IORate;
+  services: ServiceIO[];
+};
+
 @Injectable({
   providedIn: 'root'
 })
@@ -53,5 +71,9 @@ export class StatusService {
    */
   status(): Observable<Status> {
     return this.http.get<Status>(`${this.url}/`);
+  }
+
+  clientIO(): Observable<ClientIO> {
+    return this.http.get<ClientIO>(`${this.url}/client-io-rates`);
   }
 }


### PR DESCRIPTION
![simple-performance-widget](https://user-images.githubusercontent.com/16167865/113155938-d6d4e600-9239-11eb-8908-d4fee38f8f07.png)

This is still a simple widget as time series rates are missing ATM.

Fixes #360
Signed-off-by: Stephan Müller <smueller@suse.com>