### PR TITLE
aqrtest: functional test battery against a live cluster

### DIFF
--- a/tests/examples/test_libaqr.py
+++ b/tests/examples/test_libaqr.py
@@ -1,0 +1,69 @@
+# project aquarium's testing battery
+# Copyright (C) 2021 SUSE, LLC.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+import asyncio
+from libaqr.testing import TestCase, caseunit, get_test_cases, requirements
+
+
+@requirements(disks=1, nics=6)
+class MyTest(TestCase):
+
+    @caseunit
+    async def func1(self):
+        print("mytest func1")
+
+    async def not_a_unit(self):
+        raise Exception("not a unit")
+
+    @caseunit
+    async def func2(self):
+        print("mytest func2")
+        raise Exception("bar")
+
+
+@requirements
+async def func2():
+    print("func 2")
+    raise Exception("foo")
+
+
+@requirements(disks=1, nics=1, nodes=1)
+async def func3():
+    print("func 3")
+
+
+async def main() -> None:
+
+    tests = get_test_cases()
+    for casename, case in tests.items():
+        print(f"=> {casename}")
+        print(f"   reqs: {case.requirements}")
+        print(f"  units: {len(case.get_units())}")
+        await case.run()
+
+        has_failures = False
+        print("   -- results --")
+        for testname, result in case.results:
+            print(f"   {testname}: {result}")
+            if not result:
+                has_failures = True
+
+        if has_failures:
+            print("   -- failures --")
+            for testname, failurestr in case.failures.items():
+                print(f"   unit: {testname}")
+                print(failurestr)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/suites/smoke/test_api_bootstrap.py
+++ b/tests/suites/smoke/test_api_bootstrap.py
@@ -11,6 +11,23 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 
-import libaqr.vagrant
 
-print(libaqr.vagrant.Vagrant.box_list())
+from libaqr.testing import TestCase, caseunit, requirements
+
+
+@requirements(
+    disks=4,
+    nodes=1,
+    nics=1
+)
+class TestAPIBootstrap(TestCase):
+
+    @caseunit
+    async def test_func_1(self):
+        print("running test func 1")
+        assert True
+
+    @caseunit
+    async def test_func_2(self):
+        print("running test func 2")
+        assert True

--- a/tests/suites/smoke/test_api_bootstrap.py
+++ b/tests/suites/smoke/test_api_bootstrap.py
@@ -1,0 +1,16 @@
+# project aquarium's testing battery
+# Copyright (C) 2021 SUSE, LLC.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+import libaqr.vagrant
+
+print(libaqr.vagrant.Vagrant.box_list())

--- a/tests/suites/smoke/test_api_orch.py
+++ b/tests/suites/smoke/test_api_orch.py
@@ -11,6 +11,13 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 
-import sys
+from libaqr.testing import TestCase, requirements
 
-sys.exit(0)
+
+@requirements(
+    disks=4,
+    nodes=1,
+    nics=1
+)
+class TestAPIOrch(TestCase):
+    pass

--- a/tests/suites/smoke/test_api_orch.py
+++ b/tests/suites/smoke/test_api_orch.py
@@ -11,13 +11,44 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 
-from libaqr.testing import TestCase, requirements
+from libaqr.testing import TestCase, caseunit, requirements
+from libaqr.http import conn
 
 
 @requirements(
-    disks=4,
+    disks=1,
     nodes=1,
     nics=1
 )
-class TestAPIOrch(TestCase):
-    pass
+class ExpectFailAPIOrch(TestCase):
+
+    @caseunit
+    async def fail_hosts(self) -> None:
+        async with conn() as session:
+            res = await session.get("/orch/hosts", timeout=5)
+            assert res.status != 200
+
+    @caseunit
+    async def fail_devices(self) -> None:
+        async with conn() as session:
+            res = await session.get("/orch/devices", timeout=5)
+            assert res.status != 200
+
+    @caseunit
+    async def fail_devices_assimilate(self) -> None:
+        async with conn() as session:
+            res = await session.post(
+                "/orch/devices/assimilate",
+                json={},
+                timeout=5
+            )
+            assert res.status != 200
+
+            res = await session.get("/orch/devices/all_assimilated", timeout=5)
+            assert res.status != 200
+
+    @caseunit
+    async def fail_pubkey(self) -> None:
+        async with conn() as session:
+            res = await session.get("/orch/pubkey", timeout=5)
+            assert res != 200

--- a/tests/suites/smoke/test_api_orch.py
+++ b/tests/suites/smoke/test_api_orch.py
@@ -1,0 +1,16 @@
+# project aquarium's testing battery
+# Copyright (C) 2021 SUSE, LLC.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+import sys
+
+sys.exit(0)

--- a/tools/aqrdev
+++ b/tools/aqrdev
@@ -22,6 +22,7 @@ import logging
 from click.decorators import make_pass_decorator
 from pathlib import Path
 
+from libaqr.images import Image
 from libaqr.deployment import Deployment, DeploymentModel, get_deployments
 from libaqr.errors import (
     AqrError,
@@ -41,8 +42,7 @@ from libaqr.misc import (
     find_builds_path,
     find_deployments_path,
     find_root,
-    import_image,
-    list_images
+    import_image
 )
 from libaqr.vagrant import Vagrant
 
@@ -188,7 +188,7 @@ def cmd_create(
     avail_boxes = Vagrant.box_list()
     avail_deployments: List[Deployment] = []
     try:
-        avail_images = list_images()
+        avail_images = [e.name for e in Image.list(find_builds_path())]
         avail_deployments = [v for v in ctx.deployments.values()]
     except RootNotFoundError:
         click.secho("Unable to find git repository's root dir")
@@ -572,17 +572,29 @@ def cmd_images() -> None:
 @pass_appctx
 def cmd_images_list(ctx: AppCtx) -> None:
     logger.debug("list images")
-    images = list_images()
+
+    buildspath = find_builds_path()
+    images = Image.list(buildspath)
+
     if len(images) == 0:
         click.secho("No images found", fg="cyan")
         return
 
+    lst: List[Dict[str, str]] = []
+    for entry in images:
+        lst.append({
+            "name": entry.name,
+            "path": str(entry.path),
+            "type": entry.type
+        })
+        if not ctx.json:
+            print("{} {} ({})".format(
+                click.style("*", fg="cyan"),
+                click.style(entry.name, fg="white", bold=True),
+                click.style(entry.type, fg="white")
+            ))
     if ctx.json:
-        print_json(images)
-        return
-
-    for image in images:
-        print_entry(image)
+        print(json.dumps(lst))
 
 
 if __name__ == "__main__":

--- a/tools/aqrdev
+++ b/tools/aqrdev
@@ -204,18 +204,19 @@ def cmd_create(
     if not box and not image:
         if "aquarium" in avail_boxes:
             box = "aquarium"
-        elif "aquarium" in avail_images:
+        elif avail_images and "aquarium" in avail_images:
             image = "aquarium"
         elif name in avail_boxes:
             box = name
-        elif name in avail_images:
+        elif avail_images and name in avail_images:
             image = name
         else:
             click.secho("Unable to find default box 'aquarium'", fg="red")
             sys.exit(errno.ENOENT)
 
     if not box and image:
-        if image not in avail_images:
+
+        if avail_images and image not in avail_images:
             click.secho(f"Image '{image}' not found", fg="red")
             sys.exit(errno.ENOENT)
 
@@ -228,6 +229,11 @@ def cmd_create(
                     f"Unable to remove existing box '{image}': {e.message}"
                 )
                 sys.exit(1)
+
+        if not avail_images:
+            click.secho("No images found", fg="red")
+            sys.exit(errno.ENOENT)
+
         try:
             click.secho(f"Importing image '{image}' as Vagrant box", fg="cyan")
             builds_path = ctx.builds_path

--- a/tools/aqrdev
+++ b/tools/aqrdev
@@ -42,10 +42,9 @@ from libaqr.misc import (
     find_deployments_path,
     find_root,
     import_image,
-    list_boxes,
-    list_images,
-    remove_box
+    list_images
 )
+from libaqr.vagrant import Vagrant
 
 logging.basicConfig(level=logging.INFO)
 logger: logging.Logger = logging.getLogger("aquarium")
@@ -186,7 +185,7 @@ def cmd_create(
     num_nodes = num_nodes if num_nodes is not None else 2
 
     avail_images: Optional[List[str]] = None
-    avail_boxes = list_boxes()
+    avail_boxes = Vagrant.box_list()
     avail_deployments: List[Deployment] = []
     try:
         avail_images = list_images()
@@ -223,7 +222,7 @@ def cmd_create(
         if image in avail_boxes and force:
             # remove existing box first
             try:
-                remove_box(image)
+                Vagrant.box_remove(image)
             except AqrError as e:
                 logger.error(
                     f"Unable to remove existing box '{image}': {e.message}"
@@ -512,7 +511,7 @@ def cmd_box() -> None:
 @pass_appctx
 def cmd_box_list(ctx: AppCtx, verbose: bool) -> None:
     logger.debug("list boxes")
-    boxes = list_boxes()
+    boxes: List[str] = Vagrant().box_list()
     deployments: List[Deployment] = []
     try:
         deployments = [v for v in ctx.deployments.values()]

--- a/tools/aqrdev
+++ b/tools/aqrdev
@@ -196,7 +196,7 @@ def cmd_create(
     except Exception:
         pass
 
-    if name in avail_deployments:
+    if any([True for d in avail_deployments if d.name == name]):
         click.secho(f"Deployment '{name}' already exists", fg="red")
         sys.exit(errno.EEXIST)
 

--- a/tools/aqrdev
+++ b/tools/aqrdev
@@ -36,13 +36,13 @@ from libaqr.errors import (
     DeploymentPathNotFoundError,
     DeploymentRunningError,
     ImageNotFoundError,
-    RootNotFoundError
+    RootNotFoundError,
+    VagrantError
 )
 from libaqr.misc import (
     find_builds_path,
     find_deployments_path,
-    find_root,
-    import_image
+    find_root
 )
 from libaqr.vagrant import Vagrant
 
@@ -236,16 +236,23 @@ def cmd_create(
         try:
             click.secho(f"Importing image '{image}' as Vagrant box", fg="cyan")
             builds_path = ctx.builds_path
-            import_image(builds_path, image)
+
+            Image.add(builds_path, image)
             avail_boxes.append(image)
             box = image
-            click.secho(f"Imported image '{image}' as Vagrant box", fg="green")
-        except ImageNotFoundError as e:
+            click.secho(
+                f"Imported image '{image}' as Vagrant box",
+                fg="green"
+            )
+        except VagrantError as e:
             click.secho(f"Error importing image '{image}': {e.message}")
-            sys.exit(1)
+            sys.exit(e.errno)
         except BoxAlreadyExistsError:
             click.secho("Box already exists, reusing.", fg="green")
             box = image
+        except ImageNotFoundError as e:
+            click.secho(f"Error importing image '{image}': {e.message}")
+            sys.exit(e.errno)
         except BuildsPathNotFoundError:
             click.secho("Unable to find builds path", fg="red")
             sys.exit(errno.ENOENT)

--- a/tools/aqrtest.py
+++ b/tools/aqrtest.py
@@ -63,6 +63,9 @@ def cmd_run(
         click.secho("No suites found", fg="yellow")
         sys.exit(0)
 
+    # add suites parent directory to pythonpath so we can import modules
+    sys.path.append(suitesdir.parent.as_posix())
+
     # prepare image
     try:
         Image.add(find_builds_path(), image)

--- a/tools/aqrtest.py
+++ b/tools/aqrtest.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+# project aquarium's testing battery
+# Copyright (C) 2021 SUSE, LLC.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+import sys
+import errno
+from pathlib import Path
+from libaqr.errors import BoxAlreadyExistsError, ImageNotFoundError, VagrantError
+from libaqr.images import Image
+from libaqr.runner import Runner
+from libaqr.suites import (
+    get_available_suites,
+    get_suite_tests
+)
+from libaqr.misc import find_builds_path
+from typing import Optional
+import click
+
+
+@click.group()
+def app() -> None:
+    pass
+
+
+@app.command("run")
+@click.argument("image", required=True, type=str)
+@click.option("-t", "--test", required=False, type=str)
+@click.option("-s", "--suite", required=False, type=str)
+@click.option("--suites-path", required=False, type=Path)
+def cmd_run(
+    image: str,
+    test: Optional[str],
+    suite: Optional[str],
+    suites_path: Optional[Path]
+) -> None:
+    """ Run a test or a suite against a given image """
+
+    suitesdir = suites_path if suites_path else Path("tests/suites")
+
+    if not suitesdir.exists():
+        click.secho("error: unable to find suites directory", fg="red")
+        sys.exit(errno.ENOENT)
+
+    available_suites = get_available_suites(suitesdir)
+    if suite:
+        if suite not in available_suites:
+            click.secho(f"error: unknown suite '{suite}'", fg="red")
+            sys.exit(errno.EINVAL)
+        available_suites = [suite]
+
+    if len(available_suites) == 0:
+        click.secho("No suites found", fg="yellow")
+        sys.exit(0)
+
+    # prepare image
+    try:
+        Image.add(find_builds_path(), image)
+    except ImageNotFoundError as e:
+        click.secho(
+            f"error: unable to find image '{image}': {e.message}",
+            fg="red"
+        )
+        sys.exit(e.errno)
+    except VagrantError as e:
+        click.secho(f"error: {e.message}", fg="red")
+        sys.exit(e.errno)
+    except BoxAlreadyExistsError:
+        # we are going to reuse that box
+        pass
+
+    deployments_path = Path("aqrtest-deployments")
+    deployments_path.mkdir(exist_ok=True)
+
+    for entry in get_suite_tests(suitesdir, suite, test):
+        runner = Runner(image, entry)
+        runner.setup(deployments_path)
+        success = runner.run()
+        runner.teardown()
+        if not success:
+            sys.exit(1)
+
+
+@app.command("daemon")
+@click.argument("id", required=True, type=str)
+def cmd_daemon(id: str) -> None:
+    """ Run inside the VM, runs aquarium """
+    pass
+
+
+@app.command("list")
+@click.option("--suites-path", required=False, type=Path)
+def cmd_list(suites_path: Optional[Path]) -> None:
+    """ List available suites """
+
+    suitesdir = suites_path if suites_path else Path("tests/suites")
+    if not suitesdir.exists():
+        click.secho("No suites found", bold=True)
+        return
+
+    available_suites = get_available_suites(suitesdir)
+    for suite_name in available_suites:
+        for entry in get_suite_tests(suitesdir, suite_name, None):
+            click.secho("{} {}/{}".format(
+                click.style(chr(0x25cf), fg="cyan", bold=True),
+                suite_name, entry.name
+            ))
+
+
+if __name__ == "__main__":
+    app()

--- a/tools/libaqr/deployment.py
+++ b/tools/libaqr/deployment.py
@@ -151,13 +151,13 @@ class Deployment:
         except AqrError as e:
             raise e
 
-    def stop(self) -> None:
+    def stop(self, interactive: bool = True) -> None:
         """ Stop deployment """
         try:
             with vagrant.deployment(self._path) as deployment:
                 if deployment.shutoff or deployment.notcreated:
                     return  # nothing to do.
-                deployment.stop()
+                deployment.stop(interactive=interactive)
         except AqrError as e:
             raise e
 

--- a/tools/libaqr/deployment.py
+++ b/tools/libaqr/deployment.py
@@ -32,7 +32,6 @@ from libaqr.errors import (
     DeploymentNotRunningError,
     DeploymentRunningError
 )
-from libaqr.misc import list_boxes
 
 
 logger: logging.Logger = logging.getLogger("aquarium")
@@ -94,7 +93,7 @@ class Deployment:
         if path.exists():
             raise DeploymentExistsError()
 
-        if box not in list_boxes():
+        if box not in vagrant.Vagrant.box_list():
             raise BoxDoesNotExistError(box)
 
         try:

--- a/tools/libaqr/errors.py
+++ b/tools/libaqr/errors.py
@@ -104,5 +104,9 @@ class ImageNotFoundError(AqrError):
 #
 # Vagrant Errors
 #
-class VagrantStatusError(AqrError):
+class VagrantError(AqrError):
+    pass
+
+
+class VagrantStatusError(VagrantError):
     pass

--- a/tools/libaqr/http.py
+++ b/tools/libaqr/http.py
@@ -1,0 +1,59 @@
+# project aquarium's testing battery
+# Copyright (C) 2021 SUSE, LLC.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+from typing import Any
+import aiohttp
+from contextlib import asynccontextmanager
+
+
+class HTTPSession:
+    _session: aiohttp.ClientSession
+    _port: int
+    _url: str
+
+    def __init__(self, session: aiohttp.ClientSession, port: int) -> None:
+        self._session = session
+        self._port = port
+        self._url = f"http://127.0.0.1:{self._port}"
+
+    async def get(
+        self,
+        what: str,
+        *args: Any,
+        **kwargs: Any
+    ) -> aiohttp.ClientResponse:
+        sep = "" if what.startswith("/") else "/"
+        endpoint = f"{self._url}{sep}{what}"
+        return await self._session.get(endpoint, *args, **kwargs)
+
+    async def post(
+        self,
+        what: str,
+        *args: Any,
+        **kwargs: Any
+    ) -> aiohttp.ClientResponse:
+        sep = "" if what.startswith("/") else "/"
+        endpoint = f"{self._url}{sep}{what}"
+        return await self._session.post(endpoint, *args, **kwargs)
+
+
+@asynccontextmanager
+async def conn(port: int = 1337):
+    clientsession = None
+    try:
+        clientsession = aiohttp.ClientSession()
+        httpsession = HTTPSession(clientsession, port)
+        yield httpsession
+    finally:
+        if clientsession:
+            await clientsession.close()

--- a/tools/libaqr/images.py
+++ b/tools/libaqr/images.py
@@ -1,0 +1,94 @@
+# Copyright (C) 2021 SUSE, LLC.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+from __future__ import annotations
+import os
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+
+class Image:
+    _name: str
+    _path: Path
+    _type: str
+
+    def __init__(self, name: str, path: Path, type: str) -> None:
+        self._name = name
+        self._path = path
+        self._type = type
+        pass
+
+    @classmethod
+    def list(cls, buildspath: Path) -> List[Image]:
+
+        if not buildspath.exists():
+            return []
+
+        images: List[Image] = []
+        for build in next(os.walk(buildspath))[1]:
+            if build.startswith("."):
+                continue
+
+            path = buildspath.joinpath(build)
+            assert path.exists()
+            try:
+                type, imgpath = cls._check_for_image(path)
+            except FileNotFoundError:
+                continue
+            assert type
+            assert imgpath
+
+            images.append(Image(build, imgpath, type))
+
+        return images
+
+    @classmethod
+    def _check_for_image(cls, path: Path) -> Tuple[str, Path]:
+        """ Check whether there's an image below `path` """
+
+        assert path.exists()
+        outdir = path.joinpath("_out")
+        if not outdir.exists():
+            raise FileNotFoundError()
+
+        raw_img: Optional[Path] = None
+        img: Optional[Path] = None
+        for entry in next(os.walk(outdir))[2]:
+            if not entry.startswith("project-aquarium"):
+                continue
+
+            imgpath = Path(entry)
+            if imgpath.suffix == ".raw":
+                raw_img = imgpath
+            elif imgpath.suffix == ".box" and entry.count("vagrant") > 0:
+                img = imgpath
+
+        if not raw_img or not img:
+            raise FileNotFoundError()
+
+        img_type = "unknown"
+        if img.as_posix().count("libvirt") > 0:
+            img_type = "libvirt"
+
+        return img_type, outdir.joinpath(img)
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    @property
+    def type(self) -> str:
+        return self._type

--- a/tools/libaqr/misc.py
+++ b/tools/libaqr/misc.py
@@ -15,7 +15,7 @@ import os
 from pathlib import Path
 import subprocess
 import shlex
-from typing import List, Optional
+from typing import Optional
 import logging
 
 from libaqr.errors import (
@@ -71,61 +71,6 @@ def import_image(buildspath: Path, imgname: str) -> None:
     stderr = proc.stdout.decode("utf-8")
     if proc.returncode != 0:
         raise BaseException(f"error adding vagrant box: {stderr}")
-
-
-def list_images() -> List[str]:
-    """ List all built Vagrant images """
-    rootdir = find_root()
-    imagepath = rootdir.joinpath("images")
-    buildspath = imagepath.joinpath("build")
-    if not buildspath.exists():
-        return []
-
-    def is_vagrant_img(path: Path) -> bool:
-        assert path.exists()
-        outdir = path.joinpath("_out")
-        if not outdir.exists():
-            raise FileNotFoundError()
-
-        rawimg: Optional[Path] = None
-        img: Optional[Path] = None
-        for entry in next(os.walk(outdir))[2]:
-            if not entry.startswith("project-aquarium"):
-                continue
-
-            imgpath = Path(entry)
-            if imgpath.suffix == ".raw":
-                rawimg = imgpath
-
-            elif imgpath.suffix == ".box":
-                if entry.count("vagrant") > 0:
-                    img = imgpath
-
-        if not rawimg:
-            raise FileNotFoundError()
-        elif not img:
-            return False
-
-        return True
-
-    images: List[str] = []
-    for build in next(os.walk(buildspath))[1]:
-        if build.startswith("."):
-            continue
-
-        try:
-            ret = is_vagrant_img(buildspath.joinpath(build))
-        except FileNotFoundError:
-            logger.debug(f"build {build} not a vagrant build")
-            continue
-
-        if not ret:
-            logger.debug(f"build {build} not a vagrant build")
-            continue
-
-        images.append(build)
-
-    return images
 
 
 def find_root() -> Path:

--- a/tools/libaqr/misc.py
+++ b/tools/libaqr/misc.py
@@ -11,66 +11,18 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 
-import os
 from pathlib import Path
-import subprocess
-import shlex
-from typing import Optional
 import logging
 
 from libaqr.errors import (
-    BoxAlreadyExistsError,
     BuildsPathNotFoundError,
     DeploymentNotFoundError,
     DeploymentPathNotFoundError,
-    ImageNotFoundError,
     RootNotFoundError
 )
-from libaqr.vagrant import Vagrant
 
 
 logger: logging.Logger = logging.getLogger("aquarium")
-
-
-def import_image(buildspath: Path, imgname: str) -> None:
-    """ Import an image as a vagrant box with the same name. """
-    avail_boxes = Vagrant.box_list()
-    if imgname in avail_boxes:
-        raise BoxAlreadyExistsError()
-
-    imgbuild = buildspath.joinpath(imgname)
-    if not imgbuild.exists():
-        raise ImageNotFoundError(f"build for image '{imgname}' not found")
-
-    outpath = imgbuild.joinpath("_out")
-    if not outpath:
-        raise ImageNotFoundError(f"image '{imgname}' not built")
-
-    outfiles = [entry for entry in next(os.walk(outpath))[2]]
-    found: Optional[str] = None
-    for file in outfiles:
-        if file.count(".vagrant.") > 0 and file.endswith(".box"):
-            found = file
-            break
-
-    if not found:
-        raise ImageNotFoundError(f"image '{imgname}' not found at {outpath}")
-
-    imgpath: Path = outpath.joinpath(found)
-    assert imgpath.exists()
-
-    boxname = imgname
-    cmd = f"vagrant box add {boxname} {imgpath}"
-    logger.debug(f"adding box {boxname} from image at {imgpath}")
-    proc = subprocess.run(
-        shlex.split(cmd),
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE
-    )
-
-    stderr = proc.stdout.decode("utf-8")
-    if proc.returncode != 0:
-        raise BaseException(f"error adding vagrant box: {stderr}")
 
 
 def find_root() -> Path:

--- a/tools/libaqr/runner.py
+++ b/tools/libaqr/runner.py
@@ -11,69 +11,133 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 
-import os
-import time
-import subprocess
-import shlex
+import asyncio
+import multiprocessing
+import traceback
+from importlib import import_module
 from pathlib import Path
-from typing import Optional
-from libaqr.errors import AqrError, BoxDoesNotExistError, DeploymentExistsError
+from typing import Dict, List, Optional, Tuple
+from pydantic import BaseModel, Field
+
+from libaqr.errors import (
+    AqrError,
+    BoxDoesNotExistError,
+    DeploymentExistsError
+)
 from libaqr.suites import SuiteEntry
 from libaqr.deployment import Deployment
+from libaqr.testing import (
+    Requirements,
+    TestCase,
+    get_test_cases
+)
 
 
 class RunnerError(AqrError):
     pass
 
 
-class Runner:
+class CaseResult(BaseModel):
+    failures: Dict[str, str] = Field({})
+    results: List[Tuple[str, bool]] = Field([])
+
+
+class RunnerResult(BaseModel):
+    retcode: int = Field(0)
+    _out: List[str] = Field([])
+    _err: List[str] = Field([])
+    cases: Dict[str, CaseResult] = {}
+
+    @property
+    def out(self) -> List[str]:
+        return self._out
+
+    @property
+    def err(self) -> List[str]:
+        return self._err
+
+    def add_out(self, value: str) -> None:
+        self._out.append(value)
+
+    def add_err(self, value: str) -> None:
+        self._err.append(value)
+
+
+class Runner(multiprocessing.Process):
 
     _boxname: str
     _test: SuiteEntry
     _run_name: Optional[str]
     _deployment: Optional[Deployment]
+    _deployments_path: Path
+    _queue: "multiprocessing.Queue[RunnerResult]"
 
-    def __init__(self, boxname: str, test: SuiteEntry):
+    def __init__(
+        self,
+        deployments: Path,
+        boxname: str,
+        test: SuiteEntry
+    ):
+        super().__init__()
         print(f"create runner for {test}")
         self._boxname = boxname
         self._test = test
         self._deployment = None
         self._run_name = None
+        self._deployments_path = deployments
+        self._queue = multiprocessing.Queue()
 
-    def run(self) -> bool:
-        assert self._deployment
-        assert self._run_name
-        print(f"running test {self._test}, run {self._run_name}")
-        start = int(time.monotonic())
+    def run(self) -> None:
+        result: RunnerResult = RunnerResult()
 
-        cmd = f"python3 {str(self._test.path)}"
-        env = os.environ.copy()
-        pythonpath = str(Path(os.path.dirname(__file__)).parent)
-        env["PYTHONPATH"] = pythonpath
-        success = True
         try:
-            proc = subprocess.run(
-                shlex.split(cmd),
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                env=env
-            )
-            if proc.returncode != 0:
-                success = False
-                print(f"test error:\n{proc.stderr.decode('utf-8')}")
-                # dump stderr / stdout to file
+            import_module(self._test.module)
         except Exception as e:
-            success = False
             print(f"error: {str(e)}")
+            result.retcode = 1
+            result.add_err(str(e))
+            self._queue.put(result)
+            return
 
-        stop = int(time.monotonic())
-        diff = stop - start
-        status_str = "passed" if success else "failed"
-        print(f"test took {diff} seconds: {status_str}")
-        return success
+        test_cases: Dict[str, TestCase] = get_test_cases()
+        has_failures = False
+        for casename, case in test_cases.items():
+            try:
+                self._setup(case.requirements)
+            except RunnerError as e:
+                result.retcode = e.errno
+                result.add_err(e.message)
+                break
 
-    def setup(self, deployments_path: Path) -> None:
-        assert deployments_path.exists()
+            try:
+                asyncio.run(case.run())
+            except Exception:
+                result.retcode = 1
+                result.add_err(traceback.format_exc())
+            finally:
+                try:
+                    self._teardown()
+                except RunnerError as e:
+                    result.retcode = e.errno
+                    result.add_err(e.message)
+                    break
+
+            case_result: CaseResult = CaseResult()
+            case_result.failures = case.failures
+            case_result.results = case.results
+            result.cases[casename] = case_result
+            if len(case.failures) > 0:
+                has_failures = True
+
+        result.retcode = 0 if not has_failures else 1
+        self._queue.put(result)
+
+    @property
+    def result(self) -> RunnerResult:
+        return self._queue.get()
+
+    def _setup(self, requirements: Requirements) -> None:
+        assert self._deployments_path.exists()
 
         def _gen_name() -> str:
             from datetime import datetime as dt
@@ -85,8 +149,10 @@ class Runner:
             self._deployment = Deployment.create(
                 name=self._run_name,
                 box=self._boxname,
-                num_nodes=2, num_disks=4, num_nics=1,
-                deployments_path=deployments_path,
+                num_nodes=requirements.nodes,
+                num_disks=requirements.disks,
+                num_nics=requirements.nics,
+                deployments_path=self._deployments_path,
                 mount_path=None
             )
         except FileNotFoundError as e:
@@ -112,7 +178,7 @@ class Runner:
                 errno=e.errno
             )
 
-    def teardown(self) -> None:
+    def _teardown(self) -> None:
         if not self._deployment:
             return
         try:

--- a/tools/libaqr/runner.py
+++ b/tools/libaqr/runner.py
@@ -1,0 +1,125 @@
+# project aquarium's testing battery
+# Copyright (C) 2021 SUSE, LLC.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+import os
+import time
+import subprocess
+import shlex
+from pathlib import Path
+from typing import Optional
+from libaqr.errors import AqrError, BoxDoesNotExistError, DeploymentExistsError
+from libaqr.suites import SuiteEntry
+from libaqr.deployment import Deployment
+
+
+class RunnerError(AqrError):
+    pass
+
+
+class Runner:
+
+    _boxname: str
+    _test: SuiteEntry
+    _run_name: Optional[str]
+    _deployment: Optional[Deployment]
+
+    def __init__(self, boxname: str, test: SuiteEntry):
+        print(f"create runner for {test}")
+        self._boxname = boxname
+        self._test = test
+        self._deployment = None
+        self._run_name = None
+
+    def run(self) -> bool:
+        assert self._deployment
+        assert self._run_name
+        print(f"running test {self._test}, run {self._run_name}")
+        start = int(time.monotonic())
+
+        cmd = f"python3 {str(self._test.path)}"
+        env = os.environ.copy()
+        pythonpath = str(Path(os.path.dirname(__file__)).parent)
+        env["PYTHONPATH"] = pythonpath
+        success = True
+        try:
+            proc = subprocess.run(
+                shlex.split(cmd),
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                env=env
+            )
+            if proc.returncode != 0:
+                success = False
+                print(f"test error:\n{proc.stderr.decode('utf-8')}")
+                # dump stderr / stdout to file
+        except Exception as e:
+            success = False
+            print(f"error: {str(e)}")
+
+        stop = int(time.monotonic())
+        diff = stop - start
+        status_str = "passed" if success else "failed"
+        print(f"test took {diff} seconds: {status_str}")
+        return success
+
+    def setup(self, deployments_path: Path) -> None:
+        assert deployments_path.exists()
+
+        def _gen_name() -> str:
+            from datetime import datetime as dt
+            now = dt.now().isoformat().replace(":", "").split(".")[0]
+            return f"aqrtest-{self._test.name}-{now}"
+
+        self._run_name = _gen_name()
+        try:
+            self._deployment = Deployment.create(
+                name=self._run_name,
+                box=self._boxname,
+                num_nodes=2, num_disks=4, num_nics=1,
+                deployments_path=deployments_path,
+                mount_path=None
+            )
+        except FileNotFoundError as e:
+            raise e
+        except DeploymentExistsError as e:
+            raise RunnerError(
+                msg=f"deployment already exists for run '{self._run_name}",
+                errno=e.errno
+            )
+        except BoxDoesNotExistError as e:
+            raise RunnerError(
+                msg=f"unable to find box '{self._boxname} for test",
+                errno=e.errno
+            )
+        except AqrError as e:
+            raise RunnerError(msg=e.message, errno=e.errno)
+
+        try:
+            self._deployment.start(conservative=False)
+        except AqrError as e:
+            raise RunnerError(
+                msg=f"starting deployment: {e.message}",
+                errno=e.errno
+            )
+
+    def teardown(self) -> None:
+        if not self._deployment:
+            return
+        try:
+            self._deployment.stop(interactive=False)
+            self._deployment.remove()
+        except AqrError as e:
+            raise RunnerError(
+                msg=f"tearing down: {e.message}",
+                errno=e.errno
+            )

--- a/tools/libaqr/suites.py
+++ b/tools/libaqr/suites.py
@@ -1,0 +1,110 @@
+# project aquarium's testing battery
+# Copyright (C) 2021 SUSE, LLC.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+import os
+from pathlib import Path
+from typing import List, Optional
+from pydantic import BaseModel
+
+
+class AqrTestError(Exception):
+
+    _msg: str
+
+    def __init__(self, message: str = ""):
+        super().__init__()
+        self._msg = message
+
+    @property
+    def message(self) -> str:
+        return self._msg
+
+
+class MissingSuiteNameError(AqrTestError):
+    pass
+
+
+class NoSuchSuiteError(AqrTestError):
+    pass
+
+
+class SuiteEntry(BaseModel):
+    suite: str
+    suite_path: Path
+    name: str
+    path: Path
+    module: str
+
+    @property
+    def test_name(self) -> str:
+        return f"{self.suite}/{self.name}"
+
+
+def get_available_suites(path: Path) -> List[str]:
+    return next(os.walk(path))[1]
+
+
+def get_suite_entries(
+    path: Path,
+    suite: str,
+    test_name: Optional[str]
+):
+    suites_path = path.joinpath(suite)
+    if not suites_path.exists():
+        raise NoSuchSuiteError(suite)
+
+    tests = next(os.walk(suites_path))[2]
+    for test in tests:
+        if not test.endswith(".py") and not test.startswith("test_"):
+            continue
+
+        entry_name = test.replace(".py", "")
+
+        if test_name and test_name != entry_name:
+            continue
+
+        entry_path = suites_path.joinpath(test)
+        entry_module = f"suites.{suite}.{entry_name}"
+
+        sentry = SuiteEntry(
+            suite=suite,
+            suite_path=suites_path,
+            name=entry_name,
+            path=entry_path,
+            module=entry_module
+        )
+        yield sentry
+
+
+def get_suite_tests(
+    path: Path,
+    suite_name: Optional[str],
+    test_name: Optional[str]
+):
+
+    if test_name and not suite_name:
+        pos = test_name.find("/")
+        if pos >= 0:
+            suite_name = test_name[:pos]
+            test_name = test_name[pos+1:]
+        else:
+            raise MissingSuiteNameError()
+
+    available = get_available_suites(path)
+    for suite in available:
+
+        if suite_name and suite != suite_name:
+            continue
+
+        for entry in get_suite_entries(path, suite, test_name):
+            yield entry

--- a/tools/libaqr/testing.py
+++ b/tools/libaqr/testing.py
@@ -1,0 +1,152 @@
+# project aquarium's testing battery
+# Copyright (C) 2021 SUSE, LLC.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple, Type, Union, cast
+from pydantic import BaseModel, Field
+import inspect
+import traceback
+
+
+class Requirements(BaseModel):
+    disks: int = Field(4, description="number of disks")
+    nics: int = Field(1, description="number of network interfaces")
+    nodes: int = Field(2, description="number of nodes")
+
+
+UnitCaseType = Callable[..., Awaitable[None]]
+
+
+class TestCase:
+    _requirements: Requirements
+    _results: List[Tuple[str, bool]]
+    _failures: Dict[str, str]
+
+    def __init__(self) -> None:
+        self._requirements = Requirements()
+        self._results = []
+        self._failures = {}
+
+    @property
+    def requirements(self) -> Requirements:
+        return self._requirements
+
+    @requirements.setter
+    def requirements(self, reqs: Requirements) -> None:
+        self._requirements = reqs
+
+    @property
+    def results(self) -> List[Tuple[str, bool]]:
+        return self._results
+
+    @property
+    def failures(self) -> Dict[str, str]:
+        return self._failures
+
+    def get_units(self) -> List[Tuple[str, Any]]:
+        _units: List[Tuple[str, Any]] = []
+        lst = inspect.getmembers(self, predicate=inspect.iscoroutinefunction)
+        for name, fn in lst:
+            if hasattr(fn, "is_caseunit") and fn.is_caseunit:
+                caseunit_name = fn.caseunit_name
+                if not caseunit_name:
+                    caseunit_name = name
+                _units.append((caseunit_name, fn))
+        return _units
+
+    async def run(self) -> None:
+        for name, fn in self.get_units():
+            success = True
+            try:
+                await fn()
+            except Exception:
+                success = False
+                self._failures[name] = traceback.format_exc()
+
+            self._results.append((name, success))
+
+
+_cases: Dict[str, TestCase] = {}
+
+
+def get_test_cases() -> Dict[str, TestCase]:
+    return _cases
+
+
+def maybe_with_args(func: Any):
+    def _wrapper(*args: Any, **kwargs: Any):
+        if len(args) == 1 and callable(args[0]):
+            return func(args[0])
+
+        def _with_args(decoratee: Any):
+            return func(decoratee, *args, **kwargs)
+        return _with_args
+
+    return _wrapper
+
+
+@maybe_with_args
+def requirements(
+    _test: Union[Type[TestCase], UnitCaseType],
+    disks: int = 4,
+    nics: int = 1,
+    nodes: int = 2
+):
+
+    reqs = Requirements(
+        disks=disks,
+        nics=nics,
+        nodes=nodes
+    )
+
+    casename = _test.__qualname__
+
+    if inspect.isclass(_test):
+        # ignore type because we still want to check this at runtime, but
+        # not getting pyright's warning about unecessary is instance checking.
+        if not issubclass(_test, TestCase):  # type: ignore
+            raise TypeError(f"{_test} is a class not of type TestCase")
+        testcls = cast(Type[TestCase], _test)
+
+        if casename not in _cases:
+            _cases[casename] = testcls()
+        _cases[casename].requirements = reqs
+
+        return testcls
+
+    elif inspect.iscoroutinefunction(_test):
+        coro = cast(Callable[..., Awaitable[None]], _test)
+
+        assert casename not in _cases
+
+        class TestCaseWrapper(TestCase):
+            @caseunit(_test.__qualname__)
+            async def testcase(self):
+                await coro()
+
+        _cases[casename] = TestCaseWrapper()
+        return _cases[casename]
+    else:
+        raise TypeError("expected class or coro")
+
+
+@maybe_with_args
+def caseunit(_test: UnitCaseType, casename: Optional[str] = None):
+    # these may report type errors depending on static checker, because these
+    # are not known members of said function. So we'll ignore them because we
+    # know what we are doing.
+    _test.is_caseunit = True  # type: ignore
+    _test.caseunit_name = _test.__qualname__  # type: ignore
+    if casename:
+        _test.caseunit_name = casename  # type: ignore
+    return _test

--- a/tools/libaqr/testing.py
+++ b/tools/libaqr/testing.py
@@ -110,6 +110,7 @@ def requirements(
     )
 
     casename = _test.__qualname__
+    print(f"case {casename}: {reqs=}")
 
     if inspect.isclass(_test):
         # ignore type because we still want to check this at runtime, but
@@ -134,7 +135,9 @@ def requirements(
             async def testcase(self):
                 await coro()
 
-        _cases[casename] = TestCaseWrapper()
+        testcls = TestCaseWrapper()
+        testcls.requirements = reqs
+        _cases[casename] = testcls
         return _cases[casename]
     else:
         raise TypeError("expected class or coro")

--- a/tools/libaqr/vagrant.py
+++ b/tools/libaqr/vagrant.py
@@ -21,6 +21,7 @@ from typing import Dict, List, Optional, Tuple
 from contextlib import contextmanager
 
 from libaqr.errors import (
+    BoxAlreadyExistsError,
     DeploymentNodeDoesNotExistError,
     DeploymentNodeNotRunningError,
     DeploymentNotFinishedError,
@@ -107,6 +108,22 @@ class Vagrant:
         if retcode != 0:
             raise VagrantError(
                 msg=f"failed removing box '{name}': {err}",
+                errno=retcode
+            )
+
+    @classmethod
+    def box_add(cls, name: str, path: Path) -> None:
+        """ Add image from 'path' as box 'name' """
+
+        avail_boxes: List[str] = cls.box_list()
+        if name in avail_boxes:
+            raise BoxAlreadyExistsError()
+
+        cmd = f"vagrant box add {name} {path}"
+        retcode, _, err = cls.run(None, cmd, interactive=False)
+        if retcode != 0:
+            raise VagrantError(
+                msg=f"failed adding box '{name}': {err}",
                 errno=retcode
             )
 

--- a/tools/libaqr/vagrant.py
+++ b/tools/libaqr/vagrant.py
@@ -24,6 +24,7 @@ from libaqr.errors import (
     DeploymentNodeDoesNotExistError,
     DeploymentNodeNotRunningError,
     DeploymentNotFinishedError,
+    VagrantError,
     VagrantStatusError
 )
 
@@ -80,6 +81,44 @@ class Vagrant:
 
         retcode, _, _ = self._run(cmd, interactive=True)
         return retcode
+
+    @classmethod
+    def box_list(cls) -> List[str]:
+        """ List all known vagrant boxes, including unrelated to aquarium. """
+
+        cmd = "vagrant box list --machine-readable"
+        retcode, out, err = cls.run(None, cmd, interactive=False)
+        if retcode != 0:
+            raise VagrantError(msg=err, errno=retcode)
+
+        boxes = (name for name in out.splitlines()
+                 if name.count("box-name") > 0)
+        boxnames = [entry.split(",")[3] for entry in boxes]
+        return boxnames
+
+    @classmethod
+    def box_remove(cls, name: str) -> None:
+        """ Remove an existing box """
+        if name not in cls.box_list():
+            return
+
+        cmd = f"vagrant box remove {name}"
+        retcode, _, err = cls.run(None, cmd, interactive=False)
+        if retcode != 0:
+            raise VagrantError(
+                msg=f"failed removing box '{name}': {err}",
+                errno=retcode
+            )
+
+    @classmethod
+    def run(
+        cls,
+        env_path: Optional[Path],
+        cmd: str,
+        interactive: bool
+    ) -> Tuple[int, str, str]:
+        inst = cls(env_path)
+        return inst._run(cmd, interactive)
 
     @property
     def nodes_status(self) -> List[Tuple[str, VagrantStateEnum]]:

--- a/tools/libaqr/vagrant.py
+++ b/tools/libaqr/vagrant.py
@@ -56,8 +56,10 @@ class Vagrant:
             return False, err
         return True, None
 
-    def stop(self) -> Tuple[bool, Optional[str]]:
+    def stop(self, interactive: bool = True) -> Tuple[bool, Optional[str]]:
         cmd = "vagrant destroy"
+        if not interactive:
+            cmd += " --force"
         retcode, _, err = self._run(cmd, interactive=True)
         if retcode != 0:
             return False, err


### PR DESCRIPTION
With this we are introducing a new script, `aqrtest.py`, which will run tests within the `tests/suites/` directory against a live vagrant cluster.

Tests are organized in Test Cases, which can be one or contain multiple Case Units. Each Test Case will declare its requirements, based on which the cluster will be deployed.

~This is still on-going work, and~ I'm looking for feedback.

**Note:** even after merge, we can't immediately make this the default on all PRs because it is expected that a lot of the API tests are going to fail. The API needs to be fixed before we can enable automatic checks as merging criteria.

Signed-off-by: Joao Eduardo Luis \<joao@suse.com>