### PR TITLE
aqrtest: functional tests battery for aquarium's backend

### DIFF
--- a/images/microOS/root/usr/lib/systemd/system/aquarium.service
+++ b/images/microOS/root/usr/lib/systemd/system/aquarium.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 User=root
 WorkingDirectory=/usr/share/aquarium
-ExecStart=/usr/local/bin/uvicorn aquarium:app --host 0.0.0.0 --port 1337
+ExecStart=/usr/local/bin/uvicorn aquarium:app_factory --factory --host 0.0.0.0 --port 1337
 Restart=always
 
 [Install]

--- a/run_aquarium.sh
+++ b/run_aquarium.sh
@@ -72,7 +72,7 @@ pushd ${SCRIPT_DIR}/src &>/dev/null
 $is_debug && export AQUARIUM_DEBUG=1
 $has_config && export AQUARIUM_CONFIG_DIR=${config_path}
 
-uvicorn aquarium:app --host 0.0.0.0 --port ${port}
+uvicorn aquarium:app_factory --factory --host 0.0.0.0 --port ${port}
 
 popd &>/dev/null
 

--- a/src/aquarium.py
+++ b/src/aquarium.py
@@ -19,6 +19,7 @@ import os
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
 from fastapi.logger import logger as fastapi_logger
+import uvicorn
 
 from gravel.controllers.gstate import GlobalState, setup_logging
 from gravel.controllers.nodes.mgr import NodeMgr
@@ -40,122 +41,120 @@ from gravel.api import (
 )
 
 
-logger: logging.Logger = fastapi_logger
+def app_factory():
+    logger: logging.Logger = fastapi_logger
 
+    api_tags_metadata = [
+        {
+            "name": "local",
+            "description": "Operations local to the node where the endpoint is being invoked."
+        },
+        {
+            "name": "bootstrap",
+            "description": "Allows creating a minimal cluster on the node."
+        },
+        {
+            "name": "orch",
+            "description": "Operations related to Ceph cluster orchestration."
+        },
+        {
+            "name": "status",
+            "description": "Allows obtaining operation status information."
+        },
+        {
+            "name": "services",
+            "description": "Create, destroy, and operate Aquarium Services."
+        },
+        {
+            "name": "nodes",
+            "description": "Perform Aquarium Cluster node operations"
+        },
+        {
+            "name": "devices",
+            "description": "Obtain and perform operations on cluster devices"
+        }
+    ]
 
-api_tags_metadata = [
-    {
-        "name": "local",
-        "description": "Operations local to the node where the endpoint is being invoked."
-    },
-    {
-        "name": "bootstrap",
-        "description": "Allows creating a minimal cluster on the node."
-    },
-    {
-        "name": "orch",
-        "description": "Operations related to Ceph cluster orchestration."
-    },
-    {
-        "name": "status",
-        "description": "Allows obtaining operation status information."
-    },
-    {
-        "name": "services",
-        "description": "Create, destroy, and operate Aquarium Services."
-    },
-    {
-        "name": "nodes",
-        "description": "Perform Aquarium Cluster node operations"
-    },
-    {
-        "name": "devices",
-        "description": "Obtain and perform operations on cluster devices"
-    }
-]
+    aquarium_app = FastAPI(docs_url=None)
+    aquarium_api = FastAPI(
+        title="Project Aquarium",
+        description="Project Aquarium is a SUSE-sponsored open source project " +
+                    "aiming at becoming an easy to use, rock solid storage " +
+                    "appliance based on Ceph.",
+        version="1.0.0",
+        openapi_tags=api_tags_metadata)
 
+    @aquarium_app.on_event("startup")  # type: ignore
+    async def on_startup():
 
-app = FastAPI(docs_url=None)
-api = FastAPI(
-    title="Project Aquarium",
-    description="Project Aquarium is a SUSE-sponsored open source project " +
-                "aiming at becoming an easy to use, rock solid storage " +
-                "appliance based on Ceph.",
-    version="1.0.0",
-    openapi_tags=api_tags_metadata)
+        lvl = "INFO" if not os.getenv("AQUARIUM_DEBUG") else "DEBUG"
+        setup_logging(lvl)
+        logger.info("Aquarium startup!")
 
+        gstate: GlobalState = GlobalState()
 
-@app.on_event("startup")  # type: ignore
-async def on_startup():
+        # init node mgr
+        logger.info("starting node manager")
+        nodemgr: NodeMgr = NodeMgr(gstate)
 
-    lvl = "INFO" if not os.getenv("AQUARIUM_DEBUG") else "DEBUG"
-    setup_logging(lvl)
-    logger.info("Aquarium startup!")
+        devices: Devices = Devices(gstate.config.options.devices.probe_interval, nodemgr)
+        gstate.add_devices(devices)
 
-    gstate: GlobalState = GlobalState()
+        status: Status = Status(gstate.config.options.status.probe_interval, gstate, nodemgr)
+        gstate.add_status(status)
 
-    # init node mgr
-    logger.info("starting node manager")
-    nodemgr: NodeMgr = NodeMgr(gstate)
+        inventory: Inventory = Inventory(
+            gstate.config.options.inventory.probe_interval,
+            nodemgr
+        )
+        gstate.add_inventory(inventory)
 
-    devices: Devices = Devices(gstate.config.options.devices.probe_interval, nodemgr)
-    gstate.add_devices(devices)
+        storage: Storage = Storage(gstate.config.options.storage.probe_interval, nodemgr)
+        gstate.add_storage(storage)
 
-    status: Status = Status(gstate.config.options.status.probe_interval, gstate, nodemgr)
-    gstate.add_status(status)
+        services: Services = Services(gstate.config.options.services.probe_interval, gstate, nodemgr)
+        gstate.add_services(services)
 
-    inventory: Inventory = Inventory(
-        gstate.config.options.inventory.probe_interval,
-        nodemgr
+        await nodemgr.start()
+        await gstate.start()
+
+        # Add instances into FastAPI's state:
+        aquarium_api.state.gstate = gstate
+        aquarium_api.state.nodemgr = nodemgr
+
+    @aquarium_app.on_event("shutdown")  # type: ignore
+    async def on_shutdown():
+        logger.info("Aquarium shutdown!")
+        await aquarium_api.state.gstate.shutdown()
+        logger.info("shutting down node manager")
+        await aquarium_api.state.nodemgr.shutdown()
+
+    aquarium_api.include_router(local.router)
+    aquarium_api.include_router(bootstrap.router)
+    aquarium_api.include_router(orch.router)
+    aquarium_api.include_router(status.router)
+    aquarium_api.include_router(services.router)
+    aquarium_api.include_router(nodes.router)
+    aquarium_api.include_router(devices.router)
+    aquarium_api.include_router(nfs.router)
+
+    #
+    # mounts
+    #   these should be the last things to be done, so fastapi is aware of
+    #   everything that comes before.
+    #
+    # api calls go here.
+    aquarium_app.mount(
+        "/api",
+        aquarium_api,
+        name="api"
     )
-    gstate.add_inventory(inventory)
+    # mounting root "/" must be the last thing, so it does not override "/api".
+    aquarium_app.mount(
+        "/",
+        StaticFiles(directory="./glass/dist/", html=True),
+        name="static"
+    )
 
-    storage: Storage = Storage(gstate.config.options.storage.probe_interval, nodemgr)
-    gstate.add_storage(storage)
+    return aquarium_app
 
-    services: Services = Services(gstate.config.options.services.probe_interval, gstate, nodemgr)
-    gstate.add_services(services)
-
-    await nodemgr.start()
-    await gstate.start()
-
-    # Add instances into FastAPI's state:
-    api.state.gstate = gstate
-    api.state.nodemgr = nodemgr
-
-
-@app.on_event("shutdown")  # type: ignore
-async def on_shutdown():
-    logger.info("Aquarium shutdown!")
-    await api.state.gstate.shutdown()
-    logger.info("shutting down node manager")
-    await api.state.nodemgr.shutdown()
-
-
-api.include_router(local.router)
-api.include_router(bootstrap.router)
-api.include_router(orch.router)
-api.include_router(status.router)
-api.include_router(services.router)
-api.include_router(nodes.router)
-api.include_router(devices.router)
-api.include_router(nfs.router)
-
-
-#
-# mounts
-#   these should be the last things to be done, so fastapi is aware of
-#   everything that comes before.
-#
-# api calls go here.
-app.mount(
-    "/api",
-    api,
-    name="api"
-)
-# mounting root "/" must be the last thing, so it does not override "/api".
-app.mount(
-    "/",
-    StaticFiles(directory="./glass/dist/", html=True),
-    name="static"
-)

--- a/src/aquarium.py
+++ b/src/aquarium.py
@@ -156,6 +156,8 @@ def app_factory():
         name="static"
     )
 
+    aquarium_app.state.api = aquarium_api
+
     return aquarium_app
 
 

--- a/src/aquarium.py
+++ b/src/aquarium.py
@@ -85,7 +85,7 @@ def app_factory():
         openapi_tags=api_tags_metadata)
 
     @aquarium_app.on_event("startup")  # type: ignore
-    async def on_startup():
+    async def on_startup():  # pyright: reportUnusedFunction=false
 
         lvl = "INFO" if not os.getenv("AQUARIUM_DEBUG") else "DEBUG"
         setup_logging(lvl)
@@ -123,7 +123,7 @@ def app_factory():
         aquarium_api.state.nodemgr = nodemgr
 
     @aquarium_app.on_event("shutdown")  # type: ignore
-    async def on_shutdown():
+    async def on_shutdown():  # pyright: reportUnusedFunction=false
         logger.info("Aquarium shutdown!")
         await aquarium_api.state.gstate.shutdown()
         logger.info("shutting down node manager")

--- a/src/aquarium.py
+++ b/src/aquarium.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # project aquarium's backend
 # Copyright (C) 2021 SUSE, LLC.
@@ -158,3 +158,6 @@ def app_factory():
 
     return aquarium_app
 
+
+if __name__ == "__main__":
+    uvicorn.run("aquarium:app_factory", host="0.0.0.0", port=1337, factory=True)

--- a/src/gravel/controllers/nodes/etcd.py
+++ b/src/gravel/controllers/nodes/etcd.py
@@ -119,8 +119,9 @@ async def spawn_etcd(
 
     cmd = _get_container_cmd()
 
+    ctx = multiprocessing.get_context("spawn")
     logger.debug("spawn etcd: " + shlex.join(cmd))
-    process = multiprocessing.Process(
+    process = ctx.Process(
         target=_bootstrap_etcd_process,
         args=(cmd,)
     )

--- a/src/gravel/controllers/nodes/mgr.py
+++ b/src/gravel/controllers/nodes/mgr.py
@@ -12,7 +12,6 @@
 # GNU General Public License for more details.
 
 import asyncio
-import multiprocessing
 from enum import Enum
 from logging import Logger
 from uuid import UUID, uuid4
@@ -154,8 +153,6 @@ class NodeMgr:
         self._deployment = NodeDeployment(gstate, self._connmgr)
 
         self.gstate = gstate
-
-        multiprocessing.set_start_method("spawn")
 
         # attempt reading our node state from disk; create one if not found.
         try:

--- a/src/gravel/tests/aqrtest/aqrtest/test.py
+++ b/src/gravel/tests/aqrtest/aqrtest/test.py
@@ -1,0 +1,128 @@
+# project aquarium's backend
+# Copyright (C) 2021 SUSE, LLC.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+import asyncio
+from abc import ABC, abstractmethod
+from typing import (
+    Any,
+    Awaitable,
+    Callable,
+    List,
+    Tuple
+)
+import traceback
+import inspect
+from aiohttp import ClientSession
+
+import uvicorn  # pyright: reportMissingTypeStubs=false
+from fastapi import Request
+import aquarium
+
+
+class AqrTest(ABC):
+    def __init__(self):
+        pass
+
+    @abstractmethod
+    async def run_test(self) -> bool:
+        return False
+
+    async def run(self) -> Tuple[bool, List[str]]:
+        app = aquarium.app_factory()
+        started = False
+        config = uvicorn.Config(app, host="0.0.0.0", port=1337)
+        server = uvicorn.Server(config)
+        failures: List[str] = []
+
+        async def run_app() -> None:
+            try:
+                config.setup_event_loop()
+                nonlocal started
+                started = True
+                await server.serve()
+            except Exception:
+                print("oops!")
+            except asyncio.CancelledError:
+                print("cancelled")
+
+        def handle_exception(req: Request, e: Exception) -> None:
+            try:
+                raise e
+            except Exception:
+                nonlocal failures
+                failures.append(traceback.format_exc())
+            stop_app()
+
+        def stop_app() -> None:
+            server.should_exit = True
+            server.force_exit = True
+
+        app.add_exception_handler(
+            Exception, handle_exception
+        )  # pyright: reportUnknownMemberType=false
+        app.state.api.add_exception_handler(
+            Exception, handle_exception
+        )  # pyright: reportUnknownMemberType=false
+
+        loop = asyncio.get_event_loop()
+        task = loop.create_task(run_app())
+        while not started:
+            await asyncio.sleep(1)
+        await asyncio.sleep(1)
+        try:
+            res = await asyncio.wait_for(self.run_test(), 300)
+        except TimeoutError:
+            res = False
+            failures.append("test timed out")
+
+        stop_app()
+        try:
+            await asyncio.wait_for(task, 10)
+            print("success waiting for server to stop")
+        except asyncio.CancelledError:
+            pass
+        except asyncio.TimeoutError:
+            print("timed out waiting for server to stop")
+
+        return res, failures
+
+
+testlist: List[Tuple[str, AqrTest]] = []
+
+
+def test(name: str):
+
+    def _wrapper(testcls: Any):
+
+        wrapped_class = None
+        if inspect.isclass(testcls):
+            wrapped_class = testcls
+        elif inspect.iscoroutinefunction(testcls):
+            class Wrapper(AqrTest):
+                async def run_test(self):
+                    return await testcls()
+            wrapped_class = Wrapper
+        else:
+            raise TypeError("test must be class or coroutine function")
+
+        testlist.append((name, wrapped_class()))
+
+    return _wrapper
+
+
+def httptest(func: Callable[[ClientSession], Awaitable[bool]]):
+
+    async def _wrapper(*args: Any, **kwargs: Any) -> bool:
+        async with ClientSession() as session:
+            return await func(session, *args, **kwargs)
+    return _wrapper

--- a/src/gravel/tests/aqrtest/tester.py
+++ b/src/gravel/tests/aqrtest/tester.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+#
+# project aquarium's backend
+# Copyright (C) 2021 SUSE, LLC.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+from __future__ import annotations
+import os
+import importlib
+import sys
+import asyncio
+from pathlib import Path
+from typing import Any, List, Tuple
+
+from aqrtest.test import testlist
+
+
+basedir = os.path.dirname(sys.argv[0])
+
+
+def is_python(name: str) -> bool:
+    return name.endswith(".py")
+
+
+def get_module(parent: str, name: str) -> str:
+    assert is_python(name)
+    name = name[:name.rfind(".")]
+    module = parent.replace("/", ".")
+    return f"{module}.{name}"
+
+
+def import_tests() -> None:
+    for entry in os.walk(Path(basedir).joinpath("tests")):
+        parent, _, filelst = entry
+        if len(filelst) == 0:
+            continue
+
+        pyfiles = ((parent, f) for f in filelst if is_python(f))
+        pymodules = (get_module(p, f) for p, f in pyfiles)
+
+        for module in pymodules:
+            print(f"=> {module}")
+            try:
+                importlib.import_module(module)
+            except Exception as e:
+                print(f"error: {str(e)}")
+            else:
+                print(f"=> imported {module}")
+
+
+def perror(*args: Any, **kwargs: Any):
+    print(*args, file=sys.stderr, **kwargs)
+
+
+async def run_tests() -> bool:
+
+    failed_tests: List[Tuple[str, List[str]]] = []
+    num_tests: int = len(testlist)
+
+    print(testlist)
+    for name, testcls in testlist:
+        print(f"=> RUN {name} ...")
+        res, failures = await testcls.run()
+        out = "PASSED" if res else "FAILED"
+        print(f"=> RUN {name} ... {out}")
+        if not res:
+            failed_tests.append((name, failures))
+
+    if len(failed_tests) > 0:
+        perror("============ FAILURES ============")
+        for testname, failures in failed_tests:
+            perror(f"-------- [ {testname} ] -----------")
+            if len(failures) == 0:
+                perror("   NO FAILURES TO SHOW")
+                continue
+
+            failure_num = 1
+            for failure in failures:
+                perror(f"FAILURE #{failure_num}")
+                perror(failure)
+                perror(f"-- 8< -- END OF FAILURE #{failure_num} -- 8< --")
+                failure_num += 1
+
+    print(f"TOTAL TESTS: {num_tests}")
+    print(f"     PASSED: {num_tests-len(failed_tests)}")
+    print(f"     FAILED: {len(failed_tests)}")
+
+    return len(failed_tests) == 0
+
+
+if __name__ == "__main__":
+    import_tests()
+    success = asyncio.run(run_tests())
+    if not success:
+        sys.exit(1)

--- a/src/gravel/tests/aqrtest/tests/smoke/test_api_local.py
+++ b/src/gravel/tests/aqrtest/tests/smoke/test_api_local.py
@@ -1,0 +1,86 @@
+# project aquarium's backend
+# Copyright (C) 2021 SUSE, LLC.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+import asyncio
+from aiohttp import ClientSession, ClientResponse
+
+from aqrtest.test import test, httptest
+
+from gravel.controllers.resources.inventory import NodeInfoModel
+
+
+async def _get(session: ClientSession, what: str) -> ClientResponse:
+    return await session.get(
+        f"http://localhost:1337/api/local/{what}"
+    )
+
+
+async def _get_inventory(session: ClientSession) -> ClientResponse:
+    return await _get(session, "inventory")
+
+
+async def _wait_inventory(session: ClientSession) -> bool:
+    inited = False
+    for _ in range(30):
+        async with await _get(session, "status") as req:
+            assert req.status == 200
+            res = await req.json()
+            if "inited" in res and res["inited"]:
+                inited = True
+                break
+            await asyncio.sleep(1)
+    return inited
+
+
+@test("fail get local inventory")
+@httptest
+async def test_local_inventory(session: ClientSession) -> bool:
+
+    req = await _get_inventory(session)
+    assert req.status == 425
+    res = await req.json()
+    assert "detail" in res
+    assert "not available" in res["detail"]
+    return True
+
+
+@test("wait and get local inventory")
+@httptest
+async def test_wait_get_local_inventory(session: ClientSession) -> bool:
+
+    res = await _wait_inventory(session)
+    assert res
+    req = await _get_inventory(session)
+    assert req.status == 200
+    return True
+
+
+@test("check inventory")
+@httptest
+async def test_check_inventory(session: ClientSession) -> bool:
+    res = await _wait_inventory(session)
+    assert res
+    req = await _get_inventory(session)
+    assert req.status == 200
+    inventory = NodeInfoModel.parse_obj(await req.json())
+
+    # min default for testing: 4 disks, 1 nic, 1 cpu thread
+    assert len(inventory.disks) >= 4
+    assert len(inventory.nics) >= 1
+    assert inventory.cpu.threads >= 1
+
+    # 1 disk unavailable (os disk), others available
+    avail_disks = len([d for d in inventory.disks if d.available])
+    assert avail_disks == (len(inventory.disks) - 1)
+
+    return True

--- a/src/gravel/tests/aqrtest/tests/smoke/test_orch_devices.py
+++ b/src/gravel/tests/aqrtest/tests/smoke/test_orch_devices.py
@@ -1,0 +1,36 @@
+# project aquarium's backend
+# Copyright (C) 2021 SUSE, LLC.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+import requests
+
+from aqrtest.test import AqrTest, test
+
+
+@test("test orch devices")
+class TestOrchDevices(AqrTest):
+
+    async def run_test(self) -> bool:
+        print("run test 1")
+        try:
+            res = requests.get(
+                "http://127.0.0.1:1337/api/orch/devices",
+                timeout=1)
+            print(f"res: {res}")
+        except Exception:
+            return False
+        return True
+
+
+@test("test function")
+async def testfunc() -> bool:
+    return True

--- a/src/gravel/typings/uvicorn.pyi
+++ b/src/gravel/typings/uvicorn.pyi
@@ -11,5 +11,69 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 
-def run(app, **kwargs) -> None:
+from typing import Any, Dict, Optional
+
+
+class Config:
+
+    def __init__(
+        self,
+        app: Any,
+        host: str,
+        port: int,
+        uds: Optional[Any] = ...,
+        fd: Optional[Any] = ...,
+        loop: str = ...,
+        http: str = ...,
+        ws: str = ...,
+        lifespan: str = ...,
+        env_file: Optional[Any] = ...,
+        log_config: Dict[str, Any] = ...,
+        log_level: Any = ...,
+        access_log: bool = ...,
+        use_colors: Optional[Any] = ...,
+        interface: str = ...,
+        debug: bool = ...,
+        reload: bool = ...,
+        reload_dirs: Optional[Any] = ...,
+        reload_delay: Optional[Any] = ...,
+        workers: Optional[Any] = ...,
+        proxy_headers: bool = ...,
+        forwarded_allow_ips: Optional[Any] = ...,
+        root_path: str = ...,
+        limit_concurrency: Optional[Any] = ...,
+        limit_max_requests: Optional[Any] = ...,
+        backlog: int = ...,
+        timeout_keep_alive: int = ...,
+        timeout_notify: int = ...,
+        callback_notify: Optional[Any] = ...,
+        ssl_keyfile: Optional[Any] = ...,
+        ssl_certfile: Optional[Any] = ...,
+        ssl_keyfile_password: Optional[Any] = ...,
+        ssl_version: str = ...,
+        ssl_cert_reqs: Any = ...,
+        ssl_ca_certs: Optional[Any] = ...,
+        ssl_ciphers: str = ...,
+        headers: Optional[Any] = ...,
+        factory: bool = ...,
+    ) -> None:
+        ...
+
+    def setup_event_loop(self) -> None: ...
+
+    ...
+
+
+class Server:
+
+    should_exit: bool
+    force_exit: bool
+
+    def __init__(self, config: Config) -> None: ...
+
+    async def serve(self, sockets: Optional[Any] = ...) -> None: ...
+    ...
+
+
+def run(app: Any, **kwargs: Any) -> None:
     ...

--- a/src/gravel/typings/uvicorn.pyi
+++ b/src/gravel/typings/uvicorn.pyi
@@ -1,0 +1,15 @@
+# project aquarium's backend
+# Copyright (C) 2021 SUSE, LLC.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+def run(app, **kwargs) -> None:
+    ...

--- a/src/mypy.ini
+++ b/src/mypy.ini
@@ -12,4 +12,3 @@ ignore_missing_imports = True
 
 [mypy-aetcd3.*]
 ignore_missing_imports = True
-

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,4 +1,5 @@
 aiofiles
+aiohttp==3.7.4.post0
 click==7.1.2
 fastapi==0.63.0
 h11==0.12.0

--- a/src/tox.ini
+++ b/src/tox.ini
@@ -21,6 +21,7 @@ deps =
 [pytest]
 addopts =
     --ignore=gravel/ceph.git
+    --ignore=gravel/tests/aqrtest
 
 [flake8]
 max-line-length = 100

--- a/systemd/aquarium.service
+++ b/systemd/aquarium.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 User=root
 WorkingDirectory=/usr/share/aquarium
-ExecStart=/usr/local/bin/uvicorn aquarium:app --host 0.0.0.0 --port 1337
+ExecStart=/usr/local/bin/uvicorn aquarium:app_factory --factory --host 0.0.0.0 --port 1337
 Restart=always
 
 [Install]


### PR DESCRIPTION
Introduce a framework to test a live aquarium deployment.

Tests are meant to be simple to write, but this likely can be further enhanced.

Each test runs a brand new aquarium instance, to avoid tainting internal state in case of exceptions.

What it doesn't do however is actually deploying VMs to run the tests on. Which it needs to, because some tests will eventually taint the deployment irreversibly (e.g., bootstrapping a cluster will leave deployed containers and assimilated disks behind). This is future looking improvements.

The work in this PR has explicitly added a test that is known to fail, as an example of how things can be broken. Said failure needs to be fixed before enabling PR checking using aqrtest.

Signed-off-by: Joao Eduardo Luis \<joao@suse.com>

