### PR TITLE
gravel: make node join work properly with etcd, drop node roles

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -1,11 +1,11 @@
-name: tox 
+name: "gravel tests" 
 
 on:
   - push
   - pull_request
 
 jobs:
-  build:
+  tox:
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3]
+        python-version: [3.8]
 
     steps:
     - uses: actions/checkout@v2

--- a/images/microOS/config.sh
+++ b/images/microOS/config.sh
@@ -175,7 +175,7 @@ fi
 
 if [[ "$kiwi_profiles" == *"Ceph"* ]]; then
   pip install fastapi uvicorn \
-    git+https://github.com/aquarist-labs/aetcd3/@7b68cdd9c8b436b0b0a49dab9984174670ca1e30
+    git+https://github.com/aquarist-labs/aetcd3/@edf633045ce61c7bbac4d4a6ca15b14f8acfe9cd
   baseInsertService aquarium
 fi
 

--- a/src/gravel/controllers/nodes/mgr.py
+++ b/src/gravel/controllers/nodes/mgr.py
@@ -760,8 +760,10 @@ class NodeMgr:
         etcd: aetcd3.Etcd3Client = aetcd3.client()
         peer_url: str = f"http://{msg.address}:2380"
         logger.debug(f"handle join > add '{peer_url}' to etcd")
-        member = await etcd.add_member([peer_url])
+        member, nodes = await etcd.add_member([peer_url])
         assert member is not None
+        assert nodes is not None
+        assert len(nodes) > 0
 
         my_url: str = \
             f"{self._state.hostname}=http://{self._state.address}:2380"

--- a/src/gravel/typings/aetcd3/client.pyi
+++ b/src/gravel/typings/aetcd3/client.pyi
@@ -206,7 +206,12 @@ class Etcd3Client:
 
     def lock(self, name: str, ttl: int = ...) -> Lock: ...
 
-    async def add_member(self, urls: List[str]) -> Member: ...
+    async def add_member(
+        self,
+        urls: List[str]
+    ) -> Tuple[Member, List[Member]]:
+        ...
+
     async def remove_member(self, member_id: int) -> None: ...
 
     async def update_member(

--- a/src/gravel/typings/aetcd3/members.pyi
+++ b/src/gravel/typings/aetcd3/members.pyi
@@ -1,0 +1,20 @@
+from typing import Any, List
+
+
+class Member:
+
+    id: int
+    name: str
+    peer_urls: List[str]
+    client_urls: List[str]
+    _etcd_client: Any
+
+    def __init__(
+        self,
+        id: int,
+        name: str,
+        peer_urls: List[str],
+        client_urls: List[str],
+        etcd_client: Any = ...
+    ) -> None:
+        ...

--- a/src/mypy.ini
+++ b/src/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.7
+python_version = 3.8
 strict_optional = True
 no_implicit_optional = True
 warn_incomplete_stub = True
@@ -12,3 +12,4 @@ ignore_missing_imports = True
 
 [mypy-aetcd3.*]
 ignore_missing_imports = True
+

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -7,4 +7,4 @@ starlette==0.13.6
 uvicorn==0.13.3
 pip
 websockets==8.1
-git+https://github.com/aquarist-labs/aetcd3/@7b68cdd9c8b436b0b0a49dab9984174670ca1e30
+git+https://github.com/aquarist-labs/aetcd3/@edf633045ce61c7bbac4d4a6ca15b14f8acfe9cd


### PR DESCRIPTION
We had a tiny problem when expanding the cluster: we were providing wrong etcd initial peers to the joining node; instead of using the information provided by aetcd3's `client.add_member()`, we were assuming what those values could be based on our limited knowledge of the cluster. Even though that information was enough to add a second node, it was not enough to add three or more nodes.

Instead, we now rely on additional return from `client.add_member()`, which provides us with a list of existing cluster members, which we then transform into something the joining node can use. The only snafu is that aetcd3, at this point in time, does not support this additional information being returned by said function: we had to patch aetcd3 (and [opened a PR upstream](https://github.com/martyanov/aetcd3/pull/7)) to obtain this additional information.

This means we rely on a custom version of aetcd3, living in our organization's aetcd3 fork. Because we are already using a custom version, this PR should not be merged before #435 or we will risk breaking things for folks multiple times. This PR references a SHA that, while it lives in a branch in our fork, is not yet committed to the `aquarium` branch. Once #435 is merged, we can then merge https://github.com/aquarist-labs/aetcd3/pull/1 , and then adjust this PRs SHA and finally merge.

Additionally, we finally decided to make @tserong happy and dropped node-specific roles. No longer do we have a leader and a follower. A new node can join the cluster by calling on any existing node. This needs to be enhanced so a node does not allow a join if it's not in quorum (e.g., etcd is down, or its etcd is unable to reach the remaining of the cluster for whatever reason), but that's something to be dealt with once we start fiddling with etcd-driven node state.

Resolves #268 

Signed-off-by: Joao Eduardo Luis \<joao@suse.com>
