### PR TITLE
tools: Add Makefile for building dist tarball

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,4 @@ tests/vagrant/deployments/
 .vagrant/
 .idea/
 conf/
-
+*.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,32 @@
+# The version needs an annotated tag in the git repo in the form vX.Y.Z.
+# If such is not present, fall back to using v0.0.0 so we get a non-empty
+# version string.
+VERSION=$(shell (git describe --match 'v*' --long 2>/dev/null || echo 'v0.0.0') | sed 's/^v//')
+
+usage:
+	@echo "Try running \`make dist\` to build a tarball"
+
+submodules:
+	git submodule update --init
+
+glass:
+	cd src/glass && npm install && npx ng build --prod --output-hashing=all
+
+dist: submodules glass
+	$(eval TMPDIR := $(shell mktemp -d))
+	$(eval TAR_BASE := $(TMPDIR)/aquarium-$(VERSION))
+	$(eval TAR_USR := $(TAR_BASE)/usr/share/aquarium)
+	$(eval TAR_UNIT := $(TAR_BASE)/usr/lib/systemd/system)
+	$(eval TAR_SBIN := $(TAR_BASE)/usr/sbin)
+	mkdir -p $(TAR_USR) $(TAR_UNIT) $(TAR_SBIN)
+	# Copy gravel, glass, aquarium.py and cephadm from src/...
+	cd src && \
+	find gravel -iname '*ceph.git*' -prune -false -o -iname '*.py' | \
+		xargs cp --parents --target-directory=$(TAR_USR) && \
+	cp --target-directory=$(TAR_USR) ./aquarium.py && \
+	cp -R --parents --target-directory=$(TAR_USR) glass/dist && \
+	cp --target-directory=$(TAR_SBIN) ./gravel/ceph.git/src/cephadm/cephadm
+	# Copy aquarium service
+	cp systemd/aquarium.service $(TAR_UNIT)
+	tar -czf aquarium-$(VERSION).tar.gz -C $(TMPDIR) aquarium-$(VERSION)
+	rm -r $(TMPDIR)

--- a/images/microOS/config.xml
+++ b/images/microOS/config.xml
@@ -608,7 +608,7 @@
         <package name="python3-requests"/>
         <package name="python3-rados"/>
         <package name="python3-websockets"/>
-        <archive name="aquarium.tar"/>
+        <archive name="aquarium.tar.gz"/>
     </packages>
 
     <packages type="image" profiles="kvm-and-xen,kvm-and-xen_x86_64,kvm-and-xen_aarch64,VMware,MS-HyperV,VirtualBox,Pine64,RaspberryPi,RaspberryPi2,Vagrant_x86_64,Vagrant_aarch64">

--- a/tools/setup-dev.sh
+++ b/tools/setup-dev.sh
@@ -4,6 +4,7 @@ dependencies_opensuse_tumbleweed=(
   "btrfsprogs"
   "git"
   "kpartx"
+  "make"
   "python3"
   "python3-rados"
   "python3-kiwi"
@@ -17,6 +18,7 @@ dependencies_opensuse_tumbleweed=(
 dependencies_debian=(
   "btrfs-progs"
   "git"
+  "make"
   "python3"
   "python3-pip"
   "python3-rados"
@@ -31,6 +33,7 @@ dependencies_debian=(
 dependencies_ubuntu=(
   "btrfs-progs"
   "git"
+  "make"
   "python3"
   "python3-pip"
   "python3-rados"


### PR DESCRIPTION
I've added a Makefile with a `dist` target, so you can now run `make dist` to get a tarball named something like aquarium-0.1.0-0-g2b6942a.tar.gz, which includes a built glass and all the necessary bits of gravel.

This doesn't change the current dev workflow at all.  You still build an image by running `./tools/build-image.sh`, but that script will in turn call `make dist` to get a tarball to install in the image.

Note: the version string used in the tarball name is based on the latest annotated tag in the form 'vX.Y.Z', which means I've suddenly introduced the notion of version numbers and releases to the project.  Until such time as an actual release is tagged, the version will default to v0.0.0, just to have the build working.

Fixes: https://github.com/aquarist-labs/aquarium/issues/277
Signed-off-by: Tim Serong <tserong@suse.com>