### PR TITLE
build: Fix opensuse builds on cloud images

### DIFF
--- a/tools/build-image.sh
+++ b/tools/build-image.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+LC_ALL=C.UTF-8
+
 rootdir=
 
 find_root() {

--- a/tools/setup-dev.sh
+++ b/tools/setup-dev.sh
@@ -12,6 +12,7 @@ dependencies_opensuse_tumbleweed=(
   "vagrant"
   "vagrant-libvirt"
   "libvirt-daemon"
+  "dosfstools"
 )
 
 dependencies_debian=(


### PR DESCRIPTION
When doing a build on an opensuse tumbleweed cloud image, the locale
isn't already set correctly for kiwi (see
https://www.suse.com/support/kb/doc/?id=000019958).

kiwi also needed dosfstools at some point. I'm not sure why, but
installing it unblocked me.

Signed-off-by: Joshua Hesketh <josh@nitrotech.org>
