### PR TITLE
glass: Fix dashboard widgets issue related to valueFormatting

### DIFF
--- a/src/glass/src/app/core/dashboard/widgets/capacity-dashboard-widget/capacity-dashboard-widget.component.html
+++ b/src/glass/src/app/core/dashboard/widgets/capacity-dashboard-widget/capacity-dashboard-widget.component.html
@@ -9,7 +9,7 @@
                                    [animations]="false"
                                    [view]="[500,175]"
                                    [tooltipDisabled]="true"
-                                   [valueFormatting]="valueFormatting.bind(this)">
+                                   [valueFormatting]="valueFormatting">
     </ngx-charts-advanced-pie-chart>
   </div>
 </glass-widget>

--- a/src/glass/src/app/core/dashboard/widgets/capacity-dashboard-widget/capacity-dashboard-widget.component.ts
+++ b/src/glass/src/app/core/dashboard/widgets/capacity-dashboard-widget/capacity-dashboard-widget.component.ts
@@ -19,7 +19,7 @@ export class CapacityDashboardWidgetComponent {
     domain: ['#30ba78', '#e0dfdf']
   };
 
-  constructor(private service: ServicesService, private bytesToSizePipe: BytesToSizePipe) {}
+  constructor(private service: ServicesService) {}
 
   updateChartData($data: Constraints) {
     this.chartData = [
@@ -29,7 +29,12 @@ export class CapacityDashboardWidgetComponent {
   }
 
   valueFormatting(c: any) {
-    return this.bytesToSizePipe.transform(c);
+    // Note, this implementation is by intention, do NOT use code like
+    // 'valueFormatting.bind(this)', otherwise this method is called
+    // over and over again because Angular CD seems to assume something
+    // has been changed.
+    const pipe = new BytesToSizePipe();
+    return pipe.transform(c);
   }
 
   loadData(): Observable<Constraints> {

--- a/src/glass/src/app/core/dashboard/widgets/performance-dashboard-widget/performance-dashboard-widget.component.html
+++ b/src/glass/src/app/core/dashboard/widgets/performance-dashboard-widget/performance-dashboard-widget.component.html
@@ -13,7 +13,7 @@
                           [showAxis]="false"
                           [tooltipDisabled]="false"
                           units="Read"
-                          [valueFormatting]="valueFormatting.bind(this)"
+                          [valueFormatting]="valueFormatting"
                           [animations]="false">
         </ngx-charts-gauge>
       </div>
@@ -22,7 +22,7 @@
                           [showAxis]="false"
                           [tooltipDisabled]="false"
                           units="Write"
-                          [valueFormatting]="valueFormatting.bind(this)"
+                          [valueFormatting]="valueFormatting"
                           [animations]="false">
         </ngx-charts-gauge>
       </div>

--- a/src/glass/src/app/core/dashboard/widgets/performance-dashboard-widget/performance-dashboard-widget.component.html
+++ b/src/glass/src/app/core/dashboard/widgets/performance-dashboard-widget/performance-dashboard-widget.component.html
@@ -1,5 +1,5 @@
 <glass-widget [loadData]="loadData.bind(this)"
-              title="Performance"
+              title="{{ 'Performance' | translate }}"
               (loadDataEvent)="updateChartData($event)">
   <div class="glass-performance-dashboard-widget"
        fxFlexFill
@@ -9,7 +9,9 @@
          fxLayout="row"
          fxLayoutAlign="center stretch">
       <div fxFlex="50">
-        <ngx-charts-gauge [results]="chartDataRead"
+        <ngx-charts-gauge #read
+                          [ngClass]="{visible: sizeUpdated}"
+                          [results]="chartDataRead"
                           [showAxis]="false"
                           [tooltipDisabled]="false"
                           units="Read"
@@ -18,7 +20,9 @@
         </ngx-charts-gauge>
       </div>
       <div fxFlex="50">
-        <ngx-charts-gauge [results]="chartDataWrite"
+        <ngx-charts-gauge #write
+                          [ngClass]="{visible: sizeUpdated}"
+                          [results]="chartDataWrite"
                           [showAxis]="false"
                           [tooltipDisabled]="false"
                           units="Write"

--- a/src/glass/src/app/core/dashboard/widgets/performance-dashboard-widget/performance-dashboard-widget.component.scss
+++ b/src/glass/src/app/core/dashboard/widgets/performance-dashboard-widget/performance-dashboard-widget.component.scss
@@ -1,3 +1,11 @@
 .glass-performance-dashboard-widget {
   max-height: 200px;
+
+  ngx-charts-gauge {
+    visibility: hidden;
+
+    &.visible {
+      visibility: visible;
+    }
+  }
 }

--- a/src/glass/src/app/core/dashboard/widgets/performance-dashboard-widget/performance-dashboard-widget.component.ts
+++ b/src/glass/src/app/core/dashboard/widgets/performance-dashboard-widget/performance-dashboard-widget.component.ts
@@ -14,7 +14,7 @@ export class PerformanceDashboardWidgetComponent {
   chartDataWrite: any[] = [];
   chartDataRead: any[] = [];
 
-  constructor(public service: StatusService, private bytesToSizePipe: BytesToSizePipe) {}
+  constructor(public service: StatusService) {}
 
   updateChartData($data: ClientIO) {
     this.chartDataWrite = this.mapServiceRate($data, 'write');
@@ -22,7 +22,12 @@ export class PerformanceDashboardWidgetComponent {
   }
 
   valueFormatting(c: any) {
-    return this.bytesToSizePipe.transform(c) + '/s';
+    // Note, this implementation is by intention, do NOT use code like
+    // 'valueFormatting.bind(this)', otherwise this method is called
+    // over and over again because Angular CD seems to assume something
+    // has been changed.
+    const pipe = new BytesToSizePipe();
+    return pipe.transform(c) + '/s';
   }
 
   loadData(): Observable<ClientIO> {

--- a/src/glass/src/app/core/dashboard/widgets/performance-dashboard-widget/performance-dashboard-widget.component.ts
+++ b/src/glass/src/app/core/dashboard/widgets/performance-dashboard-widget/performance-dashboard-widget.component.ts
@@ -1,4 +1,5 @@
-import { Component } from '@angular/core';
+import { Component, ViewChild } from '@angular/core';
+import { GaugeComponent } from '@swimlane/ngx-charts';
 import * as _ from 'lodash';
 import { Observable } from 'rxjs';
 
@@ -11,6 +12,13 @@ import { ClientIO, StatusService } from '~/app/shared/services/api/status.servic
   styleUrls: ['./performance-dashboard-widget.component.scss']
 })
 export class PerformanceDashboardWidgetComponent {
+  @ViewChild('read', { static: true })
+  readChart!: GaugeComponent;
+  @ViewChild('write', { static: true })
+  writeChart!: GaugeComponent;
+
+  sizeUpdated = false;
+
   chartDataWrite: any[] = [];
   chartDataRead: any[] = [];
 
@@ -19,6 +27,20 @@ export class PerformanceDashboardWidgetComponent {
   updateChartData($data: ClientIO) {
     this.chartDataWrite = this.mapServiceRate($data, 'write');
     this.chartDataRead = this.mapServiceRate($data, 'read');
+
+    // This is a somewhat dumb workaround to force the charts to adapt
+    // their size to the parent container. This is caused by the change
+    // detection strategy 'ChangeDetectionStrategy.OnPush' of the chart.
+    // The size of the charts is otherwise rendered with 600x400 pixels
+    // and only updated the second time the data is loaded (which is 15
+    // seconds by default).
+    if (!this.sizeUpdated) {
+      setTimeout(() => {
+        this.readChart.update();
+        this.writeChart.update();
+        this.sizeUpdated = true;
+      });
+    }
   }
 
   valueFormatting(c: any) {

--- a/src/glass/src/app/core/dashboard/widgets/services-capacity-dashboard-widget/services-capacity-dashboard-widget.component.html
+++ b/src/glass/src/app/core/dashboard/widgets/services-capacity-dashboard-widget/services-capacity-dashboard-widget.component.html
@@ -9,7 +9,7 @@
                                [animations]="false"
                                [legend]="true"
                                [showDataLabel]="true"
-                               [dataLabelFormatting]="dataLabelFormatting.bind(this)"
+                               [dataLabelFormatting]="dataLabelFormatting"
                                [roundEdges]="false"
                                [tooltipDisabled]="true">
     </ngx-charts-bar-horizontal>

--- a/src/glass/src/app/core/dashboard/widgets/sys-info-dashboard-widget/sys-info-dashboard-widget.component.html
+++ b/src/glass/src/app/core/dashboard/widgets/sys-info-dashboard-widget/sys-info-dashboard-widget.component.html
@@ -46,7 +46,7 @@
                                          [view]="[500,175]"
                                          [animations]="false"
                                          [tooltipDisabled]="true"
-                                         [valueFormatting]="valueFormatting.bind(this)">
+                                         [valueFormatting]="valueFormatting">
           </ngx-charts-advanced-pie-chart>
         </div>
       </div>

--- a/src/glass/src/app/core/dashboard/widgets/sys-info-dashboard-widget/sys-info-dashboard-widget.component.ts
+++ b/src/glass/src/app/core/dashboard/widgets/sys-info-dashboard-widget/sys-info-dashboard-widget.component.ts
@@ -39,13 +39,15 @@ export class SysInfoDashboardWidgetComponent {
     domain: ['#ffecb5', '#ffc107', '#ff9e02']
   };
 
-  constructor(
-    private bytesToSizePipe: BytesToSizePipe,
-    private localNodeService: LocalNodeService
-  ) {}
+  constructor(private localNodeService: LocalNodeService) {}
 
   valueFormatting(c: any) {
-    return this.bytesToSizePipe.transform(c);
+    // Note, this implementation is by intention, do NOT use code like
+    // 'valueFormatting.bind(this)', otherwise this method is called
+    // over and over again because Angular CD seems to assume something
+    // has been changed.
+    const pipe = new BytesToSizePipe();
+    return pipe.transform(c);
   }
 
   updateData($data: Inventory) {


### PR DESCRIPTION
Do not use foo.bind(this) in combination with 'valueFormatting', otherwise Angular CD will get confused and assumes false changes.

Fix various issues in the `Performance` dashboard widget:
- Translate title text
- Add workaround to force charts to adapt their size to the parent container. Better approaches are welcome.

Signed-off-by: Volker Theile <vtheile@suse.com>