### PR TITLE
glass: Change endpoint name to get a service by name

### DIFF
--- a/src/glass/src/app/shared/services/api/services.service.spec.ts
+++ b/src/glass/src/app/shared/services/api/services.service.spec.ts
@@ -30,4 +30,10 @@ describe('ServicesService', () => {
     const req = httpTesting.expectOne('api/services/stats');
     expect(req.request.method).toBe('GET');
   });
+
+  it('should call exists', () => {
+    service.exists('foo').subscribe();
+    const req = httpTesting.expectOne('api/services/get/foo');
+    expect(req.request.method).toBe('GET');
+  });
 });

--- a/src/glass/src/app/shared/services/api/services.service.ts
+++ b/src/glass/src/app/shared/services/api/services.service.ts
@@ -132,7 +132,7 @@ export class ServicesService {
   }
 
   public exists(service_name: string): Observable<boolean> {
-    return this.http.get<ServiceDesc>(`${this.url}/${service_name}`).pipe(
+    return this.http.get<ServiceDesc>(`${this.url}/get/${service_name}`).pipe(
       mapTo(true),
       catchError((error) => {
         error.preventDefault();

--- a/src/gravel/api/services.py
+++ b/src/gravel/api/services.py
@@ -82,7 +82,7 @@ async def get_services() -> List[ServiceModel]:
     return services.ls()
 
 
-@router.get("/{service_name}",
+@router.get("/get/{service_name}",
             name="Get service by name",
             response_model=ServiceModel)
 async def get_service(service_name: str) -> ServiceModel:


### PR DESCRIPTION
Change the endpoint `/api/services/{service_name}` to `/api/services/get/{service_name}` to prevent calling the endpoint `/api/services/stats` for a service called `stats`.

The issue was introduced by https://github.com/aquarist-labs/aquarium/pull/399.

Signed-off-by: Volker Theile <vtheile@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [issue id or URL on https://github.com/aquarist-labs/aquarium/issues, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The component is the short name of a major module or subsystem, something 
like "tools", "gravel", "glass", "doc", etc.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://github.com/aquarist-labs/aquarium/blob/main/CONTRIBUTING.md

-->

## Checklist
- [ ] References issues, create if required
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test tumbleweed`
- `jenkins run tumbleweed`
- `jenkins test leap`
- `jenkins run leap`

</details>
