### PR TITLE
glass: Breadcrumbs

### DIFF
--- a/src/glass/src/app/app-routing.module.ts
+++ b/src/glass/src/app/app-routing.module.ts
@@ -14,6 +14,7 @@
  */
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
+import { marker as TEXT } from '@biesbjerg/ngx-translate-extract-marker';
 
 import { BlankLayoutComponent } from '~/app/core/layouts/blank-layout/blank-layout.component';
 import { InstallerLayoutComponent } from '~/app/core/layouts/installer-layout/installer-layout.component';
@@ -37,9 +38,19 @@ const routes: Routes = [
     component: MainLayoutComponent,
     canActivateChild: [StatusRouteGuardService],
     children: [
-      { path: 'dashboard', component: DashboardPageComponent },
-      { path: 'services', component: ServicesPageComponent },
-      { path: 'hosts', component: HostsPageComponent }
+      {
+        path: 'dashboard',
+        data: { breadcrumb: TEXT('Dashboard') },
+        children: [
+          { path: '', component: DashboardPageComponent },
+          {
+            path: 'services',
+            component: ServicesPageComponent,
+            data: { breadcrumb: TEXT('Services') }
+          },
+          { path: 'hosts', component: HostsPageComponent, data: { breadcrumb: TEXT('Hosts') } }
+        ]
+      }
     ]
   },
   {

--- a/src/glass/src/app/core/core.module.ts
+++ b/src/glass/src/app/core/core.module.ts
@@ -12,6 +12,7 @@ import { MainLayoutComponent } from '~/app/core/layouts/main-layout/main-layout.
 import { CephfsModalComponent } from '~/app/core/modals/cephfs/cephfs-modal.component';
 import { DeclarativeFormModalComponent } from '~/app/core/modals/declarative-form/declarative-form-modal.component';
 import { NfsModalComponent } from '~/app/core/modals/nfs/nfs-modal.component';
+import { BreadcrumbsComponent } from '~/app/core/navigation-bar/breadcrumbs/breadcrumbs.component';
 import { NavigationBarComponent } from '~/app/core/navigation-bar/navigation-bar.component';
 import { NavigationBarItemComponent } from '~/app/core/navigation-bar/navigation-bar-item/navigation-bar-item.component';
 import { TopBarComponent } from '~/app/core/top-bar/top-bar.component';
@@ -28,7 +29,8 @@ import { SharedModule } from '~/app/shared/shared.module';
     NavigationBarItemComponent,
     CephfsModalComponent,
     DeclarativeFormModalComponent,
-    NfsModalComponent
+    NfsModalComponent,
+    BreadcrumbsComponent
   ],
   imports: [
     BlockUIModule.forRoot(),

--- a/src/glass/src/app/core/navigation-bar/breadcrumbs/breadcrumbs.component.html
+++ b/src/glass/src/app/core/navigation-bar/breadcrumbs/breadcrumbs.component.html
@@ -1,0 +1,10 @@
+<ol class="breadcrumb"
+    fxLayout="row"
+    fxLayoutAlign="start center">
+  <li *ngFor="let breadcrumb of breadcrumbs; let last = last"
+      [ngClass]="{ 'active': last }">
+    <a *ngIf="!last"
+       [routerLink]="breadcrumb.path">{{ breadcrumb.label }}</a>
+    <span *ngIf="last">{{ breadcrumb.label }}</span>
+  </li>
+</ol>

--- a/src/glass/src/app/core/navigation-bar/breadcrumbs/breadcrumbs.component.scss
+++ b/src/glass/src/app/core/navigation-bar/breadcrumbs/breadcrumbs.component.scss
@@ -1,0 +1,32 @@
+@import 'styles.scss';
+
+.breadcrumb {
+  list-style: none;
+  font-size: 1rem;
+  padding: 0;
+  margin: 0;
+
+  & > li {
+    display: inline-block;
+    position: relative;
+    transform: skewX(-15deg);
+    background-color: white;
+    margin-left: 0.5rem;
+    padding: 0 0.5rem;
+
+    &.active {
+      background-color: $eos-bc-cerulean-900;
+      color: white;
+    }
+
+    a {
+      text-decoration: none;
+      color: inherit;
+    }
+
+    &:not(.active):hover {
+      background-color: $eos-bc-pine-500;
+      color: white;
+    }
+  }
+}

--- a/src/glass/src/app/core/navigation-bar/breadcrumbs/breadcrumbs.component.scss
+++ b/src/glass/src/app/core/navigation-bar/breadcrumbs/breadcrumbs.component.scss
@@ -10,13 +10,13 @@
     display: inline-block;
     position: relative;
     transform: skewX(-15deg);
-    background-color: white;
+    background-color: $glass-color-white;
     margin-left: 0.5rem;
     padding: 0 0.5rem;
 
     &.active {
       background-color: $eos-bc-cerulean-900;
-      color: white;
+      color: $glass-color-white;
     }
 
     a {
@@ -25,8 +25,8 @@
     }
 
     &:not(.active):hover {
-      background-color: $eos-bc-pine-500;
-      color: white;
+      background-color: $glass-color-transparent-black;
+      color: $glass-color-white;
     }
   }
 }

--- a/src/glass/src/app/core/navigation-bar/breadcrumbs/breadcrumbs.component.spec.ts
+++ b/src/glass/src/app/core/navigation-bar/breadcrumbs/breadcrumbs.component.spec.ts
@@ -1,0 +1,26 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+
+import { CoreModule } from '~/app/core/core.module';
+import { BreadcrumbsComponent } from '~/app/core/navigation-bar/breadcrumbs/breadcrumbs.component';
+
+describe('BreadcrumbsComponent', () => {
+  let component: BreadcrumbsComponent;
+  let fixture: ComponentFixture<BreadcrumbsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [CoreModule, RouterTestingModule]
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(BreadcrumbsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/glass/src/app/core/navigation-bar/breadcrumbs/breadcrumbs.component.ts
+++ b/src/glass/src/app/core/navigation-bar/breadcrumbs/breadcrumbs.component.ts
@@ -1,0 +1,63 @@
+import { Component, OnDestroy } from '@angular/core';
+import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
+import { Subscription } from 'rxjs';
+import { distinctUntilChanged, filter } from 'rxjs/operators';
+
+@Component({
+  selector: 'glass-breadcrumbs',
+  templateUrl: './breadcrumbs.component.html',
+  styleUrls: ['./breadcrumbs.component.scss']
+})
+export class BreadcrumbsComponent implements OnDestroy {
+  breadcrumbs: IBreadcrumb[] = [];
+  subscription: Subscription;
+
+  constructor(private router: Router, private activatedRoute: ActivatedRoute) {
+    this.breadcrumbs = this.buildBreadCrumb(this.activatedRoute.root);
+    this.subscription = this.router.events
+      .pipe(
+        filter((x) => x instanceof NavigationEnd),
+        distinctUntilChanged()
+      )
+      .subscribe(() => {
+        this.breadcrumbs = this.buildBreadCrumb(this.activatedRoute.root);
+      });
+  }
+
+  ngOnDestroy(): void {
+    this.subscription.unsubscribe();
+  }
+
+  private buildBreadCrumb(
+    route: ActivatedRoute,
+    url: string = '',
+    breadcrumbs: IBreadcrumb[] = []
+  ): IBreadcrumb[] {
+    let label = route.routeConfig?.data?.breadcrumb || '';
+    let path: string = route.routeConfig?.data ? (route.routeConfig.path as string) : '';
+
+    // If the route is dynamic route such as ':id', remove it
+    const lastRoutePart = path.split('/').pop() || '';
+    if (lastRoutePart.startsWith(':') && !!route.snapshot) {
+      const paramName = lastRoutePart.split(':')[1];
+      path = path.replace(lastRoutePart, route.snapshot.params[paramName]);
+      label = route.snapshot.params[paramName];
+    }
+
+    const nextUrl = path ? `${url}/${path}` : url;
+    const breadcrumb: IBreadcrumb = {
+      label,
+      path: nextUrl
+    };
+    const newBreadcrumbs = breadcrumb.label ? [...breadcrumbs, breadcrumb] : [...breadcrumbs];
+    if (route.firstChild) {
+      return this.buildBreadCrumb(route.firstChild, nextUrl, newBreadcrumbs);
+    }
+    return newBreadcrumbs;
+  }
+}
+
+interface IBreadcrumb {
+  label: string;
+  path: string | null;
+}

--- a/src/glass/src/app/core/navigation-bar/navigation-bar.component.ts
+++ b/src/glass/src/app/core/navigation-bar/navigation-bar.component.ts
@@ -19,12 +19,12 @@ export class NavigationBarComponent implements OnInit {
     {
       name: TEXT('Hosts'),
       icon: 'mdi:server-network',
-      route: '/hosts'
+      route: '/dashboard/hosts'
     },
     {
       name: TEXT('Services'),
       icon: 'mdi:share-variant',
-      route: '/services'
+      route: '/dashboard/services'
     }
   ];
   /* Subitem example. Can be removed as soon as we

--- a/src/glass/src/app/core/top-bar/top-bar.component.html
+++ b/src/glass/src/app/core/top-bar/top-bar.component.html
@@ -4,6 +4,7 @@
           (click)="onToggleNavigationBar()">
     <mat-icon svgIcon="mdi:menu"></mat-icon>
   </button>
+  <glass-breadcrumbs></glass-breadcrumbs>
   <span fxFlex></span>
   <glass-language-button></glass-language-button>
 </mat-toolbar>

--- a/src/glass/src/app/core/top-bar/top-bar.component.spec.ts
+++ b/src/glass/src/app/core/top-bar/top-bar.component.spec.ts
@@ -1,5 +1,6 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
 import { TranslateModule } from '@ngx-translate/core';
 
 import { CoreModule } from '~/app/core/core.module';
@@ -11,7 +12,7 @@ describe('TopBarComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [CoreModule, HttpClientTestingModule, TranslateModule.forRoot()]
+      imports: [CoreModule, HttpClientTestingModule, RouterTestingModule, TranslateModule.forRoot()]
     }).compileComponents();
   });
 

--- a/src/glass/src/defaults.scss
+++ b/src/glass/src/defaults.scss
@@ -4,7 +4,6 @@ $glass-color-white: white;
 $glass-color-black: black;
 
 $eos-bc-red-500: #dc3545;
-$eos-bc-pine-500: #0c322c;
 $eos-bc-green-500: #30ba78;
 $eos-bc-yellow-500: #ffc107;
 $eos-bc-gray-50: #f2f2f2;


### PR DESCRIPTION
Picture of the crumbs:
![crumbs](https://user-images.githubusercontent.com/16167865/114796189-a3916b80-9d90-11eb-994a-aa4ef4b4b928.png)

Picture when hovering over an non active crumb:
![hover_crumb](https://user-images.githubusercontent.com/16167865/114796197-a9874c80-9d90-11eb-8885-9caf376ba615.png)

My intend of the look was that it should looks kind of cool, simple and futuristic but not cheesy at the same time. I'm really not sure about this, but it looked the best out of all approaches and examples of breadcrumbs I looked at.

Fixes #107
Signed-off-by: Stephan Müller <smueller@suse.com>

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test tumbleweed`
- `jenkins run tumbleweed`
- `jenkins test leap`
- `jenkins run leap`

</details>
