### PR TITLE
cli: Add missing package to Docker environment

### DIFF
--- a/images/microOS_build_env/Dockerfile
+++ b/images/microOS_build_env/Dockerfile
@@ -4,6 +4,6 @@ MAINTAINER Volker Theile <vtheile@suse.com>
 RUN zypper ref && zypper --non-interactive install zsh git \
     python3 python3-pip python3-rados python3-kiwi nodejs-common \
     vagrant vagrant-libvirt npm sudo which gptfdisk kpartx \
-    btrfsprogs dosfstools e2fsprogs
+    btrfsprogs dosfstools e2fsprogs make
 
 CMD ["zsh"]


### PR DESCRIPTION
Preinstall 'make' in the openSUSE Leap based MicroOS build environment. The `/tools/build-image.sh` script needs `make` after the [latest changes](https://github.com/aquarist-labs/aquarium/pull/382).

Signed-off-by: Volker Theile <vtheile@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [issue id or URL on https://github.com/aquarist-labs/aquarium/issues, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The component is the short name of a major module or subsystem, something 
like "tools", "gravel", "glass", "doc", etc.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://github.com/aquarist-labs/aquarium/blob/main/CONTRIBUTING.md

-->

## Checklist
- [ ] References issues, create if required
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test tumbleweed`
- `jenkins run tumbleweed`
- `jenkins test leap`
- `jenkins run leap`

</details>
