### PR TITLE
gravel: init stage rework (phase 2)

### DIFF
--- a/src/aquarium.py
+++ b/src/aquarium.py
@@ -104,7 +104,10 @@ async def on_startup():
     status: Status = Status(gstate.config.options.status.probe_interval, gstate, nodemgr)
     gstate.add_status(status)
 
-    inventory: Inventory = Inventory(gstate.config.options.inventory.probe_interval)
+    inventory: Inventory = Inventory(
+        gstate.config.options.inventory.probe_interval,
+        nodemgr
+    )
     gstate.add_inventory(inventory)
 
     storage: Storage = Storage(gstate.config.options.storage.probe_interval, nodemgr)

--- a/src/gravel/api/local.py
+++ b/src/gravel/api/local.py
@@ -126,6 +126,6 @@ async def get_status(request: Request) -> NodeStatusReplyModel:
     nodemgr: NodeMgr = request.app.state.nodemgr
 
     return NodeStatusReplyModel(
-        inited=nodemgr.inited,
+        inited=nodemgr.available,
         node_stage=nodemgr.deployment_state.stage
     )

--- a/src/gravel/cephadm/cephadm.py
+++ b/src/gravel/cephadm/cephadm.py
@@ -15,6 +15,7 @@ import asyncio
 from logging import Logger
 import os
 import json
+import shlex
 from io import StringIO
 from typing import (
     Callable,
@@ -61,7 +62,7 @@ class Cephadm:
                    outcb: Optional[Callable[[str], None]] = None
                    ) -> Tuple[str, str, int]:
 
-        cmdlst: List[str] = f"{self.cephadm} {cmd}".split()
+        cmdlst: List[str] = shlex.split(f"{self.cephadm} {cmd}")
 
         process = await asyncio.create_subprocess_exec(
             *cmdlst,
@@ -125,7 +126,8 @@ class Cephadm:
                 if m in t:
                     percentcb(p)
 
-        cmd = f"bootstrap --skip-prepare-host --mon-ip {addr}"
+        cmd = f"bootstrap --skip-prepare-host --mon-ip {addr} " \
+              "--skip-dashboard --skip-monitoring-stack"
         return await self.call(cmd, outcb_handler)
 
     async def gather_facts(self) -> HostFactsModel:

--- a/src/gravel/cephadm/cephadm.py
+++ b/src/gravel/cephadm/cephadm.py
@@ -17,6 +17,7 @@ import os
 import json
 import shlex
 from io import StringIO
+import time
 from typing import (
     Callable,
     List,
@@ -193,3 +194,13 @@ class Cephadm:
             ),
             disks=inventory
         )
+
+    async def pull_images(self) -> None:
+        logger.debug("fetching ceph container image")
+        time_begin: int = int(time.monotonic())
+        _, stderr, rc = await self.call("pull")
+        if rc != 0:
+            raise CephadmError(stderr)
+        time_end: int = int(time.monotonic())
+        time_diff: int = time_end - time_begin
+        logger.debug(f"pulled ceph container images: took {time_diff} sec")

--- a/src/gravel/controllers/nodes/mgr.py
+++ b/src/gravel/controllers/nodes/mgr.py
@@ -73,12 +73,17 @@ from gravel.controllers.orch.orchestrator import Orchestrator
 logger: Logger = fastapi_logger
 
 
+# none       aquarium is running
+# prestart   aquarium is prestarting, obtains images, inventory
+# available  ready to be deployed
+# started    has been deployed, ready to be used
 class NodeInitStage(int, Enum):
     NONE = 0
     PRESTART = 1
-    STARTED = 2
-    STOPPING = 3
-    STOPPED = 4
+    AVAILABLE = 2
+    STARTED = 3
+    STOPPING = 4
+    STOPPED = 5
 
 
 class NodeStateModel(BaseModel):
@@ -367,6 +372,10 @@ class NodeMgr:
     @property
     def inited(self) -> bool:
         return self._init_stage >= NodeInitStage.PRESTART
+
+    @property
+    def available(self) -> bool:
+        return self._init_stage >= NodeInitStage.AVAILABLE
 
     @property
     def started(self) -> bool:

--- a/src/gravel/controllers/nodes/mgr.py
+++ b/src/gravel/controllers/nodes/mgr.py
@@ -324,6 +324,18 @@ class NodeMgr:
         if not res:
             logger.error("unable to enable managed ceph.conf by cephadm")
 
+    async def finish_deployment(self) -> None:
+        assert self._state
+
+        if self.deployment_state.ready:
+            return
+        elif self.deployment_state.joining:
+            raise NodeAlreadyJoiningError()
+        elif not self.deployment_state.deployed:
+            raise NodeNotBootstrappedError()
+
+        self.deployment_state.mark_ready()
+
     @property
     def bootstrapper_stage(self) -> BootstrapStage:
         if not self._deployment.bootstrapper:
@@ -347,18 +359,6 @@ class NodeMgr:
         if not self._deployment.bootstrapper:
             return ""
         return self._deployment.bootstrapper.error_msg
-
-    async def finish_deployment(self) -> None:
-        assert self._state
-
-        if self.deployment_state.ready:
-            return
-        elif self.deployment_state.joining:
-            raise NodeAlreadyJoiningError()
-        elif not self.deployment_state.deployed:
-            raise NodeNotBootstrappedError()
-
-        self.deployment_state.mark_ready()
 
     @property
     def deployment_state(self) -> DeploymentState:

--- a/src/gravel/controllers/resources/devices.py
+++ b/src/gravel/controllers/resources/devices.py
@@ -77,7 +77,7 @@ class Devices(Ticker):
         return (
             self.nodemgr.deployment_state.deployed or
             self.nodemgr.deployment_state.ready
-        )
+        ) and self.nodemgr.started
 
     async def probe(self) -> None:
 

--- a/src/gravel/controllers/resources/inventory.py
+++ b/src/gravel/controllers/resources/inventory.py
@@ -24,6 +24,7 @@ from pydantic.main import BaseModel
 from gravel.cephadm.models import NodeInfoModel
 from gravel.controllers.gstate import Ticker
 from gravel.cephadm.cephadm import Cephadm
+from gravel.controllers.nodes.mgr import NodeMgr
 
 
 logger: Logger = fastapi_logger
@@ -38,17 +39,19 @@ class Inventory(Ticker):
 
     _latest: Optional[NodeInfoModel]
     _subscribers: List[Subscriber]
+    _nodemgr: NodeMgr
 
-    def __init__(self, probe_interval: float):
+    def __init__(self, probe_interval: float, nodemgr: NodeMgr):
         super().__init__(probe_interval)
         self._latest = None
         self._subscribers = []
+        self._nodemgr = nodemgr
 
     async def _do_tick(self) -> None:
         await self.probe()
 
     async def _should_tick(self) -> bool:
-        return True
+        return self._nodemgr.inited
 
     async def probe(self) -> None:
         cephadm: Cephadm = Cephadm()

--- a/src/gravel/controllers/resources/status.py
+++ b/src/gravel/controllers/resources/status.py
@@ -94,7 +94,7 @@ class Status(Ticker):
         return (
             self.nodemgr.deployment_state.deployed or
             self.nodemgr.deployment_state.ready
-        )
+        ) and self.nodemgr.started
 
     async def probe(self) -> None:
         assert self._mon

--- a/src/gravel/controllers/resources/storage.py
+++ b/src/gravel/controllers/resources/storage.py
@@ -68,13 +68,10 @@ class Storage(Ticker):
         await self._update()
 
     async def _should_tick(self) -> bool:
-        if not (
+        return (
             self.nodemgr.deployment_state.deployed or
             self.nodemgr.deployment_state.ready
-        ):
-            logger.debug("not ticking, not bootstrapped")
-            return False
-        return True
+        ) and self.nodemgr.started
 
     @property
     def available(self) -> int:

--- a/src/gravel/tests/conftest.py
+++ b/src/gravel/tests/conftest.py
@@ -137,7 +137,10 @@ async def gstate(fs: fake_filesystem.FakeFilesystem, mocker: MockerFixture):
     status: Status = Status(gstate.config.options.status.probe_interval, gstate, nodemgr)
     gstate.add_status(status)
 
-    inventory: Inventory = Inventory(gstate.config.options.inventory.probe_interval)
+    inventory: Inventory = Inventory(
+        gstate.config.options.inventory.probe_interval,
+        nodemgr
+    )
     gstate.add_inventory(inventory)
 
     storage: Storage = FakeStorage(gstate.config.options.storage.probe_interval, nodemgr)


### PR DESCRIPTION
Second installment in the "let's rework the backend's init workflow" series.

In this episode we are dropping the `prestart` state and replacing it with a `prepare`, which will obtain container images and process the initial inventory; then we add a new state, `available`, which means the node is now available to serve a bootstrap or a join request.

This difference is mostly for the benefit of the backend, so we can keep track where we are instead of cramming everything into the same state. Additionally, the frontend will be able to distinguish between these two states and inform the user in case we're still preparing the node.

On a tangential topic, we're also now disabling the dashboard and the monitoring stack on bootstrap. We don't use it, and makes it easier to figure out which containers to pull.

Signed-off-by: Joao Eduardo Luis \<joao@suse.com>