### PR TITLE
gravel: make obtaining inventory quicker on node start

### DIFF
--- a/src/gravel/controllers/gstate.py
+++ b/src/gravel/controllers/gstate.py
@@ -113,6 +113,9 @@ class Ticker(ABC):
     async def shutdown(self) -> None:
         pass
 
+    def set_tick_interval(self, new_interval: float) -> None:
+        self._tick_interval = new_interval
+
 
 class GlobalState:
 

--- a/src/gravel/controllers/nodes/mgr.py
+++ b/src/gravel/controllers/nodes/mgr.py
@@ -226,7 +226,10 @@ class NodeMgr:
             if not await _obtain_images():
                 # xxx: find way to shutdown here?
                 return
-            self.gstate.inventory.subscribe(_inventory_subscriber, once=True)
+            await self.gstate.inventory.subscribe(
+                _inventory_subscriber,
+                once=True
+            )
 
         self._init_stage = NodeInitStage.PREPARE
         asyncio.create_task(_task())

--- a/src/gravel/controllers/resources/inventory.py
+++ b/src/gravel/controllers/resources/inventory.py
@@ -81,11 +81,16 @@ class Inventory(Ticker):
     def latest(self) -> Optional[NodeInfoModel]:
         return self._latest
 
-    def subscribe(
+    async def subscribe(
         self,
         cb: Callable[[NodeInfoModel], Awaitable[None]],
         once: bool
     ) -> None:
+        # if we have available state, call back immediately.
+        if self._latest:
+            await cb(self._latest)  # type: ignore
+            if once:
+                return
         self._subscribers.append(Subscriber(cb=cb, once=once))
 
     async def _publish(self) -> None:

--- a/src/gravel/controllers/resources/inventory.py
+++ b/src/gravel/controllers/resources/inventory.py
@@ -36,19 +36,34 @@ class Subscriber(BaseModel):
 
 
 class Inventory(Ticker):
+    """
+    Obtain host's inventory. Only runs once the node has been inited.
+
+    Until the node is inited and is able to probe for the first time, will
+    attempt to tick every 1.0 second. Once the first probe is finished, will
+    reset its tick interval to the interval provided to the ctor (which will
+    likely be the one passed through the config values).
+    """
 
     _latest: Optional[NodeInfoModel]
     _subscribers: List[Subscriber]
     _nodemgr: NodeMgr
+    _has_probed_once: bool
+    _probe_interval: float
 
     def __init__(self, probe_interval: float, nodemgr: NodeMgr):
-        super().__init__(probe_interval)
+        super().__init__(1.0)
         self._latest = None
         self._subscribers = []
         self._nodemgr = nodemgr
+        self._has_probed_once = False
+        self._probe_interval = probe_interval
 
     async def _do_tick(self) -> None:
         await self.probe()
+        if not self._has_probed_once:
+            super().set_tick_interval(self._probe_interval)
+            self._has_probed_once = True
 
     async def _should_tick(self) -> bool:
         return self._nodemgr.inited


### PR DESCRIPTION
The quicker we obtain the inventory, less time the user is waiting for the node to become available to bootstrap.

By fiddling with the tick interval and calling back on the subscribe as soon as possible, we're reducing this time from about 30-60 seconds, to a handful of seconds.

This actually resolves #328 

Signed-off-by: Joao Eduardo Luis \<joao@suse.com>