### PR TITLE
glass: service capacity gets weird on 0.0% occupation

### DIFF
--- a/src/glass/src/app/core/dashboard/widgets/services-capacity-dashboard-widget/services-capacity-dashboard-widget.component.ts
+++ b/src/glass/src/app/core/dashboard/widgets/services-capacity-dashboard-widget/services-capacity-dashboard-widget.component.ts
@@ -26,7 +26,10 @@ export class ServicesCapacityDashboardWidgetComponent {
           result.push(serviceStorage);
         });
         _.orderBy(result, ['utilization'], ['desc']);
-        return _.take(result, 5);
+        return _.map(_.take(result, 5), (record) => {
+          record.utilization = parseFloat(record.utilization.toFixed(2));
+          return record;
+        });
       })
     );
   }


### PR DESCRIPTION
Utilizations of 0.000006287751370776091 and 0.00004227160129839737 will be rendered as 2 bar charts with different length. This looks weird because effective the value is 0%. Because of that the 'utilization' property will be rounded to 2 decimal places.

Fixes: https://github.com/aquarist-labs/aquarium/issues/383

Signed-off-by: Volker Theile <vtheile@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [issue id or URL on https://github.com/aquarist-labs/aquarium/issues, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The component is the short name of a major module or subsystem, something 
like "tools", "gravel", "glass", "doc", etc.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://github.com/aquarist-labs/aquarium/blob/main/CONTRIBUTING.md

-->

## Checklist
- [x] References issues, create if required
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test tumbleweed`
- `jenkins run tumbleweed`
- `jenkins test leap`
- `jenkins run leap`

</details>
