### PR TITLE
doc: fix node names

### DIFF
--- a/doc/from-zero-to-hacking.md
+++ b/doc/from-zero-to-hacking.md
@@ -44,8 +44,8 @@ network name/address. If this fails, please check whether the firewall
 settings allow remote incoming connections.
 
 The provided `Vagrant` image will be forwarding ports to the local host. In the
-`localhost`, ports `1337` and `1338` will be used; the former for `node01`, the
-latter for `node02`.
+`localhost`, ports `1337` and `1338` will be used; the former for `node1`, the
+latter for `node2`.
 
 At this moment, although we spin-up both virtual machines, we do not
 support a multi-node deployment yet.
@@ -177,7 +177,7 @@ and running should not be much of a hurdle.
 4. `./tools/aqrdev shell foobar [--node NODE]`
 
     If `NODE` is not specified, the shell will be dropped by default on
-    `node01`. You can always choose to drop into `node02` by specifying that
+    `node1`. You can always choose to drop into `node2` by specifying that
     much.
 
     Note this will drop you into a regular user session and you will


### PR DESCRIPTION
The names of the deployed nodes are no longer `node01` and `node02` but `node1` and `node2`.

Also the https://github.com/aquarist-labs/aquarium/blob/main/tests/vagrant/README.md seems to be outdated as well and I'm wondering what to do about it. I do have the feeling it will be more or less a duplicated subset of `from-zero-to-hacking.md`. I'm wondering if we can just remove the content of https://github.com/aquarist-labs/aquarium/blob/main/tests/vagrant/README.md .

Signed-off-by: Tatjana Dehler <tdehler@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [issue id or URL on https://github.com/aquarist-labs/aquarium/issues, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The component is the short name of a major module or subsystem, something 
like "tools", "gravel", "glass", "doc", etc.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://github.com/aquarist-labs/aquarium/blob/main/CONTRIBUTING.md

-->

## Checklist
- [ ] References issues, create if required
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test tumbleweed`
- `jenkins run tumbleweed`
- `jenkins test leap`
- `jenkins run leap`

</details>
