### PR TITLE
gravel: fix ctrl/status and deduplicate some code

### DIFF
--- a/src/gravel/controllers/orch/ceph.py
+++ b/src/gravel/controllers/orch/ceph.py
@@ -250,6 +250,35 @@ class Mon(Ceph):
             return False
         return True
 
+    def pool_set(
+        self,
+        poolname: str,
+        var: str,
+        value: str,
+        really: bool = False
+    ) -> bool:
+        """ Set given pool's configuration variable to a provided value """
+        assert poolname
+        assert var
+        assert value
+        cmd: Dict[str, str] = {
+            "prefix": "osd pool set",
+            "pool": poolname,
+            "var": var,
+            "val": value
+        }
+        if really:
+            cmd["yes_i_really_mean_it"] = "true"
+
+        try:
+            self.call(cmd)
+        except CephCommandError as e:
+            logger.error(
+                f"mon > unable to set {var} = {value} on pool {poolname}")
+            logger.exception(e)
+            return False
+        return True
+
     def _set_default_ruleset_config(self, rulesetid: int) -> bool:
         r = self.config_set(
             "global",
@@ -309,49 +338,30 @@ class Mon(Ceph):
         return True
 
     def set_pool_ruleset(self, poolname: str, ruleset: str) -> bool:
+        """ Set a given pool's ruleset. Expects a ruleset's name. """
         assert ruleset
-        cmd: Dict[str, str] = {
-            "prefix": "osd pool set",
-            "pool": poolname,
-            "var": "crush_rule",
-            "val": ruleset
-        }
-        try:
-            self.call(cmd)
-        except CephCommandError as e:
-            logger.error(f"mon > unable to set pool crush ruleset: {str(e)}")
-            logger.exception(e)
-            return False
-        return True
+        r = self.pool_set(poolname, "crush_rule", ruleset)
+        if not r:
+            logger.error(f"mon > unable to set pool crush ruleset to {ruleset}")
+        return r
 
     def set_pool_size(self, name: str, size: int) -> None:
-        size_cmd: Dict[str, Any] = {
-            "prefix": "osd pool set",
-            "pool": name,
-            "var": "size",
-            "val": str(size)
-        }
+        """
+        Set a given pool's size to the provided value.
+        If the provided value is greater than 2, sets min_size to 2; otherwise
+        sets min_size to 1.
+        """
+        really: bool = False
         if size == 1:
-            size_cmd["yes_i_really_mean_it"] = True
-        try:
-            self.call(size_cmd)
-        except CephCommandError as e:
+            really = True
+        r = self.pool_set(name, "size", str(size), really=really)
+        if not r:
             logger.error("mon > unable to set pool size")
-            logger.debug(str(e))
-            logger.debug(str(size_cmd))
 
         minsize = 2 if size > 2 else 1
-        minsize_cmd: Dict[str, str] = {
-            "prefix": "osd pool set",
-            "pool": name,
-            "var": "min_size",
-            "val": str(minsize)
-        }
-        try:
-            self.call(minsize_cmd)
-        except CephCommandError as e:
+        r = self.pool_set(name, "min_size", str(minsize))
+        if not r:
             logger.error("mon > unable to set pool min_size")
-            logger.debug(str(e))
 
     def set_allow_pool_size_one(self) -> None:
         r = self.config_set("global", "mon_allow_pool_size_one", "true")

--- a/src/gravel/controllers/orch/ceph.py
+++ b/src/gravel/controllers/orch/ceph.py
@@ -234,18 +234,30 @@ class Mon(Ceph):
             logger.exception(e)
             raise NoRulesetError()
 
-    def _set_default_ruleset_config(self, rulesetid: int) -> bool:
+    def config_set(self, who: str, name: str, value: str) -> bool:
         cmd = {
             "prefix": "config set",
-            "who": "global",
-            "name": "osd_pool_default_crush_rule",
-            "value": f"{rulesetid}"
+            "who": who,
+            "name": name,
+            "value": value
         }
         try:
             self.call(cmd)
         except CephCommandError as e:
-            logger.error(f"mon > unable to set default crush rule: {str(e)}")
+            logger.error(
+                f"mon > unable to set config: {name} = {value} on {who}")
             logger.exception(e)
+            return False
+        return True
+
+    def _set_default_ruleset_config(self, rulesetid: int) -> bool:
+        r = self.config_set(
+            "global",
+            "osd_pool_default_crush_rule",
+            str(rulesetid)
+        )
+        if not r:
+            logger.error("mon > unable to set default crush rule")
             return False
         return True
 
@@ -342,22 +354,14 @@ class Mon(Ceph):
             logger.debug(str(e))
 
     def set_allow_pool_size_one(self) -> None:
-        cmd: Dict[str, str] = {
-            "prefix": "config set",
-            "who": "global",
-            "name": "mon_allow_pool_size_one",
-            "value": "true"
-        }
-        self.call(cmd)
+        r = self.config_set("global", "mon_allow_pool_size_one", "true")
+        if not r:
+            logger.error("mon > unable to set allow pool size one")
 
     def disable_warn_on_no_redundancy(self) -> None:
-        cmd: Dict[str, str] = {
-            "prefix": "config set",
-            "who": "global",
-            "name": "mon_warn_on_pool_no_redundancy",
-            "value": "false"
-        }
-        self.call(cmd)
+        r = self.config_set("global", "mon_warn_on_pool_no_redundancy", "false")
+        if not r:
+            logger.error("mon > unable to disable warn on no redundancy")
 
     def get_pools_stats(self) -> List[CephOSDPoolStatsModel]:
         cmd: Dict[str, str] = {

--- a/src/gravel/controllers/resources/status.py
+++ b/src/gravel/controllers/resources/status.py
@@ -95,7 +95,8 @@ class Status(Ticker):
 
     async def _should_tick(self) -> bool:
         nodemgr: NodeMgr = get_node_mgr()
-        return nodemgr.stage >= NodeStageEnum.BOOTSTRAPPED
+        return (nodemgr.stage >= NodeStageEnum.BOOTSTRAPPED and
+                nodemgr.stage != NodeStageEnum.JOINING)
 
     async def probe(self) -> None:
         assert self._mon


### PR DESCRIPTION
We introduced a regression a while ago while fixing a bug, making the status controller tick while a node is joining, which should not happen because, at the time, we don't have a ceph.conf. This patchset fixes this.

Additionally, we're deduplicating some code in the ceph controller.

Signed-off-by: Joao Eduardo Luis \<joao@suse.com>