### PR TITLE
glass: Enhance declarative form modal

### DIFF
--- a/src/glass/src/app/core/modals/declarative-form/declarative-form-modal.component.html
+++ b/src/glass/src/app/core/modals/declarative-form/declarative-form-modal.component.html
@@ -16,7 +16,7 @@
                autocapitalize="none"
                [formControlName]="field.name"
                [readonly]="field.readonly">
-        <mat-icon *ngIf="field.type === 'password'"
+        <mat-icon *ngIf="field.hasCopyToClipboardButton"
                   matSuffix
                   mat-ripple
                   svgIcon="mdi:content-copy"

--- a/src/glass/src/app/core/modals/declarative-form/declarative-form-modal.component.ts
+++ b/src/glass/src/app/core/modals/declarative-form/declarative-form-modal.component.ts
@@ -28,6 +28,7 @@ export class DeclarativeFormModalComponent {
     private notificationService: NotificationService,
     @Inject(MAT_DIALOG_DATA) data: DeclarativeFormConfig
   ) {
+    // Sanitize the configuration.
     this.config = _.defaultsDeep(data, {
       fields: [],
       okButtonVisible: true,
@@ -35,6 +36,20 @@ export class DeclarativeFormModalComponent {
       cancelButtonVisible: true,
       cancelButtonText: TEXT('Cancel'),
       cancelButtonResult: false
+    });
+    _.forEach(this.config.fields, (field: FormFieldConfig) => {
+      switch (field.type) {
+        case 'password':
+          _.defaultsDeep(field, {
+            hasCopyToClipboardButton: true
+          });
+          break;
+        default:
+          _.defaultsDeep(field, {
+            hasCopyToClipboardButton: false
+          });
+          break;
+      }
     });
     this.formGroup = this.createForm();
   }

--- a/src/glass/src/app/pages/hosts-page/hosts-page.component.ts
+++ b/src/glass/src/app/pages/hosts-page/hosts-page.component.ts
@@ -60,7 +60,8 @@ export class HostsPageComponent {
               type: 'text',
               name: 'token',
               value: res.token,
-              readonly: true
+              readonly: true,
+              hasCopyToClipboardButton: true
             }
           ],
           okButtonVisible: false,

--- a/src/glass/src/app/shared/models/declarative-form-config.type.ts
+++ b/src/glass/src/app/shared/models/declarative-form-config.type.ts
@@ -6,6 +6,9 @@ export type FormFieldConfig = {
   readonly?: boolean;
   required?: boolean;
   hint?: string;
+
+  // text | password
+  hasCopyToClipboardButton?: boolean;
 };
 
 export type DeclarativeFormConfig = {


### PR DESCRIPTION
Add 'hasCopyToClipboardButton' property. It is used by the 'text' and 'password' fields.

Signed-off-by: Volker Theile <vtheile@suse.com>