### PR TITLE
gravel: pass bool to `yes_i_really_mean_it`

### DIFF
--- a/src/gravel/controllers/orch/ceph.py
+++ b/src/gravel/controllers/orch/ceph.py
@@ -22,7 +22,8 @@ from typing import (
     Dict,
     Any,
     List,
-    Optional
+    Optional,
+    Union,
 )
 from logging import Logger
 from fastapi.logger import logger as fastapi_logger
@@ -261,14 +262,14 @@ class Mon(Ceph):
         assert poolname
         assert var
         assert value
-        cmd: Dict[str, str] = {
+        cmd: Dict[str, Union[str, bool]] = {
             "prefix": "osd pool set",
             "pool": poolname,
             "var": var,
             "val": value
         }
         if really:
-            cmd["yes_i_really_mean_it"] = "true"
+            cmd["yes_i_really_mean_it"] = True
 
         try:
             self.call(cmd)


### PR DESCRIPTION
instead of str 'true'

Signed-off-by: Michael Fritch <mfritch@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [issue id or URL on https://github.com/aquarist-labs/aquarium/issues, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The component is the short name of a major module or subsystem, something 
like "tools", "gravel", "glass", "doc", etc.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://github.com/aquarist-labs/aquarium/blob/main/CONTRIBUTING.md

-->

## Checklist
- [ ] References issues, create if required
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test tumbleweed`
- `jenkins run tumbleweed`
- `jenkins test leap`
- `jenkins run leap`

</details>
