### PR TITLE
glass: Remove unit test

### DIFF
--- a/src/glass/src/app/shared/services/api/services.service.spec.ts
+++ b/src/glass/src/app/shared/services/api/services.service.spec.ts
@@ -19,12 +19,6 @@ describe('ServicesService', () => {
     expect(service).toBeTruthy();
   });
 
-  it('should call reservations', () => {
-    service.reservations().subscribe();
-    const req = httpTesting.expectOne('api/services/reservations');
-    expect(req.request.method).toBe('GET');
-  });
-
   it('should call list', () => {
     service.list().subscribe();
     const req = httpTesting.expectOne('api/services/');


### PR DESCRIPTION
Need to remove the /api/services/reservation service unit test after the endpoint has been dropped in 22bef0ab336397cb94e91338a1e24e0c2cf0cff4.

Signed-off-by: Volker Theile <vtheile@suse.com>