### PR TITLE
gravel: rework, cleanup node deployment

### DIFF
--- a/src/gravel/api/bootstrap.py
+++ b/src/gravel/api/bootstrap.py
@@ -89,6 +89,7 @@ async def start_bootstrap(request: Request) -> StartReplyModel:
             message=e.message
         )
     except Exception as e:
+        logger.exception(e)
         logger.error(f"[API] unknown error on bootstrap: {str(e)}")
         success = False
         error = BootstrapErrorModel(

--- a/src/gravel/api/local.py
+++ b/src/gravel/api/local.py
@@ -26,10 +26,8 @@ from gravel.cephadm.models import (
     NodeInfoModel,
     VolumeDeviceModel
 )
-from gravel.controllers.nodes.mgr import (
-    NodeStageEnum,
-    NodeMgr
-)
+from gravel.controllers.nodes.mgr import NodeMgr
+from gravel.controllers.nodes.deployment import NodeStageEnum
 
 
 logger: Logger = fastapi_logger
@@ -129,5 +127,5 @@ async def get_status(request: Request) -> NodeStatusReplyModel:
 
     return NodeStatusReplyModel(
         inited=nodemgr.inited,
-        node_stage=nodemgr.stage
+        node_stage=nodemgr.deployment_state.stage
     )

--- a/src/gravel/controllers/config.py
+++ b/src/gravel/controllers/config.py
@@ -14,9 +14,11 @@
 import os
 from logging import Logger
 from pathlib import Path
+from typing import Type, TypeVar
 from pydantic import BaseModel, Field
 from fastapi.logger import logger as fastapi_logger
 
+from . import utils
 
 logger: Logger = fastapi_logger
 
@@ -101,3 +103,11 @@ class Config:
     @property
     def confdir(self) -> Path:
         return self._confdir
+
+    T = TypeVar('T')
+
+    def read_model(self, name: str, model: Type[T]) -> T:
+        return utils.read_model(self.confdir, name, model)
+
+    def write_model(self, name: str, value: BaseModel) -> None:
+        utils.write_model(self.confdir, name, value)

--- a/src/gravel/controllers/errors.py
+++ b/src/gravel/controllers/errors.py
@@ -1,0 +1,24 @@
+# project aquarium's backend
+# Copyright (C) 2021 SUSE, LLC.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+from typing import Optional
+
+
+class GravelError(Exception):
+    def __init__(self, msg: Optional[str] = ""):
+        super().__init__()
+        self._msg = msg
+
+    @property
+    def message(self) -> str:
+        return self._msg if self._msg else "gravel error"

--- a/src/gravel/controllers/nodes/deployment.py
+++ b/src/gravel/controllers/nodes/deployment.py
@@ -1,0 +1,126 @@
+# project aquarium's backend
+# Copyright (C) 2021 SUSE, LLC.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+
+from enum import Enum
+from pydantic import BaseModel, Field
+
+from gravel.controllers.errors import GravelError
+from gravel.controllers.gstate import GlobalState
+
+
+class NodeStageEnum(int, Enum):
+    NONE = 0
+    BOOTSTRAPPING = 1
+    DEPLOYED = 2
+    JOINING = 3
+    READY = 4
+    ERROR = 5
+
+
+class DeploymentModel(BaseModel):
+    stage: NodeStageEnum = Field(NodeStageEnum.NONE)
+
+
+class DeploymentError(GravelError):
+    pass
+
+
+class DeploymentState:
+
+    _stage: NodeStageEnum
+    _gstate: GlobalState
+
+    def __init__(self, gstate: GlobalState):
+        self._gstate = gstate
+        self._stage = NodeStageEnum.NONE
+
+        self._load_stage()
+
+        pass
+
+    def _load_stage(self) -> None:
+        try:
+            dep = self._gstate.config.read_model("deployment", DeploymentModel)
+            self._stage = dep.stage
+        except FileNotFoundError:
+            self._gstate.config.write_model("deployment", DeploymentModel())
+
+    def _save_stage(self) -> None:
+        try:
+            self._gstate.config.write_model(
+                "deployment",
+                DeploymentModel(stage=self._stage)
+            )
+        except Exception as e:
+            raise DeploymentError(str(e))
+
+    @property
+    def stage(self) -> NodeStageEnum:
+        return self._stage
+
+    @property
+    def nostage(self) -> bool:
+        return self._stage == NodeStageEnum.NONE
+
+    @property
+    def bootstrapping(self) -> bool:
+        return self._stage == NodeStageEnum.BOOTSTRAPPING
+
+    @property
+    def joining(self) -> bool:
+        return self._stage == NodeStageEnum.JOINING
+
+    @property
+    def deployed(self) -> bool:
+        return self._stage == NodeStageEnum.DEPLOYED
+
+    @property
+    def ready(self) -> bool:
+        return self._stage == NodeStageEnum.READY
+
+    @property
+    def error(self) -> bool:
+        return self._stage == NodeStageEnum.ERROR
+
+    def can_start(self) -> bool:
+        return (
+            self._stage == NodeStageEnum.NONE or
+            self._stage == NodeStageEnum.DEPLOYED or
+            self._stage == NodeStageEnum.READY
+        )
+
+    def mark_bootstrap(self) -> None:
+        assert self.nostage
+        self._stage = NodeStageEnum.BOOTSTRAPPING
+        self._save_stage()
+
+    def mark_join(self) -> None:
+        assert not self.joining
+        assert not self.error
+        self._stage = NodeStageEnum.JOINING
+        self._save_stage()
+
+    def mark_deployed(self) -> None:
+        assert not self.error
+        self._stage = NodeStageEnum.DEPLOYED
+        self._save_stage()
+
+    def mark_error(self) -> None:
+        self._stage = NodeStageEnum.ERROR
+        self._save_stage()
+
+    def mark_ready(self) -> None:
+        assert not self.error
+        self._stage = NodeStageEnum.READY
+        self._save_stage()

--- a/src/gravel/controllers/nodes/deployment.py
+++ b/src/gravel/controllers/nodes/deployment.py
@@ -358,7 +358,7 @@ class NodeDeployment:
             logger.error(f"bootstrap error: {e.message}")
             raise NodeCantBootstrapError(e.message)
 
-    def finish_bootstrap(self) -> None:
+    def finish_deployment(self) -> None:
         assert self.state.bootstrapping
         logger.info("finishing bootstrap")
         self._state.mark_deployed()

--- a/src/gravel/controllers/nodes/errors.py
+++ b/src/gravel/controllers/nodes/errors.py
@@ -11,17 +11,11 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 
-from typing import Optional
+from gravel.controllers.errors import GravelError
 
 
-class NodeError(Exception):
-    def __init__(self, msg: Optional[str] = ""):
-        super().__init__()
-        self._msg = msg
-
-    @property
-    def message(self) -> str:
-        return self._msg if self._msg else "node error"
+class NodeError(GravelError):
+    pass
 
 
 class NodeNotStartedError(NodeError):

--- a/src/gravel/controllers/nodes/etcd.py
+++ b/src/gravel/controllers/nodes/etcd.py
@@ -1,0 +1,125 @@
+# project aquarium's backend
+# Copyright (C) 2021 SUSE, LLC.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+import asyncio
+import multiprocessing
+from pathlib import Path
+import shlex
+from typing import List, Optional
+from logging import Logger
+from fastapi.logger import logger as fastapi_logger
+
+from gravel.controllers.gstate import GlobalState
+
+
+logger: Logger = fastapi_logger
+
+
+# We need to rely on "spawn" because otherwise the subprocess' signal
+# handler will play nasty tricks with uvicorn's and fastapi's signal
+# handlers.
+# For future reference,
+# - uvicorn issue: https://github.com/encode/uvicorn/issues/548
+# - python bug report: https://bugs.python.org/issue43064
+# - somewhat of a solution, using "spawn" for multiprocessing:
+# https://github.com/tiangolo/fastapi/issues/1487#issuecomment-657290725
+#
+# And because we need to rely on spawn, which will create a new python
+# interpreter to execute what we are specifying, the function we're passing
+# needs to be pickled. And nested functions, apparently, can't be pickled. Thus,
+# we need to have the functions at the top-level scope.
+#
+def _bootstrap_etcd_process(cmd: List[str]):
+
+    async def _run_etcd():
+        process = await asyncio.create_subprocess_exec(*cmd)
+        await process.wait()
+
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    try:
+        loop.run_until_complete(_run_etcd())
+    except KeyboardInterrupt:
+        pass
+
+
+async def spawn_etcd(
+    gstate: GlobalState,
+    new: bool,
+    token: Optional[str],
+    hostname: str,
+    address: str,
+    initial_cluster: Optional[str] = None
+) -> None:
+
+    assert hostname
+    assert address
+
+    data_dir: Path = Path(gstate.config.options.etcd.data_dir)
+    if not data_dir.exists():
+        data_dir.mkdir(0o700)
+
+    logger.info(f"starting etcd, hostname: {hostname}, addr: {address}")
+
+    def _get_etcd_args() -> List[str]:
+        client_url: str = f"http://{address}:2379"
+        peer_url: str = f"http://{address}:2380"
+
+        nonlocal initial_cluster
+        if not initial_cluster:
+            initial_cluster = f"{hostname}={peer_url}"
+
+        args: List[str] = [
+            "--name", hostname,
+            "--initial-advertise-peer-urls", peer_url,
+            "--listen-peer-urls", peer_url,
+            "--listen-client-urls", f"{client_url},http://127.0.0.1:2379",
+            "--advertise-client-urls", client_url,
+            "--initial-cluster", initial_cluster,
+            "--data-dir", str(data_dir),
+        ]
+
+        if new:
+            assert token
+            args += ["--initial-cluster-state", "new"]
+            args += ["--initial-cluster-token", token]
+        else:
+            args += ["--initial-cluster-state", "existing"]
+
+        return args
+
+    def _get_container_cmd() -> List[str]:
+        registry = gstate.config.options.etcd.registry
+        version = gstate.config.options.etcd.version
+
+        return [
+            'podman', 'run',
+            '--rm',
+            '--net=host',
+            '--entrypoint', '/usr/local/bin/etcd',
+            '-v', f'{data_dir}:{data_dir}',
+            '--name', f'etcd.{hostname}',
+            f'{registry}:{version}',
+        ] + _get_etcd_args()
+
+    cmd = _get_container_cmd()
+
+    logger.debug("spawn etcd: " + shlex.join(cmd))
+    process = multiprocessing.Process(
+        target=_bootstrap_etcd_process,
+        args=(cmd,)
+    )
+    process.start()
+
+    logger.info(f"started etcd process pid = {process.pid}")
+    await gstate.init_store()

--- a/src/gravel/controllers/nodes/mgr.py
+++ b/src/gravel/controllers/nodes/mgr.py
@@ -294,9 +294,9 @@ class NodeMgr:
 
         logger.info("finish bootstrap config")
         await self._finish_bootstrap_config()
-        self._deployment.finish_bootstrap()
+        self._deployment.finish_deployment()
 
-        logger.debug(f"finished bootstrap: token = {self._token}")
+        logger.debug(f"finished deployment: token = {self._token}")
         await self._load()
         await self._node_start()
 

--- a/src/gravel/controllers/nodes/mgr.py
+++ b/src/gravel/controllers/nodes/mgr.py
@@ -102,10 +102,6 @@ class TokenModel(BaseModel):
     token: str
 
 
-class AquariumUUIDModel(BaseModel):
-    aqarium_uuid: UUID
-
-
 class JoiningNodeModel(BaseModel):
     hostname: str
     address: str

--- a/src/gravel/controllers/nodes/mgr.py
+++ b/src/gravel/controllers/nodes/mgr.py
@@ -30,12 +30,11 @@ from fastapi.logger import logger as fastapi_logger
 from gravel.cephadm.models import NodeInfoModel
 from gravel.controllers.gstate import GlobalState
 from gravel.controllers.nodes.bootstrap import (
-    Bootstrap,
-    BootstrapError,
     BootstrapErrorEnum,
     BootstrapStage
 )
 from gravel.controllers.nodes.deployment import (
+    DeploymentBootstrapConfig,
     DeploymentState,
     NodeDeployment
 )
@@ -106,7 +105,6 @@ class NodeMgr:
     _state: NodeStateModel
     _token: Optional[str]
     _joining: Dict[str, JoiningNodeModel]
-    _bootstrapper: Optional[Bootstrap]
     _deployment: NodeDeployment
 
     gstate: GlobalState
@@ -117,7 +115,6 @@ class NodeMgr:
         self._connmgr = get_conn_mgr()
         self._token = None
         self._joining = {}
-        self._bootstrapper = None
         self._deployment = NodeDeployment(gstate, self._connmgr)
 
         self.gstate = gstate
@@ -268,93 +265,38 @@ class NodeMgr:
     async def bootstrap(self) -> None:
 
         assert self._state
+        if self._init_stage < NodeInitStage.PRESTART:
+            raise NodeNotStartedError()
+
         if self.deployment_state.error:
             raise NodeCantBootstrapError("node is in error state")
 
-        try:
-            await self._prepare_bootstrap()
-        except NodeError as e:
-            logger.error(f"bootstrap prepare error: {e.message}")
-            raise e
+        self._token = self._generate_token()
 
-        assert not self._bootstrapper
-        await self._start_bootstrap()
-        self._bootstrapper = Bootstrap()
-
-        async def finish_bootstrap_cb(
-            success: bool,
-            error: Optional[str]
-        ) -> None:
-            if not success:
-                error = error if error else "unknown error"
-                logger.error(f"bootstrap finish error: {error}")
-                await self._finish_bootstrap_error(error)
-                return
-
-            await self._finish_bootstrap()
-
-        try:
-            await self._bootstrapper.bootstrap(
-                self.address, finish_bootstrap_cb
-            )
-        except BootstrapError as e:
-            logger.error(f"bootstrap error: {e.message}")
-            raise NodeCantBootstrapError(e.message)
-
-    async def _bootstrap_etcd(self, token: str) -> None:
         assert self._state.hostname
         assert self._state.address
-        await spawn_etcd(
-            self.gstate,
-            new=True,
-            token=token,
-            hostname=self._state.hostname,
-            address=self._state.address
+        logger.info("bootstrap node")
+        await self._deployment.bootstrap(
+            DeploymentBootstrapConfig(
+                hostname=self._state.hostname,
+                address=self._state.address,
+                token=self._token
+            ),
+            self._finish_bootstrap
         )
-
-    async def _prepare_bootstrap(self) -> None:
-        assert self._state
-        if self.deployment_state.bootstrapping:
-            raise NodeCantBootstrapError("node bootstrapping")
-        elif not self.deployment_state.nostage:
-            raise NodeCantBootstrapError("node can't be bootstrapped")
-        elif self._init_stage < NodeInitStage.PRESTART:
-            raise NodeNotStartedError()
-
-        self._token = self._generate_token()
-        logger.info(f"generated new token: {self._token}")
-        await self._bootstrap_etcd(self._token)
         await self._save_token()
 
-    async def _start_bootstrap(self) -> None:
-        assert self._state
-        assert self.deployment_state.nostage
-        assert self._state.hostname
-        assert self._state.address
-        self.deployment_state.mark_bootstrap()
-
-    async def _finish_bootstrap_error(self, error: str) -> None:
-        """
-        Called asynchronously, we don't benefit anyone by throwing
-        exceptions, but we can easily lock down the node by setting state to
-        error.
-        """
-        assert self.deployment_state.bootstrapping
-        self.deployment_state.mark_error()
-
-    async def _finish_bootstrap(self):
+    async def _finish_bootstrap(self, success: bool, error: Optional[str]):
         """
         Called asynchronously, presumes bootstrap was successful.
         """
         assert self._state
-        assert self.deployment_state.bootstrapping
 
-        logger.info("finishing bootstrap")
+        logger.info("finish bootstrap config")
         await self._finish_bootstrap_config()
+        self._deployment.finish_bootstrap()
 
-        self.deployment_state.mark_deployed()
         logger.debug(f"finished bootstrap: token = {self._token}")
-
         await self._load()
         await self._node_start()
 
@@ -386,27 +328,27 @@ class NodeMgr:
 
     @property
     def bootstrapper_stage(self) -> BootstrapStage:
-        if not self._bootstrapper:
+        if not self._deployment.bootstrapper:
             return BootstrapStage.NONE
-        return self._bootstrapper.stage
+        return self._deployment.bootstrapper.stage
 
     @property
     def bootstrapper_progress(self) -> int:
-        if not self._bootstrapper:
+        if not self._deployment.bootstrapper:
             return 0
-        return self._bootstrapper.progress
+        return self._deployment.bootstrapper.progress
 
     @property
     def bootstrapper_error_code(self) -> BootstrapErrorEnum:
-        if not self._bootstrapper:
+        if not self._deployment.bootstrapper:
             return BootstrapErrorEnum.NONE
-        return self._bootstrapper.error_code
+        return self._deployment.bootstrapper.error_code
 
     @property
     def bootstrapper_error_msg(self) -> str:
-        if not self._bootstrapper:
+        if not self._deployment.bootstrapper:
             return ""
-        return self._bootstrapper.error_msg
+        return self._deployment.bootstrapper.error_msg
 
     async def finish_deployment(self) -> None:
         assert self._state

--- a/src/gravel/controllers/resources/devices.py
+++ b/src/gravel/controllers/resources/devices.py
@@ -74,7 +74,10 @@ class Devices(Ticker):
         await self.probe()
 
     async def _should_tick(self) -> bool:
-        return (self.nodemgr.bootstrapped or self.nodemgr.ready)
+        return (
+            self.nodemgr.deployment_state.deployed or
+            self.nodemgr.deployment_state.ready
+        )
 
     async def probe(self) -> None:
 

--- a/src/gravel/controllers/resources/status.py
+++ b/src/gravel/controllers/resources/status.py
@@ -32,8 +32,7 @@ from gravel.controllers.orch.models import (
     CephStatusModel
 )
 from gravel.controllers.nodes.mgr import (
-    NodeMgr,
-    NodeStageEnum
+    NodeMgr
 )
 from gravel.controllers.services import (
     ServiceTypeEnum,
@@ -92,8 +91,10 @@ class Status(Ticker):
         await self.probe()
 
     async def _should_tick(self) -> bool:
-        return (self.nodemgr.stage >= NodeStageEnum.BOOTSTRAPPED and
-                self.nodemgr.stage != NodeStageEnum.JOINING)
+        return (
+            self.nodemgr.deployment_state.deployed or
+            self.nodemgr.deployment_state.ready
+        )
 
     async def probe(self) -> None:
         assert self._mon

--- a/src/gravel/controllers/resources/storage.py
+++ b/src/gravel/controllers/resources/storage.py
@@ -18,8 +18,7 @@ from pydantic.fields import Field
 from pydantic.main import BaseModel
 from gravel.controllers.gstate import Ticker
 from gravel.controllers.nodes.mgr import (
-    NodeMgr,
-    NodeStageEnum
+    NodeMgr
 )
 from gravel.controllers.orch.ceph import Mon
 
@@ -69,12 +68,11 @@ class Storage(Ticker):
         await self._update()
 
     async def _should_tick(self) -> bool:
-        stage = self.nodemgr.stage
-        if stage != NodeStageEnum.BOOTSTRAPPED and \
-           stage != NodeStageEnum.READY:
-            logger.debug(
-                f"not ticking, not bootstrapped (current={stage})"
-            )
+        if not (
+            self.nodemgr.deployment_state.deployed or
+            self.nodemgr.deployment_state.ready
+        ):
+            logger.debug("not ticking, not bootstrapped")
             return False
         return True
 

--- a/src/gravel/controllers/utils.py
+++ b/src/gravel/controllers/utils.py
@@ -1,0 +1,53 @@
+# project aquarium's backend
+# Copyright (C) 2021 SUSE, LLC.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+
+from pathlib import Path
+from typing import Type, TypeVar
+from pydantic import BaseModel
+from pydantic.tools import parse_file_as
+
+
+def _get_file_path(dirpath: Path, name: str) -> Path:
+    if not dirpath.exists() or not dirpath.is_dir():
+        raise NotADirectoryError()
+
+    file: Path = dirpath.joinpath(f"{name}.json")
+    return file
+
+
+T = TypeVar('T')
+
+
+def read_model(
+    dirpath: Path,
+    name: str,
+    model: Type[T]
+) -> T:
+    file: Path = _get_file_path(dirpath, name)
+    if not file.exists():
+        raise FileNotFoundError()
+    elif not file.is_file():
+        raise FileExistsError()
+    return parse_file_as(model, file)
+
+
+def write_model(
+    dirpath: Path,
+    name: str,
+    model: BaseModel
+):
+    file: Path = _get_file_path(dirpath, name)
+    if file.exists() and not file.is_file():
+        raise FileExistsError()
+    file.write_text(model.json())


### PR DESCRIPTION
This is just a first pass towards a proper rework of the initial node deployment workflow.

Right now we're simply spinning-off a bit of the bootstrap and join code to a `deployment.py` module.

I'm going to do this in batches to make it easier to review.

Signed-off-by: Joao Eduardo Luis \<joao@suse.com>