### PR TITLE
glass: add nfs service

### DIFF
--- a/src/glass/src/app/core/core.module.ts
+++ b/src/glass/src/app/core/core.module.ts
@@ -10,6 +10,7 @@ import { BlankLayoutComponent } from '~/app/core/layouts/blank-layout/blank-layo
 import { InstallerLayoutComponent } from '~/app/core/layouts/installer-layout/installer-layout.component';
 import { MainLayoutComponent } from '~/app/core/layouts/main-layout/main-layout.component';
 import { CephfsModalComponent } from '~/app/core/modals/cephfs/cephfs-modal.component';
+import { NfsModalComponent } from '~/app/core/modals/nfs/nfs-modal.component';
 import { NavigationBarComponent } from '~/app/core/navigation-bar/navigation-bar.component';
 import { NavigationBarItemComponent } from '~/app/core/navigation-bar/navigation-bar-item/navigation-bar-item.component';
 import { TopBarComponent } from '~/app/core/top-bar/top-bar.component';
@@ -24,7 +25,8 @@ import { SharedModule } from '~/app/shared/shared.module';
     InstallerLayoutComponent,
     BlankLayoutComponent,
     NavigationBarItemComponent,
-    CephfsModalComponent
+    CephfsModalComponent,
+    NfsModalComponent
   ],
   imports: [
     BlockUIModule.forRoot(),

--- a/src/glass/src/app/core/modals/nfs/nfs-modal.component.html
+++ b/src/glass/src/app/core/modals/nfs/nfs-modal.component.html
@@ -1,0 +1,125 @@
+<div class="glass-nfs-modal">
+  <mat-card *ngIf="showWarning"
+            class="warning">
+    <mat-card-content fxLayout="row">
+      <mat-icon class="glass-icon-2x"
+                svgIcon="mdi:alert"></mat-icon>
+      <div class="text"
+           fxLayout="column"
+           fxLayoutAlign="center center">
+        <span *ngFor="let warning of showWarningText">
+          {{ warning }}
+        </span>
+      </div>
+    </mat-card-content>
+  </mat-card>
+  <h1 mat-dialog-title>NFS</h1>
+  <mat-dialog-content fxLayout="column"
+                      fxLayoutAlign="none">
+    <form [formGroup]="formGroup"
+          class="mat-typography"
+          novalidate
+          fxLayout="column"
+          fxLayoutAlign="none">
+      <div fxLayout="row"
+           fxLayoutAlign="space-between none"
+           fxLayoutGap="16px">
+        <mat-form-field fxFlex>
+          <mat-label translate>Available Capacity</mat-label>
+          <input matInput
+                 type="text"
+                 [value]="formGroup.value.availableSpace | bytesToSize"
+                 readonly>
+        </mat-form-field>
+        <mat-form-field fxFlex>
+          <mat-label translate>Reserved Capacity</mat-label>
+          <input matInput
+                 type="text"
+                 [value]="formGroup.value.reservedSpace | bytesToSize"
+                 readonly>
+        </mat-form-field>
+        <mat-form-field [ngClass]="{'mat-form-field-invalid': formGroup.hasError('overBudget', 'requiredSpace')}"
+                        fxFlex>
+          <mat-label translate>Raw Required Capacity</mat-label>
+          <input matInput
+                 type="text"
+                 [value]="formGroup.value.rawRequiredSpace | bytesToSize"
+                 readonly>
+        </mat-form-field>
+      </div>
+      <mat-form-field fxFlex>
+        <mat-label translate>Service Name</mat-label>
+        <input matInput
+               type="text"
+               formControlName="name"
+               required>
+        <mat-error *ngIf="formGroup.invalid">
+          <span *ngIf="formGroup.hasError('required', 'name')">
+            This field is required.
+          </span>
+        </mat-error>
+      </mat-form-field>
+      <mat-form-field class="glass-form-field-no-underline glass-form-field-hint"
+                      fxFlex>
+        <mat-label translate>Number Of Replicas</mat-label>
+        <input #replicasInput
+               matInput
+               type="number"
+               formControlName="replicas"
+               hidden>
+        <mat-slider color="primary"
+                    [value]="replicasInput.value"
+                    (input)="onReplicasChange($event)"
+                    min="1"
+                    max="3"
+                    step="1"
+                    thumbLabel="true"
+                    fxFlex>
+        </mat-slider>
+        <mat-hint>
+          <span>{{formGroup.get('replicas')?.value | redundancyLevel:'long'}}</span>
+        </mat-hint>
+      </mat-form-field>
+      <div fxLayout="row"
+           fxLayoutAlign="space-between center"
+           fxLayoutGap="16px">
+        <mat-form-field class="glass-form-field-no-underline"
+                        [ngClass]="{'mat-form-field-invalid': formGroup.hasError('overBudget', 'requiredSpace')}"
+                        fxFlex="80">
+          <mat-label translate>Estimated Required Capacity</mat-label>
+          <input #requiredSpaceInput
+                 matInput
+                 type="number"
+                 formControlName="requiredSpace"
+                 hidden>
+          <mat-slider color="primary"
+                      [value]="requiredSpaceInput.value"
+                      (input)="onRequiredSpaceChange($event)"
+                      min="0"
+                      [max]="formGroup.value.availableSpace"
+                      step="1"
+                      fxFlex>
+          </mat-slider>
+        </mat-form-field>
+        <mat-form-field [ngClass]="{'mat-form-field-invalid': formGroup.hasError('overBudget', 'requiredSpace')}"
+                        fxFlex="20">
+          <input matInput
+                 type="text"
+                 [value]="formGroup.value.requiredSpace | bytesToSize"
+                 readonly>
+        </mat-form-field>
+      </div>
+    </form>
+  </mat-dialog-content>
+  <mat-dialog-actions>
+    <button mat-button
+            [mat-dialog-close]="false">
+      <span translate>Cancel</span>
+    </button>
+    <glass-submit-button [form]="formGroup"
+                         (buttonClick)="onSubmit()"
+                         cdkFocusInitial>
+      <span translate>Create</span>
+    </glass-submit-button>
+  </mat-dialog-actions>
+</div>

--- a/src/glass/src/app/core/modals/nfs/nfs-modal.component.scss
+++ b/src/glass/src/app/core/modals/nfs/nfs-modal.component.scss
@@ -1,0 +1,38 @@
+@import 'styles.scss';
+
+.glass-nfs-modal {
+  .warning {
+    @extend .glass-color-theme-warn;
+    margin-bottom: 8px;
+
+    .mat-icon {
+      margin-right: 16px;
+    }
+  }
+
+  ::ng-deep .mat-form-field {
+    &.glass-form-field-no-underline {
+      .mat-form-field-underline {
+        visibility: hidden;
+      }
+    }
+
+    &.glass-form-field-hint {
+      margin-bottom: 10px;
+    }
+
+    &.mat-form-field-invalid {
+      .mat-input-element {
+        color: $eos-bc-red-500;
+      }
+      .mat-slider {
+        .mat-slider-track-fill,
+        .mat-slider-thumb-label,
+        .mat-slider-thumb,
+        .mat-slider-focus-ring {
+          background-color: $eos-bc-red-500;
+        }
+      }
+    }
+  }
+}

--- a/src/glass/src/app/core/modals/nfs/nfs-modal.component.spec.ts
+++ b/src/glass/src/app/core/modals/nfs/nfs-modal.component.spec.ts
@@ -1,0 +1,41 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatDialogRef } from '@angular/material/dialog';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { TranslateModule } from '@ngx-translate/core';
+
+import { CoreModule } from '~/app/core/core.module';
+
+import { NfsModalComponent } from './nfs-modal.component';
+
+describe('NfsComponent', () => {
+  let component: NfsModalComponent;
+  let fixture: ComponentFixture<NfsModalComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        HttpClientTestingModule,
+        NoopAnimationsModule,
+        CoreModule,
+        TranslateModule.forRoot()
+      ],
+      providers: [
+        {
+          provide: MatDialogRef,
+          useValue: {}
+        }
+      ]
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(NfsModalComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/glass/src/app/core/modals/nfs/nfs-modal.component.ts
+++ b/src/glass/src/app/core/modals/nfs/nfs-modal.component.ts
@@ -1,0 +1,156 @@
+import { Component, OnInit } from '@angular/core';
+import { FormBuilder, FormGroup, ValidationErrors, ValidatorFn, Validators } from '@angular/forms';
+import { MatDialogRef } from '@angular/material/dialog';
+import { MatSliderChange } from '@angular/material/slider';
+import { marker as TEXT } from '@biesbjerg/ngx-translate-extract-marker';
+import * as _ from 'lodash';
+import { BlockUI, NgBlockUI } from 'ng-block-ui';
+import { finalize } from 'rxjs/operators';
+
+import {
+  CheckRequirementsReply,
+  Constraints,
+  CreateServiceReply,
+  ServicesService
+} from '~/app/shared/services/api/services.service';
+import { NotificationService } from '~/app/shared/services/notification.service';
+
+@Component({
+  selector: 'glass-nfs',
+  templateUrl: './nfs-modal.component.html',
+  styleUrls: ['./nfs-modal.component.scss']
+})
+export class NfsModalComponent implements OnInit {
+  @BlockUI()
+  blockUI!: NgBlockUI;
+
+  public formGroup: FormGroup;
+  public showWarning = false;
+  public showWarningText: string[] = [];
+
+  private constraints: Constraints | undefined = undefined;
+
+  constructor(
+    private dialogRef: MatDialogRef<NfsModalComponent>,
+    private formBuilder: FormBuilder,
+    private notification: NotificationService,
+    private services: ServicesService
+  ) {
+    this.formGroup = this.formBuilder.group({
+      availableSpace: [0],
+      reservedSpace: [0],
+      rawRequiredSpace: [0],
+      name: ['', [Validators.required]],
+      replicas: [
+        2,
+        [Validators.required, Validators.min(1), Validators.max(3), this.budgetValidator(this)]
+      ],
+      requiredSpace: [0, [Validators.required, Validators.min(1), this.budgetValidator(this)]]
+    });
+  }
+
+  ngOnInit(): void {
+    this.services.getConstraints().subscribe({
+      next: (constraints: Constraints) => {
+        this.formGroup.patchValue({
+          availableSpace: _.defaultTo(constraints.allocations.available, 0),
+          reservedSpace: _.defaultTo(constraints.allocations.allocated, 0)
+        });
+        this.constraints = constraints;
+        this.updateValues();
+      }
+    });
+  }
+
+  public onReplicasChange(event: MatSliderChange): void {
+    const replicas = !!event.value ? event.value : 0;
+    this.formGroup.patchValue({ replicas });
+    this.updateValues();
+  }
+
+  public onRequiredSpaceChange(event: MatSliderChange): void {
+    const requiredSpace = !!event.value ? event.value : 0;
+    this.formGroup.patchValue({ requiredSpace });
+    this.updateValues();
+  }
+
+  public onSubmit(): void {
+    if (this.formGroup.pristine || this.formGroup.invalid) {
+      return;
+    }
+    const values = this.formGroup.value;
+    this.blockUI.start(TEXT('Please wait, assessing service specifications ...'));
+    this.services
+      .checkRequirements(values.requiredSpace, values.replicas)
+      .pipe(finalize(() => this.blockUI.stop()))
+      .subscribe({
+        next: (result: CheckRequirementsReply) => {
+          if (!result.feasible) {
+            this.notification.show(TEXT('Service creation requirements not met.'), {
+              type: 'error'
+            });
+            return;
+          }
+          this.createService();
+        },
+        error: () => this.blockUI.stop()
+      });
+  }
+
+  private updateValues(): void {
+    const values = this.formGroup.value;
+    const rawRequiredSpace = values.requiredSpace * values.replicas;
+    this.formGroup.patchValue({ rawRequiredSpace });
+
+    this.showWarning = false;
+    this.showWarningText = [];
+    if (this.constraints) {
+      const maxReplicas = this.constraints.redundancy.max_replicas;
+      const numHosts = this.constraints.availability.hosts;
+      if (values.replicas > maxReplicas) {
+        this.showWarning = true;
+        this.showWarningText.push(
+          TEXT(`Current deployment can only guarantee ${maxReplicas} replicas.`)
+        );
+      }
+
+      if (numHosts === 1) {
+        this.showWarning = true;
+        this.showWarningText.push(
+          TEXT('Current deployment has a single host and can\'t tolerate failures.')
+        );
+      }
+    }
+  }
+
+  private createService(): void {
+    const values = this.formGroup.value;
+    this.blockUI.start(TEXT('Please wait, deploying NFS service ...'));
+    this.services
+      .create(values.name, 'nfs', values.requiredSpace, values.replicas)
+      .pipe(finalize(() => this.blockUI.stop()))
+      .subscribe({
+        next: (result: CreateServiceReply) => {
+          let success = false;
+          if (!result.success) {
+            this.notification.show(TEXT('Failed to create service.'), { type: 'error' });
+          } else {
+            this.notification.show(TEXT('Service successfully created.'));
+            success = true;
+          }
+          this.dialogRef.close(success);
+        }
+      });
+  }
+
+  private budgetValidator(parent: any): ValidatorFn {
+    return (): ValidationErrors | null => {
+      if (!parent?.formGroup?.value) {
+        return null;
+      }
+      const values = parent.formGroup.value;
+      const overBudget = values.rawRequiredSpace > values.availableSpace;
+      return overBudget ? { overBudget: true } : null;
+    };
+  }
+}

--- a/src/glass/src/app/pages/deployment-page/deployment-page.component.html
+++ b/src/glass/src/app/pages/deployment-page/deployment-page.component.html
@@ -64,16 +64,27 @@
         <mat-panel-title>NFS</mat-panel-title>
         <mat-panel-description>
           {{ 'Configure NFS service' | translate }}
-          <mat-icon *ngIf="!nfs"
-                    class="glass-color-accent"
-                    svgIcon="mdi:plus-circle-outline">
-          </mat-icon>
-          <mat-icon *ngIf="nfs"
-                    class="glass-color-primary"
-                    svgIcon="mdi:check-circle-outline">
+          <mat-icon class="glass-color-accent"
+                    svgIcon="mdi:plus-circle-outline"
+                    (click)="openNfsDialog()">
           </mat-icon>
         </mat-panel-description>
       </mat-expansion-panel-header>
+      <div *ngIf="nfsList.length === 0">
+        <span translate>No NFS services configured</span>
+      </div>
+
+      <div *ngIf="nfsList.length > 0"
+           fxLayout="column"
+           fxLayoutAlign="start start">
+        <div *ngFor="let service of nfsList"
+             fxLayout="row"
+             fxLayoutAlign="start center">
+          <mat-icon svgIcon="mdi:nas"></mat-icon>
+          <span>&nbsp;</span>
+          <span>{{ service.name }} ({{ service.reservation | bytesToSize }})</span>
+        </div>
+      </div>
     </mat-expansion-panel>
 
     <mat-expansion-panel>

--- a/src/glass/src/app/pages/deployment-page/deployment-page.component.ts
+++ b/src/glass/src/app/pages/deployment-page/deployment-page.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit, ViewChild } from '@angular/core';
 import { MatStepper } from '@angular/material/stepper';
 import { marker as TEXT } from '@biesbjerg/ngx-translate-extract-marker';
+import _ from 'lodash';
 import { BlockUI, NgBlockUI } from 'ng-block-ui';
 
 import { translate } from '~/app/i18n.helper';
@@ -28,7 +29,6 @@ export class DeploymentPageComponent implements OnInit {
   @BlockUI()
   blockUI!: NgBlockUI;
 
-  nfs = false;
   devices: Device[] = [];
   devicesColumns: DatatableColumn[] = [
     {
@@ -65,6 +65,7 @@ export class DeploymentPageComponent implements OnInit {
   deploymentSuccessful = true;
 
   public cephfsList: ServiceDesc[] = [];
+  public nfsList: ServiceDesc[] = [];
 
   constructor(
     private dialog: DialogService,
@@ -77,11 +78,7 @@ export class DeploymentPageComponent implements OnInit {
 
   ngOnInit(): void {
     this.getDevices();
-    this.updateCephfsList();
-  }
-
-  addNfs(): void {
-    this.nfs = true;
+    this.updateServicesLists();
   }
 
   getDevices(): void {
@@ -161,10 +158,18 @@ export class DeploymentPageComponent implements OnInit {
       );
   }
 
+  public openNfsDialog(): void {
+    this.dialog.openNfs((result) => {
+      if (result) {
+        this.updateServicesLists(['nfs']);
+      }
+    });
+  }
+
   public openCephfsDialog(): void {
     this.dialog.openCephfs((result) => {
       if (result) {
-        this.updateCephfsList();
+        this.updateServicesLists(['cephfs']);
       }
     });
   }
@@ -181,11 +186,20 @@ export class DeploymentPageComponent implements OnInit {
     });
   }
 
-  private updateCephfsList(): void {
-    this.services.list().subscribe({
-      next: (result: ServiceDesc[]) => {
-        this.cephfsList = result;
-      }
+  private updateServicesLists(serviceTypes: string[] = ['cephfs', 'nfs']): void {
+    this.services.list().subscribe((result: ServiceDesc[]) => {
+      serviceTypes.forEach((serviceType) => {
+        switch (serviceType) {
+          case 'cephfs': {
+            this.cephfsList = _.filter(result, { type: 'cephfs' });
+            break;
+          }
+          case 'nfs': {
+            this.nfsList = _.filter(result, { type: 'nfs' });
+            break;
+          }
+        }
+      });
     });
   }
 

--- a/src/glass/src/app/pages/services-page/services-page.component.html
+++ b/src/glass/src/app/pages/services-page/services-page.component.html
@@ -25,4 +25,8 @@
           (click)="onAddService('cephfs')">
     <span translate>CephFS Service</span>
   </button>
+  <button mat-menu-item
+          (click)="onAddService('nfs')">
+    <span translate>NFS Service</span>
+  </button>
 </mat-menu>

--- a/src/glass/src/app/pages/services-page/services-page.component.ts
+++ b/src/glass/src/app/pages/services-page/services-page.component.ts
@@ -68,6 +68,13 @@ export class ServicesPageComponent implements OnInit {
           }
         });
         break;
+      case 'nfs':
+        this.dialog.openNfs((res) => {
+          if (res) {
+            this.loadData();
+          }
+        });
+        break;
     }
   }
 

--- a/src/glass/src/app/shared/services/dialog.service.ts
+++ b/src/glass/src/app/shared/services/dialog.service.ts
@@ -3,6 +3,7 @@ import { Injectable } from '@angular/core';
 import { MatDialog, MatDialogConfig } from '@angular/material/dialog';
 
 import { CephfsModalComponent } from '~/app/core/modals/cephfs/cephfs-modal.component';
+import { NfsModalComponent } from '~/app/core/modals/nfs/nfs-modal.component';
 
 @Injectable({
   providedIn: 'root'
@@ -14,6 +15,10 @@ export class DialogService {
 
   openCephfs(onClose: (result: boolean) => void): void {
     this.open(CephfsModalComponent, onClose);
+  }
+
+  openNfs(onClose: (result: boolean) => void): void {
+    this.open(NfsModalComponent, onClose);
   }
 
   open(


### PR DESCRIPTION
- glass: add NFS component: Add the component itself and to the dialog service in addition. It's more or less the content of the CephFS dialog at the moment. I would like to take it as a starting point and refactor/extract duplicated content step by step later.
- glass: add NFS component to the installer
- glass: add NFS component to services page

Signed-off-by: Tatjana Dehler <tdehler@suse.com>