### PR TITLE
Fixtures

### DIFF
--- a/images/microOS/root/usr/lib/systemd/system/aquarium.service
+++ b/images/microOS/root/usr/lib/systemd/system/aquarium.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 User=root
 WorkingDirectory=/usr/share/aquarium
-ExecStart=/usr/local/bin/uvicorn aquarium:app --host 0.0.0.0 --port 1337
+ExecStart=/usr/local/bin/uvicorn aquarium:app_factory --factory --host 0.0.0.0 --port 1337
 Restart=always
 
 [Install]

--- a/run_aquarium.sh
+++ b/run_aquarium.sh
@@ -72,7 +72,7 @@ pushd ${SCRIPT_DIR}/src &>/dev/null
 $is_debug && export AQUARIUM_DEBUG=1
 $has_config && export AQUARIUM_CONFIG_DIR=${config_path}
 
-uvicorn aquarium:app --host 0.0.0.0 --port ${port}
+uvicorn aquarium:app_factory --factory --host 0.0.0.0 --port ${port}
 
 popd &>/dev/null
 

--- a/src/aquarium.py
+++ b/src/aquarium.py
@@ -112,7 +112,8 @@ def app_factory():
         storage: Storage = Storage(gstate.config.options.storage.probe_interval, nodemgr)
         gstate.add_storage(storage)
 
-        services: Services = Services(gstate.config.options.services.probe_interval, gstate, nodemgr)
+        services: Services = Services(
+            gstate.config.options.services.probe_interval, gstate, nodemgr)
         gstate.add_services(services)
 
         await nodemgr.start()
@@ -150,9 +151,13 @@ def app_factory():
         name="api"
     )
     # mounting root "/" must be the last thing, so it does not override "/api".
+    static_dir = os.path.join(
+        os.path.dirname(os.path.realpath(__file__)),
+        'glass/dist/'
+    )
     aquarium_app.mount(
         "/",
-        StaticFiles(directory="./glass/dist/", html=True),
+        StaticFiles(directory=static_dir, html=True),
         name="static"
     )
 

--- a/src/aquarium.py
+++ b/src/aquarium.py
@@ -19,6 +19,7 @@ import os
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
 from fastapi.logger import logger as fastapi_logger
+import uvicorn
 
 from gravel.controllers.gstate import GlobalState, setup_logging
 from gravel.controllers.nodes.mgr import NodeMgr
@@ -40,122 +41,120 @@ from gravel.api import (
 )
 
 
-logger: logging.Logger = fastapi_logger
+def app_factory():
+    logger: logging.Logger = fastapi_logger
 
+    api_tags_metadata = [
+        {
+            "name": "local",
+            "description": "Operations local to the node where the endpoint is being invoked."
+        },
+        {
+            "name": "bootstrap",
+            "description": "Allows creating a minimal cluster on the node."
+        },
+        {
+            "name": "orch",
+            "description": "Operations related to Ceph cluster orchestration."
+        },
+        {
+            "name": "status",
+            "description": "Allows obtaining operation status information."
+        },
+        {
+            "name": "services",
+            "description": "Create, destroy, and operate Aquarium Services."
+        },
+        {
+            "name": "nodes",
+            "description": "Perform Aquarium Cluster node operations"
+        },
+        {
+            "name": "devices",
+            "description": "Obtain and perform operations on cluster devices"
+        }
+    ]
 
-api_tags_metadata = [
-    {
-        "name": "local",
-        "description": "Operations local to the node where the endpoint is being invoked."
-    },
-    {
-        "name": "bootstrap",
-        "description": "Allows creating a minimal cluster on the node."
-    },
-    {
-        "name": "orch",
-        "description": "Operations related to Ceph cluster orchestration."
-    },
-    {
-        "name": "status",
-        "description": "Allows obtaining operation status information."
-    },
-    {
-        "name": "services",
-        "description": "Create, destroy, and operate Aquarium Services."
-    },
-    {
-        "name": "nodes",
-        "description": "Perform Aquarium Cluster node operations"
-    },
-    {
-        "name": "devices",
-        "description": "Obtain and perform operations on cluster devices"
-    }
-]
+    aquarium_app = FastAPI(docs_url=None)
+    aquarium_api = FastAPI(
+        title="Project Aquarium",
+        description="Project Aquarium is a SUSE-sponsored open source project " +
+                    "aiming at becoming an easy to use, rock solid storage " +
+                    "appliance based on Ceph.",
+        version="1.0.0",
+        openapi_tags=api_tags_metadata)
 
+    @aquarium_app.on_event("startup")  # type: ignore
+    async def on_startup():
 
-app = FastAPI(docs_url=None)
-api = FastAPI(
-    title="Project Aquarium",
-    description="Project Aquarium is a SUSE-sponsored open source project " +
-                "aiming at becoming an easy to use, rock solid storage " +
-                "appliance based on Ceph.",
-    version="1.0.0",
-    openapi_tags=api_tags_metadata)
+        lvl = "INFO" if not os.getenv("AQUARIUM_DEBUG") else "DEBUG"
+        setup_logging(lvl)
+        logger.info("Aquarium startup!")
 
+        gstate: GlobalState = GlobalState()
 
-@app.on_event("startup")  # type: ignore
-async def on_startup():
+        # init node mgr
+        logger.info("starting node manager")
+        nodemgr: NodeMgr = NodeMgr(gstate)
 
-    lvl = "INFO" if not os.getenv("AQUARIUM_DEBUG") else "DEBUG"
-    setup_logging(lvl)
-    logger.info("Aquarium startup!")
+        devices: Devices = Devices(gstate.config.options.devices.probe_interval, nodemgr)
+        gstate.add_devices(devices)
 
-    gstate: GlobalState = GlobalState()
+        status: Status = Status(gstate.config.options.status.probe_interval, gstate, nodemgr)
+        gstate.add_status(status)
 
-    # init node mgr
-    logger.info("starting node manager")
-    nodemgr: NodeMgr = NodeMgr(gstate)
+        inventory: Inventory = Inventory(
+            gstate.config.options.inventory.probe_interval,
+            nodemgr
+        )
+        gstate.add_inventory(inventory)
 
-    devices: Devices = Devices(gstate.config.options.devices.probe_interval, nodemgr)
-    gstate.add_devices(devices)
+        storage: Storage = Storage(gstate.config.options.storage.probe_interval, nodemgr)
+        gstate.add_storage(storage)
 
-    status: Status = Status(gstate.config.options.status.probe_interval, gstate, nodemgr)
-    gstate.add_status(status)
+        services: Services = Services(gstate.config.options.services.probe_interval, gstate, nodemgr)
+        gstate.add_services(services)
 
-    inventory: Inventory = Inventory(
-        gstate.config.options.inventory.probe_interval,
-        nodemgr
+        await nodemgr.start()
+        await gstate.start()
+
+        # Add instances into FastAPI's state:
+        aquarium_api.state.gstate = gstate
+        aquarium_api.state.nodemgr = nodemgr
+
+    @aquarium_app.on_event("shutdown")  # type: ignore
+    async def on_shutdown():
+        logger.info("Aquarium shutdown!")
+        await aquarium_api.state.gstate.shutdown()
+        logger.info("shutting down node manager")
+        await aquarium_api.state.nodemgr.shutdown()
+
+    aquarium_api.include_router(local.router)
+    aquarium_api.include_router(bootstrap.router)
+    aquarium_api.include_router(orch.router)
+    aquarium_api.include_router(status.router)
+    aquarium_api.include_router(services.router)
+    aquarium_api.include_router(nodes.router)
+    aquarium_api.include_router(devices.router)
+    aquarium_api.include_router(nfs.router)
+
+    #
+    # mounts
+    #   these should be the last things to be done, so fastapi is aware of
+    #   everything that comes before.
+    #
+    # api calls go here.
+    aquarium_app.mount(
+        "/api",
+        aquarium_api,
+        name="api"
     )
-    gstate.add_inventory(inventory)
+    # mounting root "/" must be the last thing, so it does not override "/api".
+    aquarium_app.mount(
+        "/",
+        StaticFiles(directory="./glass/dist/", html=True),
+        name="static"
+    )
 
-    storage: Storage = Storage(gstate.config.options.storage.probe_interval, nodemgr)
-    gstate.add_storage(storage)
+    return aquarium_app
 
-    services: Services = Services(gstate.config.options.services.probe_interval, gstate, nodemgr)
-    gstate.add_services(services)
-
-    await nodemgr.start()
-    await gstate.start()
-
-    # Add instances into FastAPI's state:
-    api.state.gstate = gstate
-    api.state.nodemgr = nodemgr
-
-
-@app.on_event("shutdown")  # type: ignore
-async def on_shutdown():
-    logger.info("Aquarium shutdown!")
-    await api.state.gstate.shutdown()
-    logger.info("shutting down node manager")
-    await api.state.nodemgr.shutdown()
-
-
-api.include_router(local.router)
-api.include_router(bootstrap.router)
-api.include_router(orch.router)
-api.include_router(status.router)
-api.include_router(services.router)
-api.include_router(nodes.router)
-api.include_router(devices.router)
-api.include_router(nfs.router)
-
-
-#
-# mounts
-#   these should be the last things to be done, so fastapi is aware of
-#   everything that comes before.
-#
-# api calls go here.
-app.mount(
-    "/api",
-    api,
-    name="api"
-)
-# mounting root "/" must be the last thing, so it does not override "/api".
-app.mount(
-    "/",
-    StaticFiles(directory="./glass/dist/", html=True),
-    name="static"
-)

--- a/src/aquarium.py
+++ b/src/aquarium.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # project aquarium's backend
 # Copyright (C) 2021 SUSE, LLC.
@@ -158,3 +158,6 @@ def app_factory():
 
     return aquarium_app
 
+
+if __name__ == "__main__":
+    uvicorn.run("aquarium:app_factory", host="0.0.0.0", port=1337, factory=True)

--- a/src/aquarium.py
+++ b/src/aquarium.py
@@ -21,6 +21,7 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.logger import logger as fastapi_logger
 import uvicorn
 
+from gravel.cephadm.cephadm import Cephadm
 from gravel.controllers.gstate import GlobalState, setup_logging
 from gravel.controllers.nodes.mgr import NodeMgr
 from gravel.controllers.orch.ceph import Ceph, Mgr, Mon
@@ -99,6 +100,10 @@ def app_factory():
         logger.info("starting node manager")
         nodemgr: NodeMgr = NodeMgr(gstate)
 
+        # Prep cephadm
+        cephadm: Cephadm = Cephadm()
+        gstate.add_cephadm(cephadm)
+
         # Set up Ceph connections
         ceph: Ceph = Ceph()
         ceph_mgr: Mgr = Mgr(ceph)
@@ -122,7 +127,8 @@ def app_factory():
 
         inventory: Inventory = Inventory(
             gstate.config.options.inventory.probe_interval,
-            nodemgr
+            nodemgr,
+            gstate
         )
         gstate.add_inventory(inventory)
 

--- a/src/aquarium.py
+++ b/src/aquarium.py
@@ -25,7 +25,6 @@ from gravel.cephadm.cephadm import Cephadm
 from gravel.controllers.gstate import GlobalState, setup_logging
 from gravel.controllers.nodes.mgr import NodeMgr
 from gravel.controllers.orch.ceph import Ceph, Mgr, Mon
-from gravel.controllers.orch.cephfs import CephFS
 from gravel.controllers.resources.inventory import Inventory
 from gravel.controllers.resources.devices import Devices
 from gravel.controllers.resources.status import Status
@@ -67,8 +66,6 @@ async def aquarium_startup(aquarium_app: FastAPI, aquarium_api: FastAPI):
     gstate.add_ceph_mgr(ceph_mgr)
     ceph_mon: Mon = Mon(ceph)
     gstate.add_ceph_mon(ceph_mon)
-    cephfs: CephFS = CephFS(ceph_mgr, ceph_mon)
-    gstate.add_cephfs(cephfs)
 
     # Set up all of the tickers
     devices: Devices = Devices(

--- a/src/aquarium.py
+++ b/src/aquarium.py
@@ -111,7 +111,11 @@ async def aquarium_shutdown(aquarium_app: FastAPI, aquarium_api: FastAPI):
     await aquarium_api.state.nodemgr.shutdown()
 
 
-def app_factory(startup_method=aquarium_startup, shutdown_method=aquarium_shutdown):
+def aquarium_factory(
+    startup_method=aquarium_startup,
+    shutdown_method=aquarium_shutdown,
+    static_dir=None
+):
     api_tags_metadata = [
         {
             "name": "local",
@@ -181,17 +185,22 @@ def app_factory(startup_method=aquarium_startup, shutdown_method=aquarium_shutdo
         name="api"
     )
     # mounting root "/" must be the last thing, so it does not override "/api".
+    if static_dir:
+        aquarium_app.mount(
+            "/",
+            StaticFiles(directory=static_dir, html=True),
+            name="static"
+        )
+
+    return aquarium_app
+
+
+def app_factory():
     static_dir = os.path.join(
         os.path.dirname(os.path.realpath(__file__)),
         'glass/dist/'
     )
-    aquarium_app.mount(
-        "/",
-        StaticFiles(directory=static_dir, html=True),
-        name="static"
-    )
-
-    return aquarium_app
+    return aquarium_factory(aquarium_startup, aquarium_shutdown, static_dir)
 
 
 if __name__ == "__main__":

--- a/src/gravel/api/local.py
+++ b/src/gravel/api/local.py
@@ -21,7 +21,6 @@ from pydantic import (
     Field
 )
 
-from gravel.cephadm.cephadm import Cephadm
 from gravel.cephadm.models import (
     NodeInfoModel,
     VolumeDeviceModel
@@ -68,7 +67,7 @@ async def get_volumes(request: Request) -> List[VolumeDeviceModel]:
     name="Obtain local node information",
     response_model=NodeInfoModel
 )
-async def get_node_info() -> NodeInfoModel:
+async def get_node_info(request: Request) -> NodeInfoModel:
     """
     Obtain this node's information and facts.
 
@@ -79,7 +78,7 @@ async def get_node_info() -> NodeInfoModel:
 
     This is a sync call to `cephadm` and may take a while to return.
     """
-    cephadm = Cephadm()
+    cephadm = request.app.state.gstate.cephadm
     return await cephadm.get_node_info()
 
 

--- a/src/gravel/api/orch.py
+++ b/src/gravel/api/orch.py
@@ -60,7 +60,7 @@ class SetNtpRequest(BaseModel):
 
 @router.get("/hosts", response_model=List[HostModel])
 def get_hosts(request: Request) -> List[HostModel]:
-    orch = Orchestrator(request.app.state.ceph_mgr)
+    orch = Orchestrator(request.app.state.gstate.ceph_mgr)
     orch_hosts = orch.host_ls()
     hosts: List[HostModel] = []
     for h in orch_hosts:
@@ -70,7 +70,7 @@ def get_hosts(request: Request) -> List[HostModel]:
 
 @router.get("/devices", response_model=Dict[str, HostsDevicesModel])
 def get_devices(request: Request) -> Dict[str, HostsDevicesModel]:
-    orch = Orchestrator(request.app.state.ceph_mgr)
+    orch = Orchestrator(request.app.state.gstate.ceph_mgr)
     orch_devs_per_host: List[OrchDevicesPerHostModel] = orch.devices_ls()
     host_devs: Dict[str, HostsDevicesModel] = {}
     for orch_host in orch_devs_per_host:
@@ -104,7 +104,7 @@ def get_devices(request: Request) -> Dict[str, HostsDevicesModel]:
 async def assimilate_devices(request: Request) -> bool:
 
     try:
-        orch = Orchestrator(request.app.state.ceph_mgr)
+        orch = Orchestrator(request.app.state.gstate.ceph_mgr)
         orch.assimilate_all_devices()
     except Exception as e:
         logger.error(str(e))
@@ -116,7 +116,7 @@ async def assimilate_devices(request: Request) -> bool:
 @router.get("/devices/all_assimilated", response_model=bool)
 async def all_devices_assimilated(request: Request) -> bool:
     try:
-        orch = Orchestrator(request.app.state.ceph_mgr)
+        orch = Orchestrator(request.app.state.gstate.ceph_mgr)
         return orch.all_devices_assimilated()
     except Exception as e:
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -126,7 +126,7 @@ async def all_devices_assimilated(request: Request) -> bool:
 @router.get("/pubkey")
 async def get_pubkey(request: Request) -> str:
     try:
-        orch = Orchestrator(request.app.state.ceph_mgr)
+        orch = Orchestrator(request.app.state.gstate.ceph_mgr)
         return orch.get_public_key()
     except Exception as e:
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,

--- a/src/gravel/api/services.py
+++ b/src/gravel/api/services.py
@@ -162,8 +162,9 @@ async def get_statistics(request: Request) -> Dict[str, ServiceStorageModel]:
     response_model=CephFSAuthorizationModel
 )
 async def get_authorization(
+    request: Request,
     name: str,
-    clientid: Optional[str] = None
+    clientid: Optional[str] = None,
 ) -> CephFSAuthorizationModel:
     """
     Obtain authorization credentials for a given service `name`. In case of
@@ -171,7 +172,7 @@ async def get_authorization(
     will obtain the authorization for a client with said `clientid`, if it
     exists.
     """
-    cephfs: CephFS = CephFS()
+    cephfs: CephFS = request.app.state.cephfs
     try:
         result = cephfs.get_authorization(name, clientid)
         return result

--- a/src/gravel/api/services.py
+++ b/src/gravel/api/services.py
@@ -172,7 +172,8 @@ async def get_authorization(
     will obtain the authorization for a client with said `clientid`, if it
     exists.
     """
-    cephfs: CephFS = request.app.state.cephfs
+    cephfs: CephFS = CephFS(
+        request.app.state.gstate.ceph_mgr, request.app.state.gstate.ceph_mon)
     try:
         result = cephfs.get_authorization(name, clientid)
         return result

--- a/src/gravel/cephadm/cephadm.py
+++ b/src/gravel/cephadm/cephadm.py
@@ -49,15 +49,12 @@ class CephadmError(Exception):
 class Cephadm:
 
     def __init__(self):
-
         if os.path.exists("./gravel/cephadm/cephadm.bin"):
             # dev environment
             self.cephadm = "sudo ./gravel/cephadm/cephadm.bin"
         else:
             # deployment environment
             self.cephadm = "sudo cephadm"
-
-        pass
 
     async def call(self, cmd: str,
                    outcb: Optional[Callable[[str], None]] = None

--- a/src/gravel/controllers/gstate.py
+++ b/src/gravel/controllers/gstate.py
@@ -23,6 +23,8 @@ from fastapi.logger import logger as fastapi_logger
 
 from gravel.controllers.config import Config
 from gravel.controllers.kv import KV
+from gravel.controllers.orch.ceph import Mgr, Mon
+from gravel.controllers.orch.cephfs import CephFS
 
 import typing
 if typing.TYPE_CHECKING:
@@ -128,12 +130,24 @@ class GlobalState:
     inventory: Inventory
     storage: Storage
     services: Services
+    cephfs: CephFS
+    ceph_mgr: Mgr
+    ceph_mon: Mon
 
     def __init__(self):
         self._config = Config()
         self._is_shutting_down = False
         self._tickers = {}
         self._kvstore = KV()
+
+    def add_cephfs(self, cephfs: CephFS):
+        self.cephfs = cephfs
+
+    def add_ceph_mgr(self, mgr: Mgr):
+        self.mgr = mgr
+
+    def add_ceph_mon(self, ceph_mon: Mon):
+        self.ceph_mon = ceph_mon
 
     def add_devices(self, devices: Devices):
         self.devices = devices

--- a/src/gravel/controllers/gstate.py
+++ b/src/gravel/controllers/gstate.py
@@ -144,7 +144,7 @@ class GlobalState:
         self.cephadm = cephadm
 
     def add_ceph_mgr(self, mgr: Mgr):
-        self.mgr = mgr
+        self.ceph_mgr = mgr
 
     def add_ceph_mon(self, ceph_mon: Mon):
         self.ceph_mon = ceph_mon

--- a/src/gravel/controllers/gstate.py
+++ b/src/gravel/controllers/gstate.py
@@ -25,7 +25,6 @@ from gravel.cephadm.cephadm import Cephadm
 from gravel.controllers.config import Config
 from gravel.controllers.kv import KV
 from gravel.controllers.orch.ceph import Mgr, Mon
-from gravel.controllers.orch.cephfs import CephFS
 
 import typing
 if typing.TYPE_CHECKING:
@@ -132,7 +131,6 @@ class GlobalState:
     storage: Storage
     services: Services
     cephadm: Cephadm
-    cephfs: CephFS
     ceph_mgr: Mgr
     ceph_mon: Mon
 
@@ -141,9 +139,6 @@ class GlobalState:
         self._is_shutting_down = False
         self._tickers = {}
         self._kvstore = KV()
-
-    def add_cephfs(self, cephfs: CephFS):
-        self.cephfs = cephfs
 
     def add_cephadm(self, cephadm: Cephadm):
         self.cephadm = cephadm

--- a/src/gravel/controllers/gstate.py
+++ b/src/gravel/controllers/gstate.py
@@ -21,6 +21,7 @@ from logging import Logger
 from typing import Dict
 from fastapi.logger import logger as fastapi_logger
 
+from gravel.cephadm.cephadm import Cephadm
 from gravel.controllers.config import Config
 from gravel.controllers.kv import KV
 from gravel.controllers.orch.ceph import Mgr, Mon
@@ -130,6 +131,7 @@ class GlobalState:
     inventory: Inventory
     storage: Storage
     services: Services
+    cephadm: Cephadm
     cephfs: CephFS
     ceph_mgr: Mgr
     ceph_mon: Mon
@@ -142,6 +144,9 @@ class GlobalState:
 
     def add_cephfs(self, cephfs: CephFS):
         self.cephfs = cephfs
+
+    def add_cephadm(self, cephadm: Cephadm):
+        self.cephadm = cephadm
 
     def add_ceph_mgr(self, mgr: Mgr):
         self.mgr = mgr

--- a/src/gravel/controllers/kv.py
+++ b/src/gravel/controllers/kv.py
@@ -46,6 +46,7 @@ class Lock:
 class KV:
 
     _client: Optional[aetcd3.Etcd3Client]
+    _is_open: bool
     _is_closing: bool
 
     def __init__(self):
@@ -69,15 +70,18 @@ class KV:
             break
         if opened:
             self._client = aetcd3.client()
+            self._is_open = True
             logger.info("opened kvstore connection")
 
     async def close(self) -> None:
         """ Close k/v store connection """
         self._is_closing = True
         if not self._client:
+            self._is_open = False
             return
         await self._client.close()
         self._client = None
+        self._is_open = False
 
     async def put(self, key: str, value: str) -> None:
         """ Put key/value pair """

--- a/src/gravel/controllers/nodes/bootstrap.py
+++ b/src/gravel/controllers/nodes/bootstrap.py
@@ -18,6 +18,7 @@ from typing import Awaitable, Callable, Optional
 from fastapi.logger import logger as fastapi_logger
 
 from gravel.cephadm.cephadm import Cephadm
+from gravel.controllers.gstate import GlobalState
 
 
 logger: Logger = fastapi_logger  # required to provide type-hint to pylance
@@ -53,13 +54,14 @@ class Bootstrap:
     _progress: int
     _error_code: BootstrapErrorEnum
     _error_msg: str
+    _gstate: GlobalState
 
-    def __init__(self):
+    def __init__(self, gstate: GlobalState):
         self._stage = BootstrapStage.NONE
         self._progress = 0
         self._error_code = BootstrapErrorEnum.NONE
         self._error_msg = ""
-        pass
+        self._gstate = gstate
 
     async def bootstrap(
         self,
@@ -114,7 +116,7 @@ class Bootstrap:
 
         retcode: int = 0
         try:
-            cephadm: Cephadm = Cephadm()
+            cephadm: Cephadm = self._gstate.cephadm
             _, _, retcode = await cephadm.bootstrap(address, progress_cb)
         except Exception as e:
             await cb(False, f"error bootstrapping: {str(e)}")

--- a/src/gravel/controllers/nodes/deployment.py
+++ b/src/gravel/controllers/nodes/deployment.py
@@ -348,7 +348,7 @@ class NodeDeployment:
 
         assert not self._bootstrapper
         await _start()
-        self._bootstrapper = Bootstrap()
+        self._bootstrapper = Bootstrap(self._gstate)
 
         try:
             await self._bootstrapper.bootstrap(

--- a/src/gravel/controllers/nodes/deployment.py
+++ b/src/gravel/controllers/nodes/deployment.py
@@ -289,6 +289,26 @@ class NodeDeployment:
         self._state.mark_ready()
         return True
 
+    async def _prepare_etcd(
+        self,
+        hostname: str,
+        address: str,
+        token: str
+    ) -> None:
+        assert self._state
+        if self._state.bootstrapping:
+            raise NodeCantBootstrapError("node bootstrapping")
+        elif not self._state.nostage:
+            raise NodeCantBootstrapError("node can't be bootstrapped")
+
+        await spawn_etcd(
+            self._gstate,
+            new=True,
+            token=token,
+            hostname=hostname,
+            address=address
+        )
+
     async def bootstrap(
         self,
         config: DeploymentBootstrapConfig,
@@ -306,25 +326,6 @@ class NodeDeployment:
         if self._state.error:
             raise NodeCantBootstrapError("node is in error state")
 
-        async def _prepare(
-            hostname: str,
-            address: str,
-            token: str
-        ) -> None:
-            assert self._state
-            if self._state.bootstrapping:
-                raise NodeCantBootstrapError("node bootstrapping")
-            elif not self._state.nostage:
-                raise NodeCantBootstrapError("node can't be bootstrapped")
-
-            await spawn_etcd(
-                self._gstate,
-                new=True,
-                token=token,
-                hostname=hostname,
-                address=address
-            )
-
         async def _start() -> None:
             assert self._state
             assert self._state.nostage
@@ -341,7 +342,7 @@ class NodeDeployment:
             await finisher(success, error)
 
         try:
-            await _prepare(hostname, address, token)
+            await self._prepare_etcd(hostname, address, token)
         except NodeError as e:
             logger.error(f"bootstrap prepare error: {e.message}")
             raise e

--- a/src/gravel/controllers/nodes/etcd.py
+++ b/src/gravel/controllers/nodes/etcd.py
@@ -119,8 +119,9 @@ async def spawn_etcd(
 
     cmd = _get_container_cmd()
 
+    ctx = multiprocessing.get_context("spawn")
     logger.debug("spawn etcd: " + shlex.join(cmd))
-    process = multiprocessing.Process(
+    process = ctx.Process(
         target=_bootstrap_etcd_process,
         args=(cmd,)
     )

--- a/src/gravel/controllers/nodes/mgr.py
+++ b/src/gravel/controllers/nodes/mgr.py
@@ -27,7 +27,7 @@ import aetcd3
 from pydantic import BaseModel
 from fastapi import status
 from fastapi.logger import logger as fastapi_logger
-from gravel.cephadm.cephadm import Cephadm, CephadmError
+from gravel.cephadm.cephadm import CephadmError
 from gravel.cephadm.models import NodeInfoModel
 from gravel.controllers.gstate import GlobalState
 from gravel.controllers.nodes.bootstrap import (
@@ -203,7 +203,7 @@ class NodeMgr:
     async def _node_prepare(self) -> None:
 
         async def _obtain_images() -> bool:
-            cephadm = Cephadm()
+            cephadm = self.gstate.cephadm
             try:
                 await asyncio.gather(
                     cephadm.pull_images(),

--- a/src/gravel/controllers/nodes/mgr.py
+++ b/src/gravel/controllers/nodes/mgr.py
@@ -361,7 +361,7 @@ class NodeMgr:
         await self._node_start()
 
     async def _finish_bootstrap_config(self) -> None:
-        mon: Mon = Mon()
+        mon: Mon = self.gstate.ceph_mon
         try:
             mon.set_allow_pool_size_one()
         except CephCommandError as e:
@@ -555,7 +555,7 @@ class NodeMgr:
             )
             return
 
-        orch = Orchestrator()
+        orch = Orchestrator(self.gstate.ceph_mgr)
         pubkey: str = orch.get_public_key()
 
         cephconf_path: Path = Path("/etc/ceph/ceph.conf")
@@ -633,13 +633,13 @@ class NodeMgr:
         node: JoiningNodeModel = self._joining[address]
         logger.info("handle ready to add > "
                     f"hostname: {node.hostname}, address: {node.address}")
-        orch = Orchestrator()
+        orch = Orchestrator(self.gstate.ceph_mgr)
         if not orch.host_add(node.hostname, node.address):
             logger.error("handle ready > failed adding host to orch")
 
         # reset default crush ruleset, and adjust pools to use a multi-node
         # ruleset, spreading replicas across hosts rather than osds.
-        mon = Mon()
+        mon = self.gstate.ceph_mon
         if not mon.set_replicated_ruleset():
             logger.error(
                 "handle ready to add > unable to set replicated ruleset")

--- a/src/gravel/controllers/nodes/mgr.py
+++ b/src/gravel/controllers/nodes/mgr.py
@@ -12,7 +12,6 @@
 # GNU General Public License for more details.
 
 import asyncio
-import multiprocessing
 from enum import Enum
 from logging import Logger
 from uuid import UUID, uuid4
@@ -154,8 +153,6 @@ class NodeMgr:
         self._deployment = NodeDeployment(gstate, self._connmgr)
 
         self.gstate = gstate
-
-        multiprocessing.set_start_method("spawn")
 
         # attempt reading our node state from disk; create one if not found.
         try:

--- a/src/gravel/controllers/orch/ceph.py
+++ b/src/gravel/controllers/orch/ceph.py
@@ -37,6 +37,11 @@ from gravel.controllers.orch.models import (
     CephStatusModel
 )
 
+# Attempt to import rados
+# NOTE(jhesketh): rados comes from a system package and cannot be installed from
+#                 pypi. So for testing it may not exist on the machine. A check
+#                 is made in `Ceph.connect` for whether the package exists.
+#                 Tests overwrite this to simulate their own cluster.
 try:
     import rados
 except ModuleNotFoundError:

--- a/src/gravel/controllers/orch/ceph.py
+++ b/src/gravel/controllers/orch/ceph.py
@@ -94,12 +94,16 @@ class Ceph:
 
     def __init__(self, conf_file: str = CEPH_CONF_FILE):
         self.conf_file = conf_file
+        self._is_connected = False
+
+    def _check_config(self):
         path = Path(self.conf_file)
         if not path.exists():
             raise FileNotFoundError(self.conf_file)
-        self._is_connected = False
 
     def connect(self):
+        self._check_config()
+
         if 'rados' not in sys.modules:
             raise MissingSystemDependency("python3-rados module not found")
 

--- a/src/gravel/controllers/orch/ceph.py
+++ b/src/gravel/controllers/orch/ceph.py
@@ -152,7 +152,6 @@ class Ceph:
     def _cmd(self, func: Callable[[str, bytes], Any],
              cmd: Dict[str, Any]
              ) -> Any:
-        self.connect()
         self.assert_is_ready()
         cmdstr: str = json.dumps(cmd)
 
@@ -176,9 +175,11 @@ class Ceph:
         return res
 
     def mon(self, cmd: Dict[str, Any]) -> Any:
+        self.connect()
         return self._cmd(self.cluster.mon_command, cmd)
 
     def mgr(self, cmd: Dict[str, Any]) -> Any:
+        self.connect()
         return self._cmd(self.cluster.mgr_command, cmd)
 
 

--- a/src/gravel/controllers/orch/cephfs.py
+++ b/src/gravel/controllers/orch/cephfs.py
@@ -38,10 +38,9 @@ class CephFS:
     mgr: Mgr
     mon: Mon
 
-    def __init__(self):
-        self.mgr = Mgr()
-        self.mon = Mon()
-        pass
+    def __init__(self, mgr: Mgr, mon: Mon):
+        self.mgr = mgr
+        self.mon = mon
 
     def create(self, name: str) -> None:
 
@@ -56,7 +55,7 @@ class CephFS:
             raise CephFSError(e) from e
 
         # schedule orchestrator to update the number of mds instances
-        orch = Orchestrator()
+        orch = Orchestrator(self.mgr)
         orch.apply_mds(name)
 
     def volume_ls(self) -> CephFSVolumeListModel:

--- a/src/gravel/controllers/orch/nfs.py
+++ b/src/gravel/controllers/orch/nfs.py
@@ -57,8 +57,8 @@ class NFSError(Exception):
 class NFS:
     mgr: Mgr
 
-    def __init__(self):
-        self.mgr = Mgr()
+    def __init__(self, ceph_mgr: Mgr):
+        self.mgr = ceph_mgr
 
     def _call(self, cmd: Dict[str, Any]) -> Any:
         try:

--- a/src/gravel/controllers/orch/orchestrator.py
+++ b/src/gravel/controllers/orch/orchestrator.py
@@ -33,8 +33,8 @@ class Orchestrator:
 
     cluster: Mgr
 
-    def __init__(self):
-        self.cluster = Mgr()
+    def __init__(self, ceph_mgr: Mgr):
+        self.cluster = ceph_mgr
 
     def call(self, cmd: Dict[str, Any]) -> Any:
         if "format" not in cmd:

--- a/src/gravel/controllers/resources/devices.py
+++ b/src/gravel/controllers/resources/devices.py
@@ -26,7 +26,7 @@ from gravel.controllers.gstate import Ticker
 from gravel.controllers.nodes.mgr import (
     NodeMgr
 )
-from gravel.controllers.orch.ceph import Mon
+from gravel.controllers.orch.ceph import Mgr, Mon
 from gravel.cephadm.models import VolumeDeviceModel
 from gravel.controllers.orch.models import (
     CephOSDDFModel,
@@ -66,9 +66,11 @@ class Devices(Ticker):
     _osds_per_host: Dict[str, List[int]] = {}
     _osd_entries: Dict[int, DeviceModel] = {}
 
-    def __init__(self, probe_interval: float, nodemgr: NodeMgr):
+    def __init__(self, probe_interval: float, nodemgr: NodeMgr, ceph_mgr: Mgr, ceph_mon: Mon):
         super().__init__(probe_interval)
         self.nodemgr = nodemgr
+        self.ceph_mon = ceph_mon
+        self.ceph_mgr = ceph_mgr
 
     async def _do_tick(self) -> None:
         await self.probe()
@@ -83,8 +85,8 @@ class Devices(Ticker):
 
         logger.debug("probe devices")
 
-        orch: Orchestrator = Orchestrator()
-        mon: Mon = Mon()
+        orch: Orchestrator = Orchestrator(self.ceph_mgr)
+        mon: Mon = self.ceph_mon
         device_lst: List[OrchDevicesPerHostModel] = orch.devices_ls()
         osd_df: CephOSDDFModel = mon.osd_df()
 

--- a/src/gravel/controllers/resources/status.py
+++ b/src/gravel/controllers/resources/status.py
@@ -79,15 +79,11 @@ class Status(Ticker):
         super().__init__(probe_interval)
         self.gstate = gstate
         self.nodemgr = nodemgr
-        self._mon = None
+        self._mon = gstate.ceph_mon
         self._latest_cluster = None
         self._latest_pools_stats = {}
 
     async def _do_tick(self) -> None:
-
-        if not self._mon:
-            self._mon = Mon()
-
         await self.probe()
 
     async def _should_tick(self) -> bool:

--- a/src/gravel/controllers/resources/storage.py
+++ b/src/gravel/controllers/resources/storage.py
@@ -59,9 +59,10 @@ class StorageModel(BaseModel):
 
 class Storage(Ticker):
 
-    def __init__(self, probe_interval: float, nodemgr: NodeMgr):
+    def __init__(self, probe_interval: float, nodemgr: NodeMgr, ceph_mon: Mon):
         super().__init__(probe_interval)
-        self.nodemgr = nodemgr
+        self.nodemgr: NodeMgr = nodemgr
+        self.ceph_mon: Mon = ceph_mon
         self._state: StorageModel = StorageModel()
 
     async def _do_tick(self) -> None:
@@ -90,7 +91,7 @@ class Storage(Ticker):
 
     async def _update(self) -> None:
         try:
-            mon = Mon()
+            mon = self.ceph_mon
             df = mon.df()
         except Exception as e:
             raise StorageError("error obtaining info from cluster") from e

--- a/src/gravel/controllers/services.py
+++ b/src/gravel/controllers/services.py
@@ -21,7 +21,7 @@ from gravel.controllers.nodes.mgr import (
     NodeMgr
 )
 
-from gravel.controllers.orch.cephfs import CephFSError
+from gravel.controllers.orch.cephfs import CephFS, CephFSError
 from gravel.controllers.orch.models import (
     CephFSListEntryModel,
     CephOSDPoolEntryModel
@@ -342,7 +342,7 @@ class Services(Ticker):
     def _create_cephfs(self, svc: ServiceModel) -> None:
         assert self._is_ready()
 
-        cephfs = self.gstate.cephfs
+        cephfs: CephFS = CephFS(self.gstate.ceph_mgr, self.gstate.ceph_mon)
         assert cephfs
 
         try:

--- a/src/gravel/tests/conftest.py
+++ b/src/gravel/tests/conftest.py
@@ -372,7 +372,10 @@ async def services(gstate):
 def app(caplog, aquarium_startup, aquarium_shutdown):
     caplog.set_level(logging.DEBUG)
     import aquarium
-    return aquarium.app_factory(startup_method=aquarium_startup, shutdown_method=aquarium_shutdown)
+    return aquarium.aquarium_factory(
+        startup_method=aquarium_startup,
+        shutdown_method=aquarium_shutdown
+    )
 
 
 @pytest.fixture

--- a/src/gravel/tests/conftest.py
+++ b/src/gravel/tests/conftest.py
@@ -177,7 +177,7 @@ class FakeKV(KV):
 
 @pytest.fixture()
 @pytest.mark.asyncio
-async def aquarium_startup(mocker):
+async def aquarium_startup(get_data_contents, mocker):
     async def startup(aquarium_app, aquarium_api):
         from gravel.cephadm.cephadm import Cephadm
         from gravel.controllers.nodes.mgr import NodeMgr, NodeError, NodeInitStage
@@ -243,9 +243,9 @@ async def aquarium_startup(mocker):
                 if cmd == 'pull':
                     return '', '', 0
                 elif cmd == 'gather-facts':
-                    return get_data_contents_raw(DATA_DIR, 'gather_facts_real.json'), "", 0
+                    return get_data_contents(DATA_DIR, 'gather_facts_real.json'), "", 0
                 elif cmd == 'ceph-volume inventory --format=json':
-                    return get_data_contents_raw(DATA_DIR, 'inventory_real.json'), "", 0
+                    return get_data_contents(DATA_DIR, 'inventory_real.json'), "", 0
                 else:
                     print(cmd)
                     print(outcb)

--- a/src/gravel/tests/conftest.py
+++ b/src/gravel/tests/conftest.py
@@ -19,6 +19,7 @@ from pyfakefs import fake_filesystem  # pyright: reportMissingTypeStubs=false
 from _pytest.fixtures import SubRequest
 from pytest_mock import MockerFixture
 
+from gravel.cephadm.cephadm import Cephadm
 from gravel.controllers.gstate import GlobalState
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), 'data')
@@ -143,6 +144,10 @@ async def gstate(fs: fake_filesystem.FakeFilesystem, mocker: MockerFixture):
     # init node mgr
     nodemgr: NodeMgr = NodeMgr(gstate)
 
+    # Prep cephadm
+    cephadm: Cephadm = Cephadm()
+    gstate.add_cephadm(cephadm)
+
     # Set up Ceph connections
     ceph: Ceph = FakeCeph()
     ceph_mgr: Mgr = Mgr(ceph)
@@ -166,7 +171,8 @@ async def gstate(fs: fake_filesystem.FakeFilesystem, mocker: MockerFixture):
 
     inventory: Inventory = Inventory(
         gstate.config.options.inventory.probe_interval,
-        nodemgr
+        nodemgr,
+        gstate
     )
     gstate.add_inventory(inventory)
 

--- a/src/gravel/tests/conftest.py
+++ b/src/gravel/tests/conftest.py
@@ -187,7 +187,6 @@ async def aquarium_startup(get_data_contents, mocker):
         from gravel.controllers.resources.storage import Storage
         from gravel.controllers.services import Services, ServiceModel
         from gravel.controllers.orch.ceph import Ceph, Mgr, Mon
-        from gravel.controllers.orch.cephfs import CephFS
         from gravel.controllers.nodes.deployment import NodeDeployment, NodeCantBootstrapError
         from fastapi.logger import logger as fastapi_logger
 
@@ -297,8 +296,6 @@ async def aquarium_startup(get_data_contents, mocker):
         gstate.add_ceph_mgr(ceph_mgr)
         ceph_mon: Mon = Mon(ceph)
         gstate.add_ceph_mon(ceph_mon)
-        cephfs: CephFS = CephFS(ceph_mgr, ceph_mon)
-        gstate.add_cephfs(cephfs)
 
         # Set up all of the tickers
         devices: Devices = Devices(

--- a/src/gravel/tests/data/gather_facts_real.json
+++ b/src/gravel/tests/data/gather_facts_real.json
@@ -1,0 +1,114 @@
+{
+    "arch": "x86_64",
+    "bios_date": "04/01/2014",
+    "bios_version": "rel-1.13.0-0-gf21b5a4-rebuilt.opensuse.org",
+    "cpu_cores": 1,
+    "cpu_count": 1,
+    "cpu_load": {
+      "15min": 0.0,
+      "1min": 0.03,
+      "5min": 0.03
+    },
+    "cpu_model": "AMD EPYC Processor (with IBPB)",
+    "cpu_threads": 1,
+    "flash_capacity": "0.0",
+    "flash_capacity_bytes": 0,
+    "flash_count": 0,
+    "flash_list": [],
+    "hdd_capacity": "60.1GB",
+    "hdd_capacity_bytes": 60129542144,
+    "hdd_count": 5,
+    "hdd_list": [
+      {
+        "description": "Virtio Block Device Unknown (8.6GB)",
+        "dev_name": "vdd",
+        "disk_size_bytes": 8589934592,
+        "model": "Unknown",
+        "rev": "Unknown",
+        "vendor": "Virtio Block Device",
+        "wwid": "Unknown"
+      },
+      {
+        "description": "Virtio Block Device Unknown (8.6GB)",
+        "dev_name": "vdb",
+        "disk_size_bytes": 8589934592,
+        "model": "Unknown",
+        "rev": "Unknown",
+        "vendor": "Virtio Block Device",
+        "wwid": "Unknown"
+      },
+      {
+        "description": "Virtio Block Device Unknown (8.6GB)",
+        "dev_name": "vde",
+        "disk_size_bytes": 8589934592,
+        "model": "Unknown",
+        "rev": "Unknown",
+        "vendor": "Virtio Block Device",
+        "wwid": "Unknown"
+      },
+      {
+        "description": "Virtio Block Device Unknown (8.6GB)",
+        "dev_name": "vdc",
+        "disk_size_bytes": 8589934592,
+        "model": "Unknown",
+        "rev": "Unknown",
+        "vendor": "Virtio Block Device",
+        "wwid": "Unknown"
+      },
+      {
+        "description": "Virtio Block Device Unknown (25.8GB)",
+        "dev_name": "vda",
+        "disk_size_bytes": 25769803776,
+        "model": "Unknown",
+        "rev": "Unknown",
+        "vendor": "Virtio Block Device",
+        "wwid": "Unknown"
+      }
+    ],
+    "hostname": "node01",
+    "interfaces": {
+      "eth0": {
+        "driver": "virtio_net",
+        "iftype": "physical",
+        "ipv4_address": "192.168.121.235/24",
+        "ipv6_address": "fe80::5054:ff:fe7c:6929/64",
+        "lower_devs_list": [],
+        "mtu": 1500,
+        "nic_type": "ethernet",
+        "operstate": "up",
+        "speed": -1,
+        "upper_devs_list": []
+      },
+      "lo": {
+        "driver": "",
+        "iftype": "logical",
+        "ipv4_address": "127.0.0.1/8",
+        "ipv6_address": "::1/128",
+        "lower_devs_list": [],
+        "mtu": 65536,
+        "nic_type": "loopback",
+        "operstate": "unknown",
+        "speed": -1,
+        "upper_devs_list": []
+      }
+    },
+    "kernel": "5.10.12-1-default",
+    "kernel_parameters": {
+      "net.ipv4.ip_nonlocal_bind": "0"
+    },
+    "kernel_security": {
+      "description": "AppArmor: Enabled(45 enforce)",
+      "enforce": 45,
+      "type": "AppArmor"
+    },
+    "memory_available_kb": 3665636,
+    "memory_free_kb": 3676188,
+    "memory_total_kb": 4014412,
+    "model": " (Standard PC (i440FX + PIIX, 1996))",
+    "nic_count": 1,
+    "operating_system": "Unknown",
+    "subscribed": "Unknown",
+    "system_uptime": 157.45,
+    "timestamp": 1613800833.7839758,
+    "vendor": "QEMU"
+  }

--- a/src/gravel/tests/data/inventory_real.json
+++ b/src/gravel/tests/data/inventory_real.json
@@ -1,0 +1,177 @@
+[
+    {
+        "available": true,
+        "device_id": "01123456",
+        "lsm_data": {},
+        "lvs": [],
+        "path": "/dev/vdb",
+        "rejected_reasons": [],
+        "sys_api": {
+            "human_readable_size": "8.00 GB",
+            "locked": 0,
+            "model": "",
+            "nr_requests": "256",
+            "partitions": {},
+            "path": "/dev/vdb",
+            "removable": "0",
+            "rev": "",
+            "ro": "0",
+            "rotational": "1",
+            "sas_address": "",
+            "sas_device_handle": "",
+            "scheduler_mode": "mq-deadline",
+            "sectors": 0,
+            "sectorsize": "512",
+            "size": 8589934592.0,
+            "support_discard": "512",
+            "vendor": "0x1af4"
+        }
+    },
+    {
+        "available": true,
+        "device_id": "01789101",
+        "lsm_data": {},
+        "lvs": [],
+        "path": "/dev/vdc",
+        "rejected_reasons": [],
+        "sys_api": {
+            "human_readable_size": "8.00 GB",
+            "locked": 0,
+            "model": "",
+            "nr_requests": "256",
+            "partitions": {},
+            "path": "/dev/vdc",
+            "removable": "0",
+            "rev": "",
+            "ro": "0",
+            "rotational": "1",
+            "sas_address": "",
+            "sas_device_handle": "",
+            "scheduler_mode": "mq-deadline",
+            "sectors": 0,
+            "sectorsize": "512",
+            "size": 8589934592.0,
+            "support_discard": "512",
+            "vendor": "0x1af4"
+        }
+    },
+    {
+        "available": true,
+        "device_id": "01112131",
+        "lsm_data": {},
+        "lvs": [],
+        "path": "/dev/vdd",
+        "rejected_reasons": [],
+        "sys_api": {
+            "human_readable_size": "8.00 GB",
+            "locked": 0,
+            "model": "",
+            "nr_requests": "256",
+            "partitions": {},
+            "path": "/dev/vdd",
+            "removable": "0",
+            "rev": "",
+            "ro": "0",
+            "rotational": "1",
+            "sas_address": "",
+            "sas_device_handle": "",
+            "scheduler_mode": "mq-deadline",
+            "sectors": 0,
+            "sectorsize": "512",
+            "size": 8589934592.0,
+            "support_discard": "512",
+            "vendor": "0x1af4"
+        }
+    },
+    {
+        "available": true,
+        "device_id": "01415161",
+        "lsm_data": {},
+        "lvs": [],
+        "path": "/dev/vde",
+        "rejected_reasons": [],
+        "sys_api": {
+            "human_readable_size": "8.00 GB",
+            "locked": 0,
+            "model": "",
+            "nr_requests": "256",
+            "partitions": {},
+            "path": "/dev/vde",
+            "removable": "0",
+            "rev": "",
+            "ro": "0",
+            "rotational": "1",
+            "sas_address": "",
+            "sas_device_handle": "",
+            "scheduler_mode": "mq-deadline",
+            "sectors": 0,
+            "sectorsize": "512",
+            "size": 8589934592.0,
+            "support_discard": "512",
+            "vendor": "0x1af4"
+        }
+    },
+    {
+        "available": false,
+        "device_id": "",
+        "lsm_data": {},
+        "lvs": [],
+        "path": "/dev/vda",
+        "rejected_reasons": [
+            "locked"
+        ],
+        "sys_api": {
+            "human_readable_size": "24.00 GB",
+            "locked": 1,
+            "model": "",
+            "nr_requests": "256",
+            "partitions": {
+                "vda1": {
+                    "holders": [],
+                    "human_readable_size": "2.00 MB",
+                    "sectors": "4096",
+                    "sectorsize": 512,
+                    "size": 2097152.0,
+                    "start": "2048"
+                },
+                "vda2": {
+                    "holders": [],
+                    "human_readable_size": "20.00 MB",
+                    "sectors": "40960",
+                    "sectorsize": 512,
+                    "size": 20971520.0,
+                    "start": "6144"
+                },
+                "vda3": {
+                    "holders": [],
+                    "human_readable_size": "18.97 GB",
+                    "sectors": "39780352",
+                    "sectorsize": 512,
+                    "size": 20367540224.0,
+                    "start": "47104"
+                },
+                "vda4": {
+                    "holders": [],
+                    "human_readable_size": "5.01 GB",
+                    "sectors": "10504159",
+                    "sectorsize": 512,
+                    "size": 5378129408.0,
+                    "start": "39827456"
+                }
+            },
+            "path": "/dev/vda",
+            "removable": "0",
+            "rev": "",
+            "ro": "0",
+            "rotational": "1",
+            "sas_address": "",
+            "sas_device_handle": "",
+            "scheduler_mode": "mq-deadline",
+            "sectors": 0,
+            "sectorsize": "512",
+            "size": 25769803776.0,
+            "support_discard": "512",
+            "vendor": "0x1af4"
+        }
+    }
+]

--- a/src/gravel/tests/functional/test_app.py
+++ b/src/gravel/tests/functional/test_app.py
@@ -17,6 +17,12 @@ import pytest
 
 @pytest.mark.asyncio
 async def test_simple_app_response(async_client):
-    response = await async_client.get("/")
+    response = await async_client.get("/api/local/status")
     assert response.status_code == 200
-    assert "<title>Aquarium</title>" in response.text
+    assert '{"inited":false,"node_stage":0}' == response.text
+    import asyncio
+    await asyncio.sleep(5)
+
+    response = await async_client.get("/api/local/status")
+    assert response.status_code == 200
+    assert '{"inited":true,"node_stage":0}' == response.text

--- a/src/gravel/tests/functional/test_app.py
+++ b/src/gravel/tests/functional/test_app.py
@@ -1,0 +1,22 @@
+# project aquarium's backend
+# Copyright (C) 2021 SUSE, LLC.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_simple_app_response(async_client):
+    response = await async_client.get("/")
+    assert response.status_code == 200
+    assert "<title>Aquarium</title>" in response.text

--- a/src/gravel/tests/unit/controllers/orch/test_ceph.py
+++ b/src/gravel/tests/unit/controllers/orch/test_ceph.py
@@ -34,7 +34,8 @@ def test_ceph_conf(fs: fake_filesystem.FakeFilesystem, mocker: MockerFixture):
         os.path.join(TEST_DIR, 'data/default_ceph.conf'),
         target_path='/etc/ceph/ceph.conf'
     )
-    Ceph()
+    ceph = Ceph()
+    ceph._check_config()
 
     # custom location
     conf_file = '/foo/bar/baz.conf'
@@ -42,12 +43,14 @@ def test_ceph_conf(fs: fake_filesystem.FakeFilesystem, mocker: MockerFixture):
         os.path.join(TEST_DIR, 'data/default_ceph.conf'),
         target_path=conf_file
     )
-    Ceph(conf_file=conf_file)
+    ceph = Ceph(conf_file=conf_file)
+    ceph._check_config()
 
     # invalid location
     conf_file = "missing.conf"
     with pytest.raises(FileNotFoundError, match=conf_file):
-        Ceph(conf_file=conf_file)
+        ceph = Ceph(conf_file=conf_file)
+        ceph._check_config()
 
 
 def test_mon_df(

--- a/src/gravel/typings/uvicorn.pyi
+++ b/src/gravel/typings/uvicorn.pyi
@@ -1,0 +1,15 @@
+# project aquarium's backend
+# Copyright (C) 2021 SUSE, LLC.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+def run(app, **kwargs) -> None:
+    ...

--- a/src/mypy.ini
+++ b/src/mypy.ini
@@ -12,4 +12,3 @@ ignore_missing_imports = True
 
 [mypy-aetcd3.*]
 ignore_missing_imports = True
-

--- a/src/requirements-test.txt
+++ b/src/requirements-test.txt
@@ -1,5 +1,8 @@
+asgi-lifespan
+httpx
 pyfakefs
 pytest
 pytest-asyncio
 pytest-datadir
 pytest-mock
+requests

--- a/src/tools/checks/ceph.py
+++ b/src/tools/checks/ceph.py
@@ -2,11 +2,13 @@
 # Copyright (C) 2021 SUSE, LLC.
 
 
-from gravel.controllers.orch.ceph import Mon
+from gravel.controllers.orch.ceph import Ceph, Mon
 
 
 if __name__ == "__main__":
-    mon = Mon()
-    print(mon.get_osdmap())
-    print(mon.get_pools())
+    ceph: Ceph = Ceph()
+    ceph_mon: Mon = Mon(ceph)
+
+    print(ceph_mon.get_osdmap())
+    print(ceph_mon.get_pools())
     pass

--- a/src/tools/checks/cephfs.py
+++ b/src/tools/checks/cephfs.py
@@ -1,10 +1,15 @@
 # project aquarium's backend
 # Copyright (C) 2021 SUSE, LLC.
 
+from gravel.controllers.orch.ceph import Ceph, Mgr, Mon
 from gravel.controllers.orch.cephfs import CephFS, CephFSError
 
 if __name__ == "__main__":
-    cephfs = CephFS()
+    ceph: Ceph = Ceph()
+    ceph_mgr: Mgr = Mgr(ceph)
+    ceph_mon: Mon = Mon(ceph)
+    cephfs: CephFS = CephFS(ceph_mgr, ceph_mon)
+
     try:
         cephfs.create("foobarbaz")
     except CephFSError as e:

--- a/src/tools/checks/storage.py
+++ b/src/tools/checks/storage.py
@@ -6,6 +6,8 @@ from gravel.controllers.resources import storage
 from gravel.controllers.orch.ceph import Mon
 
 
+# TODO(jhesketh): This is probably broken from a previous ticker refactor
+
 async def main():
 
     await storage.tick()

--- a/systemd/aquarium.service
+++ b/systemd/aquarium.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 User=root
 WorkingDirectory=/usr/share/aquarium
-ExecStart=/usr/local/bin/uvicorn aquarium:app --host 0.0.0.0 --port 1337
+ExecStart=/usr/local/bin/uvicorn aquarium:app_factory --factory --host 0.0.0.0 --port 1337
 Restart=always
 
 [Install]


### PR DESCRIPTION
Rework how we make external connections to enable easier testing.

This means we pass objects between methods to keep the connections established (rather than rebuilding various connections on requests).

This should ease testing allowing us to stub boundary layers.
