### PR TITLE
gravel: osd pool default size

### DIFF
--- a/src/gravel/cephadm/cephadm.py
+++ b/src/gravel/cephadm/cephadm.py
@@ -60,6 +60,7 @@ class Cephadm:
                    outcb: Optional[Callable[[str], None]] = None
                    ) -> Tuple[str, str, int]:
 
+        logger.debug(f"call: {cmd}")
         cmd = self.cephadm + cmd
 
         process = await asyncio.create_subprocess_exec(

--- a/src/gravel/cephadm/cephadm.py
+++ b/src/gravel/cephadm/cephadm.py
@@ -12,12 +12,13 @@
 # GNU General Public License for more details.
 
 import asyncio
-from logging import Logger
-import os
 import json
+import os
 import shlex
-from io import StringIO
 import time
+
+from io import StringIO
+from logging import Logger
 from typing import (
     Callable,
     List,

--- a/src/gravel/controllers/orch/ceph.py
+++ b/src/gravel/controllers/orch/ceph.py
@@ -261,6 +261,21 @@ class Mon:
             logger.exception(e)
             raise NoRulesetError()
 
+    def config_get(self, who: str, name: str) -> Any:
+        cmd = {
+            "prefix": "config get",
+            "who": who,
+            "key": name,
+        }
+        try:
+            value = self.call(cmd)
+        except CephCommandError as e:
+            logger.error(
+                f"mon > unable to get config: {name} on {who}")
+            logger.exception(e)
+            return None
+        return value
+
     def config_set(self, who: str, name: str, value: str) -> bool:
         cmd = {
             "prefix": "config set",
@@ -407,3 +422,16 @@ class Mon:
         }
         results: Dict[str, Any] = self.call(cmd)
         return parse_obj_as(List[CephOSDPoolStatsModel], results)
+
+    def get_pool_default_size(self) -> Optional[int]:
+        return self.config_get("mon", "osd_pool_default_size")
+
+    def set_pool_default_size(self, size: int) -> bool:
+        r = self.config_set(
+            "global",
+            "osd_pool_default_size",
+            str(size)
+        )
+        if not r:
+            logger.error("mon > unable to set osd pool default size: {size}")
+        return r

--- a/src/gravel/tests/conftest.py
+++ b/src/gravel/tests/conftest.py
@@ -11,30 +11,32 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 
+import httpx
+import logging
 import os
-from types import SimpleNamespace
 import pytest
 import sys
+
+from asgi_lifespan import LifespanManager
 from pyfakefs import fake_filesystem  # pyright: reportMissingTypeStubs=false
-from _pytest.fixtures import SubRequest
+from pytest_mock import MockerFixture
+from types import SimpleNamespace
 from typing import (
-    Callable,
-    Tuple,
     Any,
     Awaitable,
+    Callable,
     Dict,
     Optional,
-    cast
+    Tuple,
+    cast,
 )
-from pytest_mock import MockerFixture
+from _pytest.fixtures import SubRequest
+
 from fastapi import FastAPI
 
 from gravel.controllers.gstate import GlobalState
 from gravel.controllers.kv import KV
 
-from asgi_lifespan import LifespanManager
-import httpx
-import logging
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), 'data')
 

--- a/src/gravel/tests/conftest.py
+++ b/src/gravel/tests/conftest.py
@@ -26,6 +26,7 @@ from typing import (
     Awaitable,
     Callable,
     Dict,
+    List,
     Optional,
     Tuple,
     cast,
@@ -251,17 +252,17 @@ async def aquarium_startup(
                 return True
 
         class FakeCephadm(Cephadm):
-            async def call(self, cmd: str,
+            async def call(self, cmd: List[str],
                            outcb: Optional[Callable[[str], None]] = None
                            ) -> Tuple[str, str, int]:
                 # Implement expected calls to cephadm with testable responses
-                if cmd == 'pull':
+                if cmd[0] == 'pull':
                     return '', '', 0
-                elif cmd == 'gather-facts':
+                elif cmd[0] == 'gather-facts':
                     return get_data_contents(
                         DATA_DIR,
                         'gather_facts_real.json'), "", 0
-                elif cmd == 'ceph-volume inventory --format=json':
+                elif cmd == ['ceph-volume', 'inventory', '--format', 'json']:
                     return get_data_contents(DATA_DIR, 'inventory_real.json'), "", 0
                 else:
                     print(cmd)

--- a/src/gravel/tests/unit/controllers/orch/test_ceph.py
+++ b/src/gravel/tests/unit/controllers/orch/test_ceph.py
@@ -131,6 +131,30 @@ def test_set_pool_size(
     mon.set_pool_size("foobar", 2)
 
 
+def test_config_get(
+    ceph_conf_file_fs: Generator[fake_filesystem.FakeFilesystem, None, None],
+    mocker: MockerFixture
+):
+    from gravel.controllers.orch.ceph import Ceph, Mon
+
+    def argscheck(cls: Any, args: Dict[str, Any]) -> Any:
+        assert "prefix" in args
+        assert "who" in args
+        assert "key" in args
+        assert "name" not in args  # config get uses `key`
+        assert "value" not in args
+        assert args["prefix"] == "config get"
+        assert args["who"] == "foo"
+        assert args["key"] == "bar"
+
+    mocker.patch.object(
+        Mon, "call", new=argscheck  # type:ignore
+    )
+    ceph = Ceph()
+    mon = Mon(ceph)
+    mon.config_get("foo", "bar")
+
+
 def test_config_set(
     ceph_conf_file_fs: Generator[fake_filesystem.FakeFilesystem, None, None],
     mocker: MockerFixture

--- a/src/gravel/tests/unit/controllers/orch/test_ceph.py
+++ b/src/gravel/tests/unit/controllers/orch/test_ceph.py
@@ -129,3 +129,27 @@ def test_set_pool_size(
     ceph = Ceph()
     mon = Mon(ceph)
     mon.set_pool_size("foobar", 2)
+
+
+def test_set_pool_default_size(
+    ceph_conf_file_fs: Generator[fake_filesystem.FakeFilesystem, None, None],
+    mocker: MockerFixture
+):
+    from gravel.controllers.orch.ceph import Ceph, Mon
+
+    def argscheck(cls: Any, args: Dict[str, Any]) -> Any:
+        assert "prefix" in args
+        assert "who" in args
+        assert "name" in args
+        assert "value" in args
+        assert args["prefix"] == "config set"
+        assert args["who"] == "global"
+        assert args["name"] == "osd_pool_default_size"
+        assert args["value"] == "2"
+
+    mocker.patch.object(
+        Mon, "call", new=argscheck
+    )
+    ceph = Ceph()
+    mon = Mon(ceph)
+    mon.set_pool_default_size(2)

--- a/src/gravel/tests/unit/controllers/orch/test_ceph.py
+++ b/src/gravel/tests/unit/controllers/orch/test_ceph.py
@@ -131,6 +131,32 @@ def test_set_pool_size(
     mon.set_pool_size("foobar", 2)
 
 
+def test_config_set(
+    ceph_conf_file_fs: Generator[fake_filesystem.FakeFilesystem, None, None],
+    mocker: MockerFixture
+):
+    from gravel.controllers.orch.ceph import Ceph, Mon
+
+    def argscheck(cls: Any, args: Dict[str, Any]) -> Any:
+        assert "prefix" in args
+        assert "who" in args
+        assert "key" not in args  # config set uses `name`
+        assert "name" in args
+        assert "value" in args
+        assert "force" not in args
+        assert args["prefix"] == "config set"
+        assert args["who"] == "foo"
+        assert args["name"] == "bar"
+        assert args["value"] == "baz"
+
+    mocker.patch.object(
+        Mon, "call", new=argscheck
+    )
+    ceph = Ceph()
+    mon = Mon(ceph)
+    mon.config_set("foo", "bar", "baz")
+
+
 def test_set_pool_default_size(
     ceph_conf_file_fs: Generator[fake_filesystem.FakeFilesystem, None, None],
     mocker: MockerFixture


### PR DESCRIPTION
set the osd pool size to 3 when more than 3 nodes are present,
otherwise, (re)set the pool size to 2.

- sets the `osd_pool_default_size` for newly created pools
- adjusts the pool size for any other existing pool(s):
  - if not managed by an aquarium service
  - if not a user-defined pool

Resolves: #404
Signed-off-by: Michael Fritch <mfritch@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [issue id or URL on https://github.com/aquarist-labs/aquarium/issues, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The component is the short name of a major module or subsystem, something 
like "tools", "gravel", "glass", "doc", etc.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://github.com/aquarist-labs/aquarium/blob/main/CONTRIBUTING.md

-->

## Checklist
- [ ] References issues, create if required
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test tumbleweed`
- `jenkins run tumbleweed`
- `jenkins test leap`
- `jenkins run leap`

</details>
