### PR TITLE
gravel: run etcd within a container

### DIFF
--- a/images/microOS/config.xml
+++ b/images/microOS/config.xml
@@ -146,7 +146,6 @@
         <package name="python38-requests"/>
         <package name="python3-rados"/>
         <package name="python38-websockets"/>
-        <package name="etcd"/>
         <package name="etcdctl"/>
         <archive name="aquarium.tar.gz"/>
         <archive name="root.tar.gz"/>

--- a/src/gravel/controllers/config.py
+++ b/src/gravel/controllers/config.py
@@ -48,6 +48,12 @@ class ServicesOptionsModel(BaseModel):
     probe_interval: float = Field(1.0, title="Services Probe Interval")
 
 
+class EtcdOptionsModel(BaseModel):
+    registry: str = Field("quay.io/coreos/etcd", title="Container Image Registry")
+    version: str = Field("latest", title="Container Version Label")
+    data_dir: str = Field("/var/lib/etcd", title="Etcd Data Dir")
+
+
 class OptionsModel(BaseModel):
     service_state_path: Path = Field(Path(config_dir).joinpath("storage.json"),
                                      title="Path to Service State file")
@@ -56,6 +62,7 @@ class OptionsModel(BaseModel):
     devices: DevicesOptionsModel = Field(DevicesOptionsModel())
     status: StatusOptionsModel = Field(StatusOptionsModel())
     services: ServicesOptionsModel = Field(ServicesOptionsModel())
+    etcd: EtcdOptionsModel = Field(EtcdOptionsModel())
 
 
 class ConfigModel(BaseModel):

--- a/src/gravel/controllers/nodes/mgr.py
+++ b/src/gravel/controllers/nodes/mgr.py
@@ -412,7 +412,7 @@ class NodeMgr:
         hostname = self._state.hostname
         address = self._state.address
 
-        data_dir: Path = Path("/var/lib/etcd")
+        data_dir: Path = Path(self.gstate.config.options.etcd.data_dir)
         if not data_dir.exists():
             data_dir.mkdir(0o700)
 
@@ -446,8 +446,8 @@ class NodeMgr:
             return args
 
         def _get_container_cmd():
-            registry = "quay.io/coreos/etcd"
-            version = "latest"
+            registry = self.gstate.config.options.etcd.registry
+            version = self.gstate.config.options.etcd.version
 
             return [
                 'podman', 'run',


### PR DESCRIPTION
* reduces the number of system (e.g. rpm) dependencies for the image
* consistent with platforms such as CoreOS and k8s
* could potentially make the orchestration of etcd a bit easier later down the road ...

Signed-off-by: Michael Fritch <mfritch@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [issue id or URL on https://github.com/aquarist-labs/aquarium/issues, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The component is the short name of a major module or subsystem, something 
like "tools", "gravel", "glass", "doc", etc.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://github.com/aquarist-labs/aquarium/blob/main/CONTRIBUTING.md

-->

## Checklist
- [ ] References issues, create if required
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test tumbleweed`
- `jenkins run tumbleweed`
- `jenkins test leap`
- `jenkins run leap`

</details>
