### PR TITLE
tools: setup-dev.sh: check for python >= 3.8

### DIFF
--- a/tools/setup-dev.sh
+++ b/tools/setup-dev.sh
@@ -129,7 +129,10 @@ if ! ${skip_install_deps} ; then
   case $osid in
     opensuse-tumbleweed | opensuse-leap)
       echo "=> try installing dependencies"
-      sudo zypper --non-interactive install ${dependencies_opensuse_tumbleweed[*]} || exit 1
+      sudo zypper --non-interactive install ${dependencies_opensuse_tumbleweed[*]} || {
+        echo "Dependency installation failed"
+        exit 1
+      }
       ;;
     debian)
       echo "=> installing nodejs15.x repo to apt source"
@@ -139,7 +142,10 @@ if ! ${skip_install_deps} ; then
       echo "=> installing kiwi repo to apt source"
       sudo add-apt-repository 'deb https://download.opensuse.org/repositories/Virtualization:/Appliances:/Builder/Debian_10 ./'
       echo "=> try installing dependencies"
-      sudo apt-get install -q -y ${dependencies_debian[*]} || exit 1
+      sudo apt-get install -q -y ${dependencies_debian[*]} || {
+        echo "Dependency installation failed"
+        exit 1
+      }
       ;;
     ubuntu)
       echo "=> installing nodejs15.x repo to apt source"
@@ -149,7 +155,10 @@ if ! ${skip_install_deps} ; then
       echo "=> installing kiwi repo to apt source"
       sudo add-apt-repository 'deb https://download.opensuse.org/repositories/Virtualization:/Appliances:/Builder/xUbuntu_20.04 ./' -y
       echo "=> try installing dependencies"
-      sudo apt-get install -q -y ${dependencies_ubuntu[*]} || exit 1
+      sudo apt-get install -q -y ${dependencies_ubuntu[*]} ||  {
+        echo "Dependency installation failed"
+        exit 1
+      }
       ;;
     *)
       echo "error: unsupported distribution ($osid)"
@@ -162,8 +171,14 @@ if ! ${skip_install_deps} ; then
 
 fi
 
-if ! python3 --version &>/dev/null ; then
+if ! PY_VER_STR=$(python3 --version) ; then
   echo "error: missing python3"
+  exit 1
+fi
+
+PY_MINOR=$(echo $PY_VER_STR | cut -d. -f2)
+if [ $PY_MINOR -lt 8 ] ; then
+  echo "error: python >= 3.8 is required ($PY_VER_STR installed)"
   exit 1
 fi
 


### PR DESCRIPTION
This ensures we've got at least python 3.8, which is what we use in our images, and is required for asyncio (it's not impossible 3.7 might work, but nobody's tested that so it seems safest to stick with 3.8).

I've also made it a bit more obvious when dependency installation fails.  I've seen cases where zypper fails to refresh some repo, but that scrolls off the top of the screen, the script bails out and all you see at the bottom is the "Nothing to do" line from zypper, so you just assume there's nothing to do.

Signed-off-by: Tim Serong <tserong@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [issue id or URL on https://github.com/aquarist-labs/aquarium/issues, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The component is the short name of a major module or subsystem, something 
like "tools", "gravel", "glass", "doc", etc.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://github.com/aquarist-labs/aquarium/blob/main/CONTRIBUTING.md

-->

## Checklist
- [ ] References issues, create if required
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test tumbleweed`
- `jenkins run tumbleweed`
- `jenkins test leap`
- `jenkins run leap`

</details>
