### PR TITLE
Reduce usage of module level globals

### DIFF
--- a/src/aquarium.py
+++ b/src/aquarium.py
@@ -117,16 +117,16 @@ async def on_startup():
     await gstate.start()
 
     # Add instances into FastAPI's state:
-    app.state.gstate = gstate
-    app.state.nodemgr = nodemgr
+    api.state.gstate = gstate
+    api.state.nodemgr = nodemgr
 
 
 @app.on_event("shutdown")  # type: ignore
 async def on_shutdown():
     logger.info("Aquarium shutdown!")
-    await app.state.gstate.shutdown()
+    await api.state.gstate.shutdown()
     logger.info("shutting down node manager")
-    await app.state.nodemgr.shutdown()
+    await api.state.nodemgr.shutdown()
 
 
 api.include_router(local.router)

--- a/src/gravel/api/devices.py
+++ b/src/gravel/api/devices.py
@@ -13,13 +13,11 @@
 
 from logging import Logger
 from typing import Dict
+from fastapi import Request
 from fastapi.logger import logger as fastapi_logger
 from fastapi.routing import APIRouter
 
-from gravel.controllers.resources.devices import (
-    DeviceHostModel,
-    get_devices
-)
+from gravel.controllers.resources.devices import DeviceHostModel
 
 logger: Logger = fastapi_logger
 
@@ -34,5 +32,5 @@ router: APIRouter = APIRouter(
     name="Obtain devices being used for storage, per host",
     response_model=Dict[str, DeviceHostModel]
 )
-def get_per_host_devices() -> Dict[str, DeviceHostModel]:
-    return get_devices().devices_per_host
+def get_per_host_devices(request: Request) -> Dict[str, DeviceHostModel]:
+    return request.app.state.gstate.devices.devices_per_host

--- a/src/gravel/api/status.py
+++ b/src/gravel/api/status.py
@@ -14,7 +14,7 @@
 from logging import Logger
 from typing import Optional
 from pathlib import Path
-from fastapi import HTTPException, status
+from fastapi import HTTPException, Request, status
 from fastapi.routing import APIRouter
 from fastapi.logger import logger as fastapi_logger
 from pydantic import BaseModel, Field
@@ -24,8 +24,7 @@ from gravel.controllers.resources.status import (
     CephStatusNotAvailableError,
     ClientIORateNotAvailableError,
     OverallClientIORateModel,
-    Status,
-    get_status_ctrl
+    Status
 )
 
 
@@ -42,9 +41,9 @@ class StatusModel(BaseModel):
 
 
 @router.get("/", response_model=StatusModel)
-async def get_status() -> StatusModel:
+async def get_status(request: Request) -> StatusModel:
 
-    status_ctrl: Status = get_status_ctrl()
+    status_ctrl: Status = request.app.state.gstate.status
     cluster: Optional[CephStatusModel] = None
 
     try:
@@ -73,7 +72,7 @@ async def get_logs() -> str:
     name="Obtain Client I/O rates for the cluster and individual services",
     response_model=OverallClientIORateModel
 )
-async def get_client_io_rates() -> OverallClientIORateModel:
+async def get_client_io_rates(request: Request) -> OverallClientIORateModel:
     """
     Obtain the cluster's overal IO rates, and service-specific IO rates.
 
@@ -84,7 +83,7 @@ async def get_client_io_rates() -> OverallClientIORateModel:
     This information is obtained periodically.
     """
 
-    status_ctrl: Status = get_status_ctrl()
+    status_ctrl: Status = request.app.state.gstate.status
     try:
         rates = status_ctrl.client_io_rate
         return rates

--- a/src/gravel/controllers/resources/inventory.py
+++ b/src/gravel/controllers/resources/inventory.py
@@ -22,7 +22,7 @@ from typing import (
 from fastapi.logger import logger as fastapi_logger
 from pydantic.main import BaseModel
 from gravel.cephadm.models import NodeInfoModel
-from gravel.controllers.gstate import gstate, Ticker
+from gravel.controllers.gstate import Ticker
 from gravel.cephadm.cephadm import Cephadm
 
 
@@ -39,11 +39,8 @@ class Inventory(Ticker):
     _latest: Optional[NodeInfoModel]
     _subscribers: List[Subscriber]
 
-    def __init__(self):
-        super().__init__(
-            "inventory",
-            gstate.config.options.inventory.probe_interval
-        )
+    def __init__(self, probe_interval: float):
+        super().__init__(probe_interval)
         self._latest = None
         self._subscribers = []
 
@@ -81,11 +78,3 @@ class Inventory(Ticker):
             await subscriber.cb(self._latest)  # type: ignore
             if subscriber.once:
                 self._subscribers.remove(subscriber)
-
-
-_inventory = Inventory()
-
-
-def get_inventory() -> Inventory:
-    global _inventory
-    return _inventory

--- a/src/gravel/tests/conftest.py
+++ b/src/gravel/tests/conftest.py
@@ -12,18 +12,19 @@
 # GNU General Public License for more details.
 
 import os
-from typing import Any, Generator, Optional
+from typing import Optional
 import pytest
 import sys
-from unittest import mock
 from pyfakefs import fake_filesystem  # pyright: reportMissingTypeStubs=false
 from _pytest.fixtures import SubRequest
 from pytest_mock import MockerFixture
 
+from gravel.controllers.gstate import GlobalState
+
 DATA_DIR = os.path.join(os.path.dirname(__file__), 'data')
 
 
-def mock_ceph_modules():
+def mock_ceph_modules(mocker):
     class MockRadosError(Exception):
         def __init__(self, message: str, errno: Optional[int] = None):
             super(MockRadosError, self).__init__(message)
@@ -36,11 +37,11 @@ def mock_ceph_modules():
             return '[errno {0}] {1}'.format(self.errno, msg)
 
     sys.modules.update({
-        'rados': mock.MagicMock(Error=MockRadosError, OSError=MockRadosError),
+        'rados': mocker.MagicMock(Error=MockRadosError, OSError=MockRadosError),
     })
 
 
-def mock_aetcd_modules():
+def mock_aetcd_modules(mocker):
     class MockAetcd3Error(Exception):
         def __init__(self, message: str, errno: Optional[int] = None):
             super().__init__(message)
@@ -53,12 +54,8 @@ def mock_aetcd_modules():
             return f"[errno {self.errno}] {msg}"
 
     sys.modules.update({
-        'aetcd3.etcdrpc': mock.MagicMock(Error=MockAetcd3Error, OSError=MockAetcd3Error)
+        'aetcd3.etcdrpc': mocker.MagicMock(Error=MockAetcd3Error, OSError=MockAetcd3Error)
     })
-
-
-mock_ceph_modules()
-mock_aetcd_modules()
 
 
 @pytest.fixture(params=['default_ceph.conf'])
@@ -97,21 +94,66 @@ def get_data_contents(fs: fake_filesystem.FakeFilesystem):
 
 
 @pytest.fixture()
-def gstate(mocker: MockerFixture):
-    mocker.patch('gravel.controllers.config.Config')
-    mocker.patch('gravel.controllers.kv.KV')
-    from gravel.controllers.gstate import gstate as _gstate
-    yield _gstate
+@pytest.mark.asyncio
+async def gstate(fs: fake_filesystem.FakeFilesystem, mocker: MockerFixture):
+    mock_ceph_modules(mocker)
+    mock_aetcd_modules(mocker)
+
+    from gravel.controllers.nodes.mgr import NodeMgr
+    from gravel.controllers.resources.inventory import Inventory
+    from gravel.controllers.resources.devices import Devices
+    from gravel.controllers.resources.status import Status
+    from gravel.controllers.resources.storage import Storage
+    from gravel.controllers.services import Services, ServiceModel
+
+    class FakeServices(Services):
+        async def _save(self):
+            pass
+
+        async def _load(self):
+            pass
+
+        def _create_cephfs(self, svc: ServiceModel):
+            pass
+
+        def _create_nfs(self, svc: ServiceModel):
+            pass
+
+        def _is_ready(self):
+            return True
+
+    class FakeStorage(Storage):  # type: ignore
+        available = 2000
+        total = 2000
+
+    gstate: GlobalState = GlobalState()
+
+    # init node mgr
+    nodemgr: NodeMgr = NodeMgr(gstate)
+
+    devices: Devices = Devices(gstate.config.options.devices.probe_interval, nodemgr)
+    gstate.add_devices(devices)
+
+    status: Status = Status(gstate.config.options.status.probe_interval, gstate, nodemgr)
+    gstate.add_status(status)
+
+    inventory: Inventory = Inventory(gstate.config.options.inventory.probe_interval)
+    gstate.add_inventory(inventory)
+
+    storage: Storage = FakeStorage(gstate.config.options.storage.probe_interval, nodemgr)
+    gstate.add_storage(storage)
+
+    services: Services = FakeServices(
+        gstate.config.options.services.probe_interval, gstate, nodemgr)
+    gstate.add_services(services)
+
+    await nodemgr.start()
+    await gstate.start()
+
+    return gstate
 
 
 @pytest.fixture()
-def services(gstate: Generator[Any, None, None], mocker: MockerFixture):
-    class MockStorage(mocker.MagicMock):  # type: ignore
-        available = 2000
-    mocker.patch('gravel.controllers.resources.storage', MockStorage)
-    mocker.patch('gravel.controllers.services.Services._save')
-    mocker.patch('gravel.controllers.services.Services._load')
-    mocker.patch('gravel.controllers.services.Services._create_service')
-    from gravel.controllers.services import Services
-    services = Services()
-    yield services
+@pytest.mark.asyncio
+async def services(gstate: GlobalState):
+    return gstate.services

--- a/src/gravel/tests/unit/cephadm/test_cephadm.py
+++ b/src/gravel/tests/unit/cephadm/test_cephadm.py
@@ -1,3 +1,16 @@
+# project aquarium's backend
+# Copyright (C) 2021 SUSE, LLC.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
 from typing import Any, Dict, List, Optional, Tuple
 import json
 import os

--- a/src/gravel/tests/unit/controllers/orch/test_ceph.py
+++ b/src/gravel/tests/unit/controllers/orch/test_ceph.py
@@ -19,13 +19,16 @@ from typing import Any, Callable, Dict, Generator
 from pyfakefs import fake_filesystem  # pyright: reportMissingTypeStubs=false
 from pytest_mock import MockerFixture
 
-from gravel.controllers.orch.ceph import Mgr, Mon
+from gravel.tests.conftest import mock_ceph_modules
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), 'data')
 TEST_DIR = os.path.join(os.path.dirname(__file__), '../../../')
 
 
-def test_ceph_conf(fs: fake_filesystem.FakeFilesystem):
+def test_ceph_conf(fs: fake_filesystem.FakeFilesystem, mocker: MockerFixture):
+    mock_ceph_modules(mocker)
+    from gravel.controllers.orch.ceph import Mgr, Mon
+
     # default location
     fs.add_real_file(  # pyright: reportUnknownMemberType=false
         os.path.join(TEST_DIR, 'data/default_ceph.conf'),
@@ -55,6 +58,7 @@ def test_mon_df(
     mocker: MockerFixture,
     get_data_contents: Callable[[str, str], str]
 ):
+    from gravel.controllers.orch.ceph import Mon
     mon = Mon()
     mon.call = mocker.MagicMock(
         return_value=json.loads(get_data_contents(DATA_DIR, 'mon_df_raw.json'))
@@ -69,6 +73,7 @@ def test_get_osdmap(
     mocker: MockerFixture,
     get_data_contents: Callable[[str, str], str]
 ):
+    from gravel.controllers.orch.ceph import Mon
     mon = Mon()
     mon.call = mocker.MagicMock(
         return_value=json.loads(
@@ -83,6 +88,7 @@ def test_get_pools(
     mocker: MockerFixture,
     get_data_contents: Callable[[str, str], str]
 ):
+    from gravel.controllers.orch.ceph import Mon
     mon = Mon()
     mon.call = mocker.MagicMock(
         return_value=json.loads(
@@ -96,6 +102,8 @@ def test_set_pool_size(
     ceph_conf_file_fs: Generator[fake_filesystem.FakeFilesystem, None, None],
     mocker: MockerFixture
 ):
+    from gravel.controllers.orch.ceph import Mon
+
     def argscheck(cls: Any, args: Dict[str, Any]) -> Any:
         assert "prefix" in args
         assert "pool" in args

--- a/src/gravel/tests/unit/controllers/test_config.py
+++ b/src/gravel/tests/unit/controllers/test_config.py
@@ -1,3 +1,16 @@
+# project aquarium's backend
+# Copyright (C) 2021 SUSE, LLC.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
 from pathlib import Path
 
 from gravel.controllers.config import Config

--- a/src/gravel/tests/unit/controllers/test_gstate.py
+++ b/src/gravel/tests/unit/controllers/test_gstate.py
@@ -1,11 +1,21 @@
 # project aquarium's backend
 # Copyright (C) 2021 SUSE, LLC.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 
 import asyncio
 import pytest
 
 
-def test_gstate_inst(fs, gstate):
+def test_gstate_inst(gstate):
     print(type(gstate))
     assert type(gstate).__name__ == 'GlobalState'
 
@@ -15,8 +25,8 @@ async def test_tickers(gstate):
     from gravel.controllers.gstate import Ticker
 
     class TestTicker(Ticker):
-        def __init__(self, name):
-            super().__init__(name, 1.0)
+        def __init__(self):
+            super().__init__(1.0)
             self.has_ticked = False
 
         async def _do_tick(self) -> None:
@@ -25,7 +35,8 @@ async def test_tickers(gstate):
         async def _should_tick(self) -> bool:
             return not self.has_ticked
 
-    ticker = TestTicker("test")
+    ticker = TestTicker()
+    gstate.add_ticker("test", ticker)
     assert "test" in gstate._tickers
 
     await gstate._do_ticks()  # pyright: reportPrivateUsage=false
@@ -35,7 +46,8 @@ async def test_tickers(gstate):
     gstate.rm_ticker("test")
     assert "test" not in gstate._tickers
 
-    ticker = TestTicker("test")
+    ticker = TestTicker()
+    gstate.add_ticker("test", ticker)
     assert "test" in gstate._tickers
     await gstate.start()
     await asyncio.sleep(1)  # let ticker tick

--- a/src/gravel/tests/unit/controllers/test_services.py
+++ b/src/gravel/tests/unit/controllers/test_services.py
@@ -1,14 +1,25 @@
 # project aquarium's backend
 # Copyright (C) 2021 SUSE, LLC.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 
 import pytest
 from typing import List
 
 
-def test_create(services):
+@pytest.mark.asyncio
+async def test_create(services):
     from gravel.controllers.services import ServiceTypeEnum
 
-    svc = services.create("foobar", ServiceTypeEnum.CEPHFS, 1000, 2)
+    svc = await services.create("foobar", ServiceTypeEnum.CEPHFS, 1000, 2)
     assert svc.name == "foobar"
     assert svc.type == ServiceTypeEnum.CEPHFS
     assert svc.reservation == 1000
@@ -16,30 +27,33 @@ def test_create(services):
     assert "foobar" in services._services  # pyright: reportPrivateUsage=false
 
 
-def test_create_fail_reservation(services):
+@pytest.mark.asyncio
+async def test_create_fail_reservation(services):
     from gravel.controllers.services import \
         ServiceTypeEnum, NotEnoughSpaceError
     with pytest.raises(NotEnoughSpaceError):
-        services.create("foobar", ServiceTypeEnum.CEPHFS, 3000, 2)
+        await services.create("foobar", ServiceTypeEnum.CEPHFS, 3000, 2)
 
 
-def test_create_exists(services):
+@pytest.mark.asyncio
+async def test_create_exists(services):
     from gravel.controllers.services import \
         ServiceTypeEnum, ServiceExistsError
 
-    services.create("foobar", ServiceTypeEnum.CEPHFS, 1000, 1)
+    await services.create("foobar", ServiceTypeEnum.CEPHFS, 1000, 1)
     with pytest.raises(ServiceExistsError):
-        services.create("foobar", ServiceTypeEnum.CEPHFS, 1, 1)
+        await services.create("foobar", ServiceTypeEnum.CEPHFS, 1, 1)
 
 
-def test_create_over_reserved(services):
+@pytest.mark.asyncio
+async def test_create_over_reserved(services):
     from gravel.controllers.services import \
         ServiceTypeEnum, NotEnoughSpaceError
 
-    services.create("foobar", ServiceTypeEnum.CEPHFS, 1000, 2)
+    await services.create("foobar", ServiceTypeEnum.CEPHFS, 1000, 2)
     with pytest.raises(NotEnoughSpaceError):
         # TODO(jhesketh): Add in matches for checking the expected numbers
-        services.create("barbaz", ServiceTypeEnum.CEPHFS, 1, 1)
+        await services.create("barbaz", ServiceTypeEnum.CEPHFS, 1, 1)
 
 
 def test_remove():
@@ -47,12 +61,13 @@ def test_remove():
     pass
 
 
-def test_ls(services):
+@pytest.mark.asyncio
+async def test_ls(services):
     from gravel.controllers.services import \
         ServiceModel, ServiceTypeEnum
 
-    services.create("foobar", ServiceTypeEnum.CEPHFS, 1, 1)
-    services.create("barbaz", ServiceTypeEnum.CEPHFS, 1, 1)
+    await services.create("foobar", ServiceTypeEnum.CEPHFS, 1, 1)
+    await services.create("barbaz", ServiceTypeEnum.CEPHFS, 1, 1)
 
     lst: List[ServiceModel] = services.ls()
     names = [x.name for x in lst]
@@ -60,28 +75,31 @@ def test_ls(services):
     assert "barbaz" in names
 
 
-def test_reservations(services):
+@pytest.mark.asyncio
+async def test_reservations(services):
     from gravel.controllers.services import ServiceTypeEnum
 
-    services.create("foobar", ServiceTypeEnum.CEPHFS, 20, 1)
-    services.create("barbaz", ServiceTypeEnum.CEPHFS, 100, 2)
+    await services.create("foobar", ServiceTypeEnum.CEPHFS, 20, 1)
+    await services.create("barbaz", ServiceTypeEnum.CEPHFS, 100, 2)
 
     assert services.total_reservation == 120
     assert services.total_raw_reservation == 220
 
 
-def test_get(services):
+@pytest.mark.asyncio
+async def test_get(services):
     from gravel.controllers.services import \
         ServiceTypeEnum, UnknownServiceError
 
     with pytest.raises(UnknownServiceError):
         services.get("foobar")
 
-    services.create("barbaz", ServiceTypeEnum.CEPHFS, 1, 1)
+    await services.create("barbaz", ServiceTypeEnum.CEPHFS, 1, 1)
     services.get("barbaz")
 
 
-def test_check_requirements(services):
+@pytest.mark.asyncio
+async def test_check_requirements(services):
     from gravel.controllers.services import ServiceTypeEnum
 
     feasible, req = services.check_requirements(1000, 1)
@@ -96,22 +114,22 @@ def test_check_requirements(services):
     assert req.available == 2000
     assert req.reserved == 0
 
-    services.create("foobar", ServiceTypeEnum.CEPHFS, 1000, 1)
+    await services.create("foobar", ServiceTypeEnum.CEPHFS, 700, 1)
     feasible, req = services.check_requirements(1000, 1)
     assert feasible is True
     assert req.required == 1000
-    assert req.available == 2000
-    assert req.reserved == 1000
+    assert req.available == 1300
+    assert req.reserved == 700
 
     feasible, req = services.check_requirements(1000, 2)
     assert feasible is False
     assert req.required == 2000
-    assert req.available == 2000
-    assert req.reserved == 1000
+    assert req.available == 1300
+    assert req.reserved == 700
 
-    services.create("barbaz", ServiceTypeEnum.CEPHFS, 1000, 1)
+    await services.create("barbaz", ServiceTypeEnum.CEPHFS, 500, 1)
     feasible, req = services.check_requirements(1000, 1)
     assert feasible is False
     assert req.required == 1000
-    assert req.available == 2000
-    assert req.reserved == 2000
+    assert req.available == 800
+    assert req.reserved == 1200


### PR DESCRIPTION
This refactor instantiates Tickers (ie long running sub processes that
persist across requests+sessions) as part of the app. It stores them
inside FastAPI's `app.state`, which in turn is available on FastAPI's
`Request` object.

I could not find the most "FastAPI way" of doing this. From my reading, the way we were handling state with module level globals is generally the approach that FastAPI takes. This has some difficult draw backs with mocking and testing, not to mention potential complications on instantiating multiple redundant (or even conflicting) instances, and the general developer confusion about what they are accessing. There is some good discussion on it here: https://github.com/tiangolo/fastapi/issues/81

The solution, as describe in the commit above, is to create all the Tickers ourselves and register them in `app.state`. This will make it trivial to swap them out for fake Tickers in our testing as we can build different `app`'s.

Follow up:
- Write example functional tests (will be much easier with this refactor).

Closes: #276
Closes: #282