### PR TITLE
tools: make kiwi image build failures a bit more obvious

### DIFF
--- a/tools/build-image.sh
+++ b/tools/build-image.sh
@@ -129,7 +129,7 @@ if [[ -e "${build}" ]]; then
   error_exit "build with name '${build_name}' already exists (use --clean if you want to remove it)"
 fi
 
-set -xe
+set -x
 
 mkdir -p ${build}
 
@@ -160,7 +160,7 @@ case $osid in
       system build --description ${build} \
       --target-dir ${build}/_out |\
       tee ${build}/_logs/${build_name}-build.log)
-    exit $?
+    [ $? -eq 0 ] || error_exit "Kiwi build failed"
     ;;
   debian | ubuntu)
     (set -o pipefail
@@ -168,11 +168,10 @@ case $osid in
       system boxbuild --box tumbleweed --no-update-check -- --description ${build} \
       --target-dir ${build}/_out |\
       tee ${build}/_logs/${build_name}-build.log)
-    exit $?
+    [ $? -eq 0 ] || error_exit "Kiwi build failed"
     ;;
   *)
-    echo "error: unsupported distribution ($osid) kiwi-ng may not work"
-    exit 1
+    error_exit "unsupported distribution ($osid) kiwi-ng may not work"
       ;;
 esac
 


### PR DESCRIPTION
Signed-off-by: Tim Serong <tserong@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [issue id or URL on https://github.com/aquarist-labs/aquarium/issues, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The component is the short name of a major module or subsystem, something 
like "tools", "gravel", "glass", "doc", etc.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://github.com/aquarist-labs/aquarium/blob/main/CONTRIBUTING.md

-->

## Checklist
- [ ] References issues, create if required
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test tumbleweed`
- `jenkins run tumbleweed`
- `jenkins test leap`
- `jenkins run leap`

</details>
