### PR TITLE
gravel: add etcd

### DIFF
--- a/images/microOS/config.sh
+++ b/images/microOS/config.sh
@@ -174,7 +174,7 @@ EOF
 fi
 
 if [[ "$kiwi_profiles" == *"Ceph"* ]]; then
-  pip install fastapi uvicorn
+  pip install fastapi uvicorn aetcd3
   baseInsertService aquarium
 fi
 

--- a/images/microOS/config.sh
+++ b/images/microOS/config.sh
@@ -174,7 +174,8 @@ EOF
 fi
 
 if [[ "$kiwi_profiles" == *"Ceph"* ]]; then
-  pip install fastapi uvicorn aetcd3
+  pip install fastapi uvicorn \
+    https://celeuma.wipwd.dev/aqr/aetcd3/aetcd3-0.1.0a5.dev2+g0aa852e.d20210410-py3-none-any.whl
   baseInsertService aquarium
 fi
 

--- a/images/microOS/config.xml
+++ b/images/microOS/config.xml
@@ -608,6 +608,8 @@
         <package name="python3-requests"/>
         <package name="python3-rados"/>
         <package name="python3-websockets"/>
+        <package name="etcd"/>
+        <package name="etcdctl"/>
         <archive name="aquarium.tar.gz"/>
     </packages>
 

--- a/src/aquarium.py
+++ b/src/aquarium.py
@@ -89,7 +89,7 @@ async def on_startup():
     logger.info("Aquarium startup!")
 
     # init node mgr
-    mgr.init_node_mgr()
+    await mgr.init_node_mgr()
 
     # create a task simply so we don't hold up the startup
     asyncio.create_task(gstate.start())
@@ -99,6 +99,7 @@ async def on_startup():
 @app.on_event("shutdown")  # type: ignore
 async def on_shutdown():
     await gstate.shutdown()
+    await mgr.shutdown()
 
 
 api.include_router(local.router)

--- a/src/aquarium.py
+++ b/src/aquarium.py
@@ -98,6 +98,7 @@ async def on_startup():
 
 @app.on_event("shutdown")  # type: ignore
 async def on_shutdown():
+    logger.info("Aquarium shutdown!")
     await gstate.shutdown()
     await mgr.shutdown()
 

--- a/src/gravel/api/services.py
+++ b/src/gravel/api/services.py
@@ -24,7 +24,6 @@ from gravel.controllers.orch.cephfs import (
     CephFSNoAuthorizationError
 )
 from gravel.controllers.orch.models import CephFSAuthorizationModel
-
 from gravel.controllers.services import (
     ConstraintsModel,
     NotEnoughSpaceError,
@@ -33,8 +32,8 @@ from gravel.controllers.services import (
     ServiceRequirementsModel,
     ServiceStorageModel,
     ServiceTypeEnum,
-    Services,
-    UnknownServiceError
+    UnknownServiceError,
+    get_services_ctrl
 )
 
 
@@ -72,13 +71,13 @@ class CreateResponse(BaseModel):
     response_model=ConstraintsModel
 )
 async def get_constraints() -> ConstraintsModel:
-    services = Services()
+    services = get_services_ctrl()
     return services.constraints
 
 
 @router.get("/", response_model=List[ServiceModel])
 async def get_services() -> List[ServiceModel]:
-    services = Services()
+    services = get_services_ctrl()
     return services.ls()
 
 
@@ -86,7 +85,7 @@ async def get_services() -> List[ServiceModel]:
             name="Get service by name",
             response_model=ServiceModel)
 async def get_service(service_name: str) -> ServiceModel:
-    services = Services()
+    services = get_services_ctrl()
     try:
         return services.get(service_name)
     except UnknownServiceError as e:
@@ -108,7 +107,7 @@ async def check_requirements(
             detail="requires positive 'size' and number of 'replicas'"
         )
 
-    services = Services()
+    services = get_services_ctrl()
     feasible, reqs = services.check_requirements(size, replicas)
     return RequirementsResponse(feasible=feasible, requirements=reqs)
 
@@ -116,7 +115,7 @@ async def check_requirements(
 @router.post("/create", response_model=CreateResponse)
 async def create_service(req: CreateRequest) -> CreateResponse:
 
-    services = Services()
+    services = get_services_ctrl()
     try:
         services.create(req.name, req.type, req.size, req.replicas)
     except NotImplementedError as e:
@@ -144,7 +143,7 @@ async def get_statistics() -> Dict[str, ServiceStorageModel]:
     allocated space for said service and how much space is being used, along
     with the service's space utilization.
     """
-    services = Services()
+    services = get_services_ctrl()
     return services.get_stats()
 
 

--- a/src/gravel/api/services.py
+++ b/src/gravel/api/services.py
@@ -118,7 +118,7 @@ async def create_service(req: CreateRequest) -> CreateResponse:
 
     services = get_services_ctrl()
     try:
-        services.create(req.name, req.type, req.size, req.replicas)
+        await services.create(req.name, req.type, req.size, req.replicas)
     except NotImplementedError as e:
         raise HTTPException(status.HTTP_501_NOT_IMPLEMENTED,
                             detail=str(e))

--- a/src/gravel/controllers/config.py
+++ b/src/gravel/controllers/config.py
@@ -44,6 +44,10 @@ class StatusOptionsModel(BaseModel):
     probe_interval: float = Field(1.0, title="Status Probe Interval")
 
 
+class ServicesOptionsModel(BaseModel):
+    probe_interval: float = Field(1.0, title="Services Probe Interval")
+
+
 class OptionsModel(BaseModel):
     service_state_path: Path = Field(Path(config_dir).joinpath("storage.json"),
                                      title="Path to Service State file")
@@ -51,6 +55,7 @@ class OptionsModel(BaseModel):
     storage: StorageOptionsModel = Field(StorageOptionsModel())
     devices: DevicesOptionsModel = Field(DevicesOptionsModel())
     status: StatusOptionsModel = Field(StatusOptionsModel())
+    services: ServicesOptionsModel = Field(ServicesOptionsModel())
 
 
 class ConfigModel(BaseModel):

--- a/src/gravel/controllers/gstate.py
+++ b/src/gravel/controllers/gstate.py
@@ -102,6 +102,9 @@ class Ticker(ABC):
         self._is_ticking = False
         self._last_tick = time.monotonic()
 
+    async def shutdown(self) -> None:
+        pass
+
 
 class GlobalState:
 
@@ -140,11 +143,17 @@ class GlobalState:
             await self._do_ticks()
 
         logger.info("tick shutting down")
+        await self._shutdown_tickers()
 
     async def _do_ticks(self) -> None:
         for desc, ticker in self.tickers.items():
             logger.debug(f"tick {desc}")
             asyncio.create_task(ticker.tick())
+
+    async def _shutdown_tickers(self) -> None:
+        for desc, ticker in self.tickers.items():
+            logger.debug(f"shutdown ticker {desc}")
+            await ticker.shutdown()
 
     def add_ticker(self, desc: str, whom: Ticker) -> None:
         if desc not in self.tickers:

--- a/src/gravel/controllers/kv.py
+++ b/src/gravel/controllers/kv.py
@@ -1,0 +1,122 @@
+# project aquarium's backend
+# Copyright (C) 2021 SUSE, LLC.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+import asyncio
+from typing import Callable, Optional
+import aetcd3
+import aetcd3.locks
+import aetcd3.events
+import grpclib.exceptions
+
+from logging import Logger
+from fastapi.logger import logger as fastapi_logger
+
+logger: Logger = fastapi_logger
+
+
+class Lock:
+    _lock: aetcd3.locks.Lock
+    _is_acquired: bool
+
+    def __init__(self, lock: aetcd3.locks.Lock):
+        self._lock = lock
+        self._is_acquired = False
+
+    async def acquire(self) -> None:
+        await self._lock.acquire()
+        self._is_acquired = True
+
+    async def release(self) -> None:
+        if not self._is_acquired:
+            return
+        await self._lock.release()
+        self._is_acquired = False
+
+
+class KV:
+
+    _client: Optional[aetcd3.Etcd3Client]
+    _is_closing: bool
+
+    def __init__(self):
+        self._client = None
+        self._is_open = False
+        self._is_closing = False
+
+    async def ensure_connection(self) -> None:
+        """ Open k/v store connection """
+        # try getting the status, loop until we make it.
+        opened = False
+        while not self._is_closing:
+            try:
+                async with aetcd3.client() as client:
+                    await client.status()
+            except Exception:
+                logger.warn("etcd not up yet? sleep.")
+                await asyncio.sleep(1.0)
+                continue
+            opened = True
+            break
+        if opened:
+            self._client = aetcd3.client()
+            logger.info("opened kvstore connection")
+
+    async def close(self) -> None:
+        """ Close k/v store connection """
+        self._is_closing = True
+        if not self._client:
+            return
+        await self._client.close()
+        self._client = None
+
+    async def put(self, key: str, value: str) -> None:
+        """ Put key/value pair """
+        assert self._client
+        await self._client.put(key, value)
+
+    async def get(self, key: str) -> str:
+        """ Get value for provided key """
+        assert self._client
+        value, _ = await self._client.get(key)
+        return value.decode("utf-8")
+
+    async def rm(self, key: str) -> None:
+        """ Remove key from store """
+        assert self._client
+        await self._client.delete(key)
+
+    async def lock(self, key: str) -> Lock:
+        """ Lock a given key. Requires compliant consumers. """
+        assert self._client
+        return Lock(self._client.lock(key))
+
+    async def watch(
+        self,
+        key: str,
+        callback: Callable[[str, str], None]
+    ) -> int:
+        """ Watch updates on a given key """
+        assert self._client
+
+        async def _cb(what: aetcd3.events.Event) -> None:
+            if not what or \
+               type(what) == grpclib.exceptions.StreamTerminatedError:
+                return
+            callback(what.key.decode("utf-8"), what.value.decode("utf-8"))
+
+        return await self._client.add_watch_callback(key, _cb)
+
+    async def cancel_watch(self, watch_id: int) -> None:
+        """ Cancel a watch """
+        assert self._client
+        await self._client.cancel_watch(watch_id)

--- a/src/gravel/controllers/kv.py
+++ b/src/gravel/controllers/kv.py
@@ -84,10 +84,12 @@ class KV:
         assert self._client
         await self._client.put(key, value)
 
-    async def get(self, key: str) -> str:
+    async def get(self, key: str) -> Optional[str]:
         """ Get value for provided key """
         assert self._client
         value, _ = await self._client.get(key)
+        if not value:
+            return None
         return value.decode("utf-8")
 
     async def rm(self, key: str) -> None:

--- a/src/gravel/controllers/nodes/messages.py
+++ b/src/gravel/controllers/nodes/messages.py
@@ -41,6 +41,7 @@ class WelcomeMessageModel(BaseModel):
     pubkey: str
     cephconf: str
     keyring: str
+    etcd_peer: str
 
 
 class ReadyToAddMessageModel(BaseModel):

--- a/src/gravel/controllers/nodes/mgr.py
+++ b/src/gravel/controllers/nodes/mgr.py
@@ -591,6 +591,10 @@ class NodeMgr:
         return self._init_stage >= NodeInitStage.PRESTART
 
     @property
+    def started(self) -> bool:
+        return self._init_stage == NodeInitStage.STARTED
+
+    @property
     def stage(self) -> NodeStageEnum:
         assert self._state
         return self._state.stage

--- a/src/gravel/controllers/nodes/mgr.py
+++ b/src/gravel/controllers/nodes/mgr.py
@@ -184,7 +184,7 @@ class NodeMgr:
         else:
             assert self._state.stage == NodeStageEnum.READY or \
                 self._state.stage == NodeStageEnum.BOOTSTRAPPED
-            self._spawn_etcd(new=False, token=None)
+            await self._spawn_etcd(new=False, token=None)
             await self._node_start()
 
     async def shutdown(self) -> None:
@@ -339,7 +339,7 @@ class NodeMgr:
         my_url: str = \
             f"{self._state.hostname}=http://{self._state.address}:2380"
         initial_cluster: str = f"{welcome.etcd_peer},{my_url}"
-        self._spawn_etcd(
+        await self._spawn_etcd(
             new=False,
             token=None,
             initial_cluster=initial_cluster
@@ -416,7 +416,7 @@ class NodeMgr:
             logger.error(f"bootstrap error: {e.message}")
             raise NodeCantBootstrapError(e.message)
 
-    def _spawn_etcd(
+    async def _spawn_etcd(
         self,
         new: bool,
         token: Optional[str],
@@ -462,8 +462,8 @@ class NodeMgr:
         )
         process.start()
 
-    def _bootstrap_etcd(self, token: str) -> None:
-        self._spawn_etcd(new=True, token=token)
+    async def _bootstrap_etcd(self, token: str) -> None:
+        await self._spawn_etcd(new=True, token=token)
 
     async def _prepare_bootstrap(self) -> None:
         assert self._state
@@ -477,7 +477,7 @@ class NodeMgr:
         self._token = self._generate_token()
         await self._save_token(should_exist=False)
         logger.info(f"generated new token: {self._token}")
-        self._bootstrap_etcd(self._token)
+        await self._bootstrap_etcd(self._token)
 
     async def _start_bootstrap(self) -> None:
         assert self._state

--- a/src/gravel/controllers/nodes/mgr.py
+++ b/src/gravel/controllers/nodes/mgr.py
@@ -510,6 +510,14 @@ class NodeMgr:
         if not res:
             logger.error("unable to set default ruleset")
 
+        res = mon.config_set(
+            "mgr",
+            "mgr/cephadm/manage_etc_ceph_ceph_conf",
+            "true"
+        )
+        if not res:
+            logger.error("unable to enable managed ceph.conf by cephadm")
+
     @property
     def bootstrapper_stage(self) -> BootstrapStage:
         if not self._bootstrapper:

--- a/src/gravel/controllers/nodes/mgr.py
+++ b/src/gravel/controllers/nodes/mgr.py
@@ -169,9 +169,11 @@ class NodeMgr:
         multiprocessing.set_start_method("spawn")
 
         self._node_init()
+
+    async def start(self) -> None:
         assert self._state
 
-        logger.debug(f"init > {self._state}")
+        logger.debug(f"start > {self._state}")
 
         assert self._state.stage == NodeStageEnum.NONE or \
             self._state.stage == NodeStageEnum.BOOTSTRAPPED or \
@@ -184,6 +186,9 @@ class NodeMgr:
                 self._state.stage == NodeStageEnum.BOOTSTRAPPED
             self._spawn_etcd(new=False, token=None)
             self._node_start()
+
+    async def shutdown(self) -> None:
+        pass
 
     def _node_init(self) -> None:
         statefile: Path = self._get_node_file("node")
@@ -829,7 +834,17 @@ def get_node_mgr() -> NodeMgr:
     return _nodemgr
 
 
-def init_node_mgr() -> None:
+async def init_node_mgr() -> None:
     global _nodemgr
     assert not _nodemgr
+    logger.info("starting node manager")
     _nodemgr = NodeMgr()
+    await _nodemgr.start()
+
+
+async def shutdown() -> None:
+    global _nodemgr
+    if _nodemgr:
+        logger.info("shutting down node manager")
+        await _nodemgr.shutdown()
+        _nodemgr = None

--- a/src/gravel/controllers/nodes/mgr.py
+++ b/src/gravel/controllers/nodes/mgr.py
@@ -209,6 +209,13 @@ class NodeMgr:
 
         get_inventory().subscribe(_subscriber, once=True)
 
+    def _generate_token(self) -> str:
+        def gen() -> str:
+            return ''.join(random.choice("0123456789abcdef") for _ in range(4))
+
+        tokenstr = '-'.join(gen() for _ in range(4))
+        return tokenstr
+
     async def join(self, leader_address: str, token: str) -> bool:
         logger.debug(
             f"join > with leader {leader_address}, token: {token}"
@@ -381,14 +388,10 @@ class NodeMgr:
         self._state.role = NodeRoleEnum.LEADER
         self._save_state()
 
-        def gen() -> str:
-            return ''.join(random.choice("0123456789abcdef") for _ in range(4))
-
-        tokenstr = '-'.join(gen() for _ in range(4))
-        self._token = tokenstr
+        self._token = self._generate_token()
         self._save_token(should_exist=False)
 
-        logger.debug(f"finished bootstrap: token = {tokenstr}")
+        logger.debug(f"finished bootstrap: token = {self._token}")
 
         self._load()
         self._node_start()

--- a/src/gravel/controllers/nodes/mgr.py
+++ b/src/gravel/controllers/nodes/mgr.py
@@ -635,6 +635,11 @@ class NodeMgr:
     def token(self) -> Optional[str]:
         return self._token
 
+    @property
+    def store(self) -> KV:
+        assert self._kvstore
+        return self._kvstore
+
     async def _obtain_state(self) -> None:
         assert self._kvstore
 

--- a/src/gravel/controllers/resources/status.py
+++ b/src/gravel/controllers/resources/status.py
@@ -38,7 +38,8 @@ from gravel.controllers.nodes.mgr import (
 )
 from gravel.controllers.services import (
     ServiceTypeEnum,
-    Services
+    Services,
+    get_services_ctrl
 )
 
 
@@ -121,7 +122,7 @@ class Status(Ticker):
             raise ClientIORateNotAvailableError()
 
         services_rates: List[ServiceIORateModel] = []
-        services: Services = Services()
+        services: Services = get_services_ctrl()
         for service in services.ls():
             svc_name: str = service.name
             svc_type: ServiceTypeEnum = service.type

--- a/src/gravel/typings/aetcd3/__init__.pyi
+++ b/src/gravel/typings/aetcd3/__init__.pyi
@@ -1,0 +1,21 @@
+# ignore because we're not using it: from . import etcdrpc
+from .client import (
+    Etcd3Client,
+    Transactions,
+    client
+)
+from .exceptions import Etcd3Exception  # type: ignore
+from .leases import Lease  # type: ignore
+from .locks import Lock
+from .members import Member  # type: ignore
+
+__all__ = (
+    'Etcd3Client',
+    'Etcd3Exception',
+    'Lease',
+    'Lock',
+    'Member',
+    'Transactions',
+    'client',
+    # 'etcdrpc',
+)

--- a/src/gravel/typings/aetcd3/client.pyi
+++ b/src/gravel/typings/aetcd3/client.pyi
@@ -1,0 +1,248 @@
+# project aquarium's backend
+# Copyright (C) 2021 SUSE, LLC.
+
+# pyright: reportMissingTypeStubs=false
+from typing import (
+    Any,
+    AsyncIterator,
+    Awaitable,
+    Callable,
+    Dict,
+    Generator,
+    IO,
+    List,
+    Optional,
+    Tuple,
+    Union
+)
+
+from aetcd3.etcdrpc.rpc_pb2 import (
+    Compare,
+    DeleteRangeResponse,
+    LeaseKeepAliveResponse,
+    LeaseRevokeResponse,
+    LeaseTimeToLiveResponse,
+    PutResponse,
+    RequestOp,
+    ResponseOp
+)
+from aetcd3.events import Event
+from aetcd3.leases import Lease
+from aetcd3.locks import Lock
+from aetcd3.members import Member
+
+
+class Transactions:
+    ...
+
+
+class KVMetadata:
+    key: bytes
+    create_revision: int
+    mod_revision: int
+    version: int
+    lease_id: int
+    ...
+
+
+class Status:
+    ...
+
+
+class Alarm:
+    ...
+
+
+class Etcd3Client:
+
+    def __init__(
+        self,
+        host: str = ...,
+        port: int = ...,
+        ca_cert: Optional[str] = ...,
+        cert_key: Optional[str] = ...,
+        cert_cert: Optional[str] = ...,
+        timeout: Optional[float] = ...,
+        user: Optional[str] = ...,
+        password: Optional[str] = ...,
+        gprc_options: Dict[Any, Any] = ...
+    ) -> None:
+        ...
+
+    async def open(self) -> None: ...
+    async def close(self) -> None: ...
+
+    async def __aenter__(self) -> Any:
+        ...
+
+    async def __aexit__(self, *args: Any) -> Any:
+        ...
+
+    async def get(
+        self,
+        key: str,
+        serializable: bool = ...
+    ) -> Tuple[bytes, KVMetadata]: ...
+
+    async def get_prefix(
+        self,
+        key_prefix: str,
+        sort_order: Optional[str] = ...,
+        sort_target: str = ...,
+        keys_only: bool = ...
+    ) -> Generator[Tuple[bytes, KVMetadata], None, None]:
+        ...
+
+    async def get_range(
+        self,
+        range_start: str,
+        range_end: str,
+        sort_order: Optional[str] = ...,
+        sort_target: str = ...,
+        **kwargs: Any
+    ) -> Generator[Tuple[bytes, KVMetadata], None, None]:
+        ...
+
+    async def get_all(
+        self,
+        sort_order: Optional[str] = ...,
+        sort_target: Optional[str] = ...,
+        keys_only: bool = ...
+    ) -> Generator[Tuple[bytes, KVMetadata], None, None]:
+        ...
+    ...
+
+    async def put(
+        self,
+        key: str,
+        value: Union[bytes, str],
+        lease: Optional[Union[Lease, int]] = ...,
+        prev_kv: bool = ...
+    ) -> PutResponse:
+        ...
+
+    async def replace(
+        self,
+        key: str,
+        initial_value: Union[bytes, str],
+        new_value: Union[bytes, str]
+    ) -> bool:
+        ...
+
+    async def delete(
+        self,
+        key: str,
+        prev_kv: bool = ...,
+        return_response: bool = ...
+    ) -> Union[bool, DeleteRangeResponse]:
+        ...
+
+    async def delete_prefix(self, prefix: str) -> DeleteRangeResponse: ...
+    async def status(self) -> Status: ...
+
+    async def add_watch_callback(
+        self,
+        key: str,
+        callback: Callable[[Event], Awaitable[None]],
+        **kwargs: Any
+    ) -> int:
+        ...
+
+    async def watch(
+        self,
+        key: str,
+        **kwargs: Any
+    ) -> Tuple[AsyncIterator[Event], Awaitable[None]]:
+        ...
+
+    async def watch_prefix(
+        self,
+        key_prefix: str,
+        **kwargs: Any
+    ) -> Tuple[AsyncIterator[Event], Awaitable[None]]:
+        ...
+
+    async def watch_once(
+        self,
+        key: str,
+        timeout: Optional[float] = ...,
+        **kwargs: Any
+    ) -> Any:
+        ...
+
+    async def watch_prefix_once(
+        self,
+        key_prefix: str,
+        timeout: Optional[float] = ...,
+        **kwargs: Any
+    ) -> Any:
+        ...
+
+    async def cancel_watch(
+        self,
+        watch_id: int
+    ) -> None:
+        ...
+
+    async def transaction(
+        self,
+        compare: List[Compare],
+        success: Optional[List[RequestOp]] = ...,
+        failure: Optional[List[RequestOp]] = ...
+    ) -> Tuple[bool, List[ResponseOp]]:
+        ...
+
+    async def lease(self, ttl: int, id: int) -> Lease: ...
+    async def revoke_lease(self, lease_id: int) -> LeaseRevokeResponse: ...
+    async def refresh_lease(self, lease_id: int) -> LeaseKeepAliveResponse: ...
+
+    async def get_lease_info(
+        self,
+        lease_id: int,
+        *,
+        keys: bool = ...
+    ) -> LeaseTimeToLiveResponse:
+        ...
+
+    def lock(self, name: str, ttl: int = ...) -> Lock: ...
+
+    async def add_member(self, urls: List[str]) -> Member: ...
+    async def remove_member(self, member_id: int) -> None: ...
+
+    async def update_member(
+        self,
+        member_id: int,
+        peer_urls: List[str]
+    ) -> None: ...
+
+    async def members(self) -> Generator[Member, None, None]: ...
+    async def compact(self, revision: int, physical: bool = ...) -> None: ...
+    async def defragment(self) -> None: ...
+    async def hash(self) -> int: ...
+    async def create_alarm(self, member_id: int = ...) -> List[Alarm]: ...
+
+    async def list_alarms(
+        self,
+        member_id: int,
+        alarm_type: str = ...
+    ) -> Generator[Alarm, None, None]:
+        ...
+
+    async def disarm_alarm(self, member_id: int = ...) -> List[Alarm]: ...
+    async def snapshot(self, file_obj: IO[bytes]) -> None: ...
+
+    ...
+
+
+def client(
+    host: str = ...,
+    port: int = ...,
+    ca_cert: Optional[str] = ...,
+    cert_key: Optional[str] = ...,
+    timeout: Optional[float] = ...,
+    cert_cert: Optional[str] = ...,
+    user: Optional[str] = ...,
+    password: Optional[str] = ...,
+    **kwargs: Any
+) -> Etcd3Client:
+    ...

--- a/src/gravel/typings/aetcd3/events.pyi
+++ b/src/gravel/typings/aetcd3/events.pyi
@@ -1,0 +1,7 @@
+# project aquarium's backend
+# Copyright (C) 2021 SUSE, LLC.
+
+class Event:
+
+    key: bytes
+    value: bytes

--- a/src/gravel/typings/aetcd3/locks.pyi
+++ b/src/gravel/typings/aetcd3/locks.pyi
@@ -1,0 +1,23 @@
+# project aquarium's backend
+# Copyright (C) 2021 SUSE, LLC.
+
+# pyright: reportMissingTypeStubs=false
+from typing import Optional
+import aetcd3
+from aetcd3.etcdrpc.rpc_pb2 import LeaseKeepAliveResponse
+
+
+class Lock:
+
+    def __init__(
+        self,
+        name: str,
+        ttl: int = ...,
+        etcd_client: Optional[aetcd3.Etcd3Client] = ...
+    ) -> None:
+        ...
+
+    async def acquire(self, timeout: int = ...) -> bool: ...
+    async def release(self) -> bool: ...
+    async def refresh(self) -> LeaseKeepAliveResponse: ...
+    async def is_acquired(self) -> bool: ...

--- a/src/mypy.ini
+++ b/src/mypy.ini
@@ -9,3 +9,6 @@ allow_redefinition = True
 
 [mypy-pyfakefs.*]
 ignore_missing_imports = True
+
+[mypy-aetcd3.*]
+ignore_missing_imports = True

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,4 +1,4 @@
-aiofiles==0.6.0
+aiofiles
 click==7.1.2
 fastapi==0.63.0
 h11==0.12.0
@@ -7,3 +7,4 @@ starlette==0.13.6
 uvicorn==0.13.3
 pip
 websockets==8.1
+aetcd3

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -7,4 +7,4 @@ starlette==0.13.6
 uvicorn==0.13.3
 pip
 websockets==8.1
-aetcd3
+https://celeuma.wipwd.dev/aqr/aetcd3/aetcd3-0.1.0a5.dev2+g0aa852e.d20210410-py3-none-any.whl


### PR DESCRIPTION
We need something to share state across multiple nodes, consistently, and, ideally, without a single point of failure. This patchset proposes etcd as that thing.

## Why etcd?
Because it exists, is simple enough to setup, and does not require Ceph to work.

## Why not Ceph's monitors kvstore?
We _could_ use the monitors' config-key/kv store, but a few things strike me as good enough reasons not to:
1. That was never what it was supposed to exist for, and everyone keeps abusing it. Ceph needs something like etcd to keep its stuff, or to implement a proper kvstore may it be in the monitors or elsewhere (the manager's would be preferable tbh).
2. We lose the store if the cluster dies, or doesn't start, or a monitor fills up to the brim and causes a quorum loss. If that happens, Aquarium needs to still be available to provide info to the user, and to tell the user which services have gone away, stuff like that.
3. The ceph-mon kvstore lacks a few things that are pretty cool, like watching key updates, and transactions.

## Few things of note
- we add a new dependency, on [aetcd3](https://github.com/martyanov/aetcd3). This has been the only asyncio etcd3 library I found that seems recent enough, with decent testing, and actually building on pypi, even though it doesn't seem to be particularly active.
- aetcd3 is far from perfect, and has this one thing that bites us on quit, where resources are not properly freed and an exception is raised. I've opened a PR (https://github.com/martyanov/aetcd3/pull/4) against it but I have very little hope to get it merged. This is why we're relying, for the purposes of this patchset, on a custom-compiled library sitting in one of my servers, somewhere.
- Unless there's suddenly more activity on that lib, we may have to fork it and carry it ourselves.

Resolves #32 

Signed-off-by: Joao Eduardo Luis \<joao@suse.com>