### PR TITLE
glass: Performance dashboard widget cleanup

### DIFF
--- a/src/glass/src/app/core/dashboard/widgets/performance-dashboard-widget/performance-dashboard-widget.component.html
+++ b/src/glass/src/app/core/dashboard/widgets/performance-dashboard-widget/performance-dashboard-widget.component.html
@@ -1,29 +1,31 @@
 <glass-widget [loadData]="loadData.bind(this)"
               title="Performance"
               (loadDataEvent)="updateChartData($event)">
-  <div class="glass-capacity-dashboard-widget"
+  <div class="glass-performance-dashboard-widget"
+       fxFlexFill
        fxLayout="column"
-       fxLayoutAlign="center center">
-    <div fxLayout="row"
-         fxLayoutAlign="center center">
-      <ngx-charts-gauge [results]="chartDataRead"
-                        [view]="[225,225]"
-                        [showAxis]="false"
-                        [tooltipDisabled]="false"
-                        fxFlex="50"
-                        units="Read"
-                        [valueFormatting]="valueFormatting.bind(this)"
-                        [animations]="false">
-      </ngx-charts-gauge>
-      <ngx-charts-gauge [results]="chartDataWrite"
-                        [showAxis]="false"
-                        [tooltipDisabled]="false"
-                        fxFlex="50"
-                        [view]="[225,225]"
-                        units="Write"
-                        [valueFormatting]="valueFormatting.bind(this)"
-                        [animations]="false">
-      </ngx-charts-gauge>
+       fxLayoutAlign="start stretch">
+    <div fxFlexFill
+         fxLayout="row"
+         fxLayoutAlign="center stretch">
+      <div fxFlex="50">
+        <ngx-charts-gauge [results]="chartDataRead"
+                          [showAxis]="false"
+                          [tooltipDisabled]="false"
+                          units="Read"
+                          [valueFormatting]="valueFormatting.bind(this)"
+                          [animations]="false">
+        </ngx-charts-gauge>
+      </div>
+      <div fxFlex="50">
+        <ngx-charts-gauge [results]="chartDataWrite"
+                          [showAxis]="false"
+                          [tooltipDisabled]="false"
+                          units="Write"
+                          [valueFormatting]="valueFormatting.bind(this)"
+                          [animations]="false">
+        </ngx-charts-gauge>
+      </div>
     </div>
     <!-- Area chart will come below as soon as rate series are available -->
   </div>

--- a/src/glass/src/app/core/dashboard/widgets/performance-dashboard-widget/performance-dashboard-widget.component.scss
+++ b/src/glass/src/app/core/dashboard/widgets/performance-dashboard-widget/performance-dashboard-widget.component.scss
@@ -1,0 +1,3 @@
+.glass-performance-dashboard-widget {
+  max-height: 200px;
+}

--- a/src/glass/src/app/core/dashboard/widgets/performance-dashboard-widget/performance-dashboard-widget.component.ts
+++ b/src/glass/src/app/core/dashboard/widgets/performance-dashboard-widget/performance-dashboard-widget.component.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import * as _ from 'lodash';
 import { Observable } from 'rxjs';
 
 import { BytesToSizePipe } from '~/app/shared/pipes/bytes-to-size.pipe';
@@ -32,7 +33,8 @@ export class PerformanceDashboardWidgetComponent {
     $data: ClientIO,
     rate: 'read' | 'write'
   ): { name: string; value: number }[] {
-    return $data.services.map((s) => ({
+    _.orderBy($data.services, ['io_rate.rate'], ['desc']);
+    return _.take($data.services, 5).map((s) => ({
       name: `${s.service_name} (${s.service_type})`,
       value: s.io_rate[rate]
     }));


### PR DESCRIPTION
- Show only the 'Top 5' services (display size is limited in the widget)
- Embed chart components in div to fix flex layout render issues

Signed-off-by: Volker Theile <vtheile@suse.com>