### PR TITLE
images/builder: Build an image in one go with containers

### DIFF
--- a/images/builder/Dockerfile
+++ b/images/builder/Dockerfile
@@ -1,0 +1,34 @@
+# project aquarium's container builder
+# Copyright (C) 2021 SUSE, LLC.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+FROM registry.opensuse.org/opensuse/leap:15.3
+LABEL aquarium.image.author="Joao Eduardo Luis <joao@suse.com>"
+LABEL aquarium.url="https://aquarist-labs.io"
+LABEL aquarium.github="https://github.com/aquarist-labs/aquarium"
+LABEL version="0.1.0"
+LABEL description="Aquarium image builder"
+
+
+RUN zypper ref
+RUN zypper --non-interactive install \
+  git python3 python3-pip python3-rados \
+  python3-kiwi nodejs-common npm \
+  sudo which gptfdisk kpartx dosfstools e2fsprogs \
+  make qemu-tools xfsprogs
+
+
+RUN mkdir -p /builder/{cache,bin,src,out}
+VOLUME [ "/builder/cache", "/builder/bin", "/builder/src", "/builder/out" ]
+
+ENTRYPOINT [ "/builder/bin/autobuilder.sh" ]
+

--- a/images/builder/README.md
+++ b/images/builder/README.md
@@ -1,0 +1,47 @@
+# Aquarium's image autobuilder, with containers
+
+This container image will be able to automatically build an Aquarium vagrant
+image, allowing its user to specify where to build from and where to build to.
+
+## Recommended usage
+
+### Build the container image
+
+    sudo podman build -t aqr-builder .
+
+### Start a build
+
+Assuming we have our source repository in `/home/foo/aquarium.git`, and want the
+final build to live under `/tmp/builds`, this would be the command to pass on:
+
+    sudo podman run --privileged \
+        -v /tmp/builds:/builder/out \
+        -v /home/foo/aquarium.git:/builder/src \
+        -v /home/foo/aquarium.git/tools:/builder/bin \
+        -v /var/cache/kiwi:/builder/cache aqr-builder
+
+In this example we are providing four volumes to the container:
+
+* The first one is for the output directory, where the resulting build will
+  live. Multiple calls to the `run` command will result in multiple resulting
+  builds under the specified output directory.
+
+* The second specifies the source repository directory; this is where we're
+  going to be obtaining the sources and needed files to build the image.
+
+* The third volume specified the location of the binaries we need; for most
+  builds, these live under the source repository's `tools/` directory. Amongst
+  the required files is the container image's entrypoint script:
+  `autobuilder.sh`.
+  
+* Finally, the fourth volume is the cache to be used by `kiwi-ng`. It is
+  particularly useful to have a shared cache directory if multiple builds are
+  being created in a short span of time (less than a week apart, ish). This
+  avoids pulling packages over and over.
+
+In the end, and assuming the build was successful, one will be able to find a
+new directory under `/tmp/builds/`. It will be named in the form of
+`aqr-<branch>-<date>.<N>`, where `branch` will be the name of the checked out
+branch from the source repository; `date` will be the current date in the format
+`YYYYMMDD`, and `N` will be a zero-padded integer representing the number of the
+build in case of multiple builds for the same branch and date.

--- a/tools/autobuilder.sh
+++ b/tools/autobuilder.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+#
+# project aquarium's container builder
+# Copyright (C) 2021 SUSE, LLC.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+build_prefix_name=${BUILDNAME}
+outdir=${OUTDIR:-"/builder/out"}
+srcdir=${SRCDIR:-"/builder/src"}
+bindir=${BINDIR:-"/builder/bin"}
+cachedir=${CACHEDIR:-"/builder/cache"}
+
+
+[[ ! -d "${outdir}" ]] && \
+  echo "error: outdir does not exist at '${outdir}'" >/dev/stderr && \
+  exit 1
+
+[[ ! -d "${srcdir}" ]] && \
+  echo "error: srcdir does not exist at '${srcdir}'" >/dev/stderr && \
+  exit 1
+
+[[ ! -d "${bindir}" ]] && \
+  echo "error: bindir does not exist at '${bindir}'" >/dev/stderr && \
+  exit 1
+
+[[ ! -d "${cachedir}" ]] && \
+  echo "error: cachedir does not exist at '${cachedir}'" >/dev/stderr && \
+  exit 1
+
+[[ -z "${build_prefix_name}" ]] && \
+  build_prefix_name=$(git -C ${srcdir} rev-parse --abbrev-ref HEAD)
+
+[[ -z "${build_prefix_name}" ]] && build_prefix_name="noname"
+
+build_prefix="aqr-${build_prefix_name}-"
+build_date=$(date +%Y%m%d)
+existing_builds=$((ls -d ${outdir}/${build_prefix}${build_date}.*) 2>/dev/null)
+
+lowest_n=0
+res=( $(echo $(for i in ${existing_builds} ; do
+        n=$(basename $i)
+        echo $i | cut -f2 -d'.' ;
+      done) | sort -n) )
+for i in ${res[*]}; do
+  j=$(( i + 0))
+  [[ $j -gt $lowest_n ]] && lowest_n=$j
+done
+
+echo $lowest_n
+next_n=$((lowest_n + 1))
+[[ $next_n -lt 10 ]] && next_n="0${next_n}"
+build_name="${build_prefix}${build_date}.${next_n}"
+
+[[ -n "${DRY}" ]] && \
+  echo "build_name: ${build_name}" && \
+  exit 0
+
+${bindir}/build-image.sh -n ${build_name} \
+  --rootdir ${srcdir} \
+  --buildsdir ${outdir} \
+  --cachedir ${cachedir} || exit 1

--- a/tools/build-image.sh
+++ b/tools/build-image.sh
@@ -27,7 +27,10 @@ usage: $0 [options]
 options:
   -n NAME | --name NAME     Specify build name (default: aquarium).
   -c | --clean              Cleanup an existing build directory before building.
-  -t | --type IMGTYPE       Specify image type (default: vagrant)
+  -t | --type IMGTYPE       Specify image type (default: vagrant).
+  --rootdir PATH            Path to repository's root.
+  --buildsdir PATH          Path to output builds directory.
+  --cachedir PATH           Path to kiwi's shared cache directory.
   -h | --help               This message.
 
 allowed image types:
@@ -50,22 +53,12 @@ error_exit() {
     exit 1
 }
 
-find_root || exit 1
-[[ -z "${rootdir}" ]] && \
-  error_exit "unable to find repository's root dir"
-
-imgdir=${rootdir}/images
-srcdir=${rootdir}/src
-
-[[ ! -d "${imgdir}" ]] && \
-  error_exit "unable to find 'images' directory at ${rootdir}"
-
-[[ ! -d "${srcdir}" ]] && \
-  error_exit "unable to find 'src' directory at ${rootdir}" 
-
 imgtype="vagrant"
 build_name="aquarium"
 clean=0
+
+buildsdir=
+cachedir=
 
 while [[ $# -gt 0 ]]; do
   case $1 in
@@ -80,6 +73,18 @@ while [[ $# -gt 0 ]]; do
       imgtype=$2
       shift 1
       ;;
+    --rootdir)
+      rootdir=$2
+      shift 1
+      ;;
+    --buildsdir)
+      buildsdir=$2
+      shift 1
+      ;;
+    --cachedir)
+      cachedir=$2
+      shift 1
+      ;;
     -h|--help)
       usage
       exit 0
@@ -90,6 +95,25 @@ while [[ $# -gt 0 ]]; do
   esac
   shift 1
 done
+
+if [[ -z "${rootdir}" ]]; then
+  find_root || exit 1
+fi
+
+[[ -z "${rootdir}" ]] && \
+  error_exit "unable to find repository's root dir"
+
+imgdir=${rootdir}/images
+srcdir=${rootdir}/src
+
+[[ -z "${buildsdir}" ]] && buildsdir=${imgdir}/build
+
+[[ ! -d "${imgdir}" ]] && \
+  error_exit "unable to find 'images' directory at ${rootdir}"
+
+[[ ! -d "${srcdir}" ]] && \
+  error_exit "unable to find 'src' directory at ${rootdir}" 
+
 
 [[ -z "${build_name}" ]] && \
   usage_error_exit "missing build name"
@@ -115,7 +139,7 @@ if ! kiwi-ng --version &>/dev/null ; then
   error_exit "missing kiwi-ng"
 fi
 
-build=${imgdir}/build/${build_name}
+build=${buildsdir}/${build_name}
 
 if [[ -e "${build}" && "${clean}" -eq "1" ]]; then
   echo "warning: removing existing build '${build_name}'"
@@ -133,7 +157,10 @@ set -x
 mkdir -p ${build}
 
 rm -f ${rootdir}/aquarium*.tar.gz
+pushd ${rootdir}
 make dist
+popd
+
 # At this point, we have a dist tarball (aquarium-$version.tar.gz), which
 # has paths prefixed with aquarium-$version.  When using the tarball inside
 # kiwi though, we need it to have bare /usr/... paths, so it's extracted
@@ -164,11 +191,14 @@ cp ${imgdir}/microOS/config.{sh,xml} \
 
 mkdir ${build}/{_out,_logs}
 
+kiwiargs=
+[[ -n "${cachedir}" ]] && kiwiargs="--shared-cache-dir=${cachedir}"
+
 osid=$(grep '^ID=' /etc/os-release | sed -e 's/\(ID=["]*\)\(.\+\)/\2/' | tr -d '"')
 case $osid in
   opensuse-tumbleweed | opensuse-leap)
     (set -o pipefail
-    sudo kiwi-ng --debug --profile=${profile} --type ${type}\
+    sudo kiwi-ng ${kiwiargs} --debug --profile=${profile} --type ${type}\
       system build --description ${build} \
       --target-dir ${build}/_out |\
       tee ${build}/_logs/${build_name}-build.log)
@@ -176,7 +206,7 @@ case $osid in
     ;;
   debian | ubuntu)
     (set -o pipefail
-    sudo kiwi-ng --debug --profile=${profile} --type ${type}\
+    sudo kiwi-ng ${kiwiargs} --debug --profile=${profile} --type ${type}\
       system boxbuild --box tumbleweed --no-update-check -- --description ${build} \
       --target-dir ${build}/_out |\
       tee ${build}/_logs/${build_name}-build.log)

--- a/tools/build-image.sh
+++ b/tools/build-image.sh
@@ -115,11 +115,6 @@ if ! kiwi-ng --version &>/dev/null ; then
   error_exit "missing kiwi-ng"
 fi
 
-if ! [[ -f /sbin/mkfs.btrfs || -f /bin/mkfs.btrfs ]]; then
-  echo "error: missing btrfsprogs"
-  exit 1
-fi
-
 build=${imgdir}/build/${build_name}
 
 if [[ -e "${build}" && "${clean}" -eq "1" ]]; then


### PR DESCRIPTION
This patchset introduces a container image able to automatically build a source tree upon being run.

Additionally, allows the user to configure the source repository's root directory and the builds' output directory via the CLI to the existing `build-image.sh` script.

This is mighty useful to build images in one go without having to 1) do a lot of things, and 2) require root. Also allows for better automation.

Signed-off-by: Joao Eduardo Luis \<joao@suse.com>