### PR TITLE
glass: Use icon buttons

### DIFF
--- a/src/glass/src/app/pages/install-wizard-page/install-wizard-page.component.html
+++ b/src/glass/src/app/pages/install-wizard-page/install-wizard-page.component.html
@@ -26,10 +26,11 @@
               </div>
             </div>
             <div class="glass-install-wizard-step-actions">
-              <button mat-button
+              <button mat-icon-button
+                      matTooltip="{{ 'Back' | translate }}"
                       class="mat-stepper-back"
                       routerLink="/installer/install-mode">
-                <span translate>Back</span>
+                <mat-icon svgIcon="mdi:arrow-left"></mat-icon>
               </button>
               <button mat-button
                       matStepperNext>
@@ -47,8 +48,10 @@
               </glass-host-details-step>
             </div>
             <div class="glass-install-wizard-step-actions">
-              <button mat-button matStepperPrevious>
-                <span translate>Back</span>
+              <button mat-icon-button
+                      matTooltip="{{ 'Back' | translate }}"
+                      matStepperPrevious>
+                <mat-icon svgIcon="mdi:arrow-left"></mat-icon>
               </button>
               <button mat-button
                       matStepperNext>
@@ -66,9 +69,10 @@
               </glass-networking-step>
             </div>
             <div class="glass-install-wizard-step-actions">
-              <button mat-button
+              <button mat-icon-button
+                      matTooltip="{{ 'Back' | translate }}"
                       matStepperPrevious>
-                <span translate>Back</span>
+                <mat-icon svgIcon="mdi:arrow-left"></mat-icon>
               </button>
               <button mat-button
                       matStepperNext>
@@ -83,9 +87,10 @@
             </div>
             <div class="glass-install-wizard-step-actions">
               <button *ngIf="!['bootstrapping', 'bootstrapped'].includes(context.stage)"
-                      mat-button
+                      mat-icon-button
+                      matTooltip="{{ 'Back' | translate }}"
                       matStepperPrevious>
-                <span translate>Back</span>
+                <mat-icon svgIcon="mdi:arrow-left"></mat-icon>
               </button>
               <button mat-button
                       class="glass-color-theme-accent"


### PR DESCRIPTION
On other installer pages we are using an mat-icon-button for the `Back` button, because of that the wizard needs to be adapted to be consistent.

![Bildschirmfoto vom 2021-05-04 10-36-14](https://user-images.githubusercontent.com/1897962/116978903-9c40ec00-acc4-11eb-9613-f481dfab4bd1.png)

Signed-off-by: Volker Theile <vtheile@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [issue id or URL on https://github.com/aquarist-labs/aquarium/issues, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The component is the short name of a major module or subsystem, something 
like "tools", "gravel", "glass", "doc", etc.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://github.com/aquarist-labs/aquarium/blob/main/CONTRIBUTING.md

-->

## Checklist
- [ ] References issues, create if required
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test tumbleweed`
- `jenkins run tumbleweed`
- `jenkins test leap`
- `jenkins run leap`

</details>
