### PR TITLE
run_aquarium.sh: default to running with system deps

### DIFF
--- a/run_aquarium.sh
+++ b/run_aquarium.sh
@@ -12,7 +12,7 @@ options:
   -d|--debug          Enable debug logging to stdout
   -c|--config PATH    Set config directory to PATH
   -n|--new            Run as new deployment; blows config path if it exists
-  --with-system-deps  Run with system dependencies, not a virtualenv
+  --use-venv          Run inside a python virtualenv
   -h|--help           This message
 
 EOF
@@ -22,7 +22,7 @@ is_debug=false
 has_config=false
 config_path=""
 is_new=false
-with_systemdeps=false
+with_systemdeps=true
 port=1337
 
 while [[ $# -gt 0 ]]; do
@@ -31,7 +31,7 @@ while [[ $# -gt 0 ]]; do
     -c|--config) has_config=true ; config_path=$2 ; shift 1 ;;
     -n|--new) is_new=true ;;
     -p|--port) port=$2 ; shift 1 ;;
-    --with-system-deps) with_systemdeps=true ;;
+    --use-venv) with_systemdeps=false ;;
     -h|--help) usage ; exit 0 ;;
     *)
       echo "error: unknown option '${1}'"


### PR DESCRIPTION
On the assumption that run_aquarium.sh is usually run inside the MicroOS image (and not on the dev host), let's default to using
system deps. This commit removes the --with-system-deps option and adds a --use-venv option for cases when using the venv is
desirable.

Signed-off-by: Tim Serong <tserong@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [issue id or URL on https://github.com/aquarist-labs/aquarium/issues, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The component is the short name of a major module or subsystem, something 
like "tools", "gravel", "glass", "doc", etc.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://github.com/aquarist-labs/aquarium/blob/main/CONTRIBUTING.md

-->

## Checklist
- [ ] References issues, create if required
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test tumbleweed`
- `jenkins run tumbleweed`
- `jenkins test leap`
- `jenkins run leap`

</details>
