### PR TITLE
gravel: create system disk on initial deployment

### DIFF
--- a/images/microOS/root/etc/containers/storage.conf
+++ b/images/microOS/root/etc/containers/storage.conf
@@ -1,0 +1,133 @@
+# This file is is the configuration file for all tools
+# that use the containers/storage library.
+# See man 5 containers-storage.conf for more information
+# The "container storage" table contains all of the server options.
+[storage]
+
+# Default Storage Driver
+driver = "overlay"
+
+# Temporary storage location
+runroot = "/var/run/containers/storage"
+
+# Primary Read/Write location of container storage
+graphroot = "/var/lib/containers/storage"
+
+[storage.options]
+# Storage options to be passed to underlying storage drivers
+
+# AdditionalImageStores is used to pass paths to additional Read/Only image stores
+# Must be comma separated list.
+additionalimagestores = [
+]
+
+# Size is used to set a maximum size of the container image.  Only supported by
+# certain container storage drivers.
+size = ""
+
+# Path to an helper program to use for mounting the file system instead of mounting it
+# directly.
+mount_program = "/usr/bin/fuse-overlayfs"
+
+# OverrideKernelCheck tells the driver to ignore kernel checks based on kernel version
+# override_kernel_check = "false"
+
+# mountopt specifies comma separated list of extra mount options
+# mountopt = "nodev"
+
+# Remap-UIDs/GIDs is the mapping from UIDs/GIDs as they should appear inside of
+# a container, to UIDs/GIDs as they should appear outside of the container, and
+# the length of the range of UIDs/GIDs.  Additional mapped sets can be listed
+# and will be heeded by libraries, but there are limits to the number of
+# mappings which the kernel will allow when you later attempt to run a
+# container.
+#
+# remap-uids = 0:1668442479:65536
+# remap-gids = 0:1668442479:65536
+
+# Remap-User/Group is a name which can be used to look up one or more UID/GID
+# ranges in the /etc/subuid or /etc/subgid file.  Mappings are set up starting
+# with an in-container ID of 0 and the a host-level ID taken from the lowest
+# range that matches the specified name, and using the length of that range.
+# Additional ranges are then assigned, using the ranges which specify the
+# lowest host-level IDs first, to the lowest not-yet-mapped container-level ID,
+# until all of the entries have been used for maps.
+#
+# remap-user = "storage"
+# remap-group = "storage"
+
+# If specified, use OSTree to deduplicate files with the overlay backend
+ostree_repo = ""
+
+# Set to skip a PRIVATE bind mount on the storage home directory.  Only supported by
+# certain container storage drivers
+# skip_mount_home = "false"
+
+[storage.options.thinpool]
+# Storage Options for thinpool
+
+# autoextend_percent determines the amount by which pool needs to be
+# grown. This is specified in terms of % of pool size. So a value of 20 means
+# that when threshold is hit, pool will be grown by 20% of existing
+# pool size.
+# autoextend_percent = "20"
+
+# autoextend_threshold determines the pool extension threshold in terms
+# of percentage of pool size. For example, if threshold is 60, that means when
+# pool is 60% full, threshold has been hit.
+# autoextend_threshold = "80"
+
+# basesize specifies the size to use when creating the base device, which
+# limits the size of images and containers.
+# basesize = "10G"
+
+# blocksize specifies a custom blocksize to use for the thin pool.
+# blocksize="64k"
+
+# directlvm_device specifies a custom block storage device to use for the
+# thin pool. Required if you setup devicemapper.
+# directlvm_device = ""
+
+# directlvm_device_force wipes device even if device already has a filesystem.
+# directlvm_device_force = "True"
+
+# fs specifies the filesystem type to use for the base device.
+# fs="xfs"
+
+# log_level sets the log level of devicemapper.
+# 0: LogLevelSuppress 0 (Default)
+# 2: LogLevelFatal
+# 3: LogLevelErr
+# 4: LogLevelWarn
+# 5: LogLevelNotice
+# 6: LogLevelInfo
+# 7: LogLevelDebug
+# log_level = "7"
+
+# min_free_space specifies the min free space percent in a thin pool require for
+# new device creation to succeed. Valid values are from 0% - 99%.
+# Value 0% disables
+# min_free_space = "10%"
+
+# mkfsarg specifies extra mkfs arguments to be used when creating the base.
+# device.
+# mkfsarg = ""
+
+# use_deferred_removal marks devicemapper block device for deferred removal.
+# If the thinpool is in use when the driver attempts to remove it, the driver
+# tells the kernel to remove it as soon as possible. Note this does not free
+# up the disk space, use deferred deletion to fully remove the thinpool.
+# use_deferred_removal = "True"
+
+# use_deferred_deletion marks thinpool device for deferred deletion.
+# If the device is busy when the driver attempts to delete it, the driver
+# will attempt to delete device every 30 seconds until successful.
+# If the program using the driver exits, the driver will continue attempting
+# to cleanup the next time the driver is used. Deferred deletion permanently
+# deletes the device and all data stored in device will be lost.
+# use_deferred_deletion = "True"
+
+# xfs_nospace_max_retries specifies the maximum number of retries XFS should
+# attempt to complete IO when ENOSPC (no space) error is returned by
+# underlying storage device.
+# xfs_nospace_max_retries = "0"

--- a/src/gravel/api/nodes.py
+++ b/src/gravel/api/nodes.py
@@ -24,6 +24,10 @@ from gravel.controllers.nodes.deployment import (
     DeploymentState,
     NodeStageEnum
 )
+from gravel.controllers.nodes.disks import (
+    DiskSolution,
+    Disks
+)
 from gravel.controllers.nodes.errors import (
     NodeAlreadyJoiningError,
     NodeCantDeployError,
@@ -71,6 +75,23 @@ class NodeJoinRequestModel(BaseModel):
 
 class TokenReplyModel(BaseModel):
     token: str
+
+
+@router.get("/devices", response_model=DiskSolution)
+async def node_get_devices(request: Request) -> DiskSolution:
+    """
+    Obtain the list of devices and a deployment solution, if possible.
+    """
+    logger.debug("api > nodes > devices")
+    nodemgr: NodeMgr = request.app.state.nodemgr
+
+    if not nodemgr.available:
+        raise HTTPException(
+            status_code=status.HTTP_428_PRECONDITION_REQUIRED,
+            detail="node is not available"
+        )
+
+    return Disks.gen_solution(request.app.state.gstate)
 
 
 @router.post("/deployment/start", response_model=DeployStartReplyModel)

--- a/src/gravel/controllers/nodes/disks.py
+++ b/src/gravel/controllers/nodes/disks.py
@@ -1,0 +1,151 @@
+# project aquarium's backend
+# Copyright (C) 2021 SUSE, LLC.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+from enum import Enum
+from logging import Logger
+from typing import List, Optional, Tuple
+from fastapi.logger import logger as fastapi_logger
+from pydantic import BaseModel, Field
+
+from gravel.cephadm.models import NodeInfoModel, VolumeDeviceModel
+from gravel.controllers.gstate import GlobalState
+
+
+logger: Logger = fastapi_logger
+
+
+class DiskTypeEnum(int, Enum):
+    NONE = 0
+    HDD = 1
+    SSD = 2
+
+
+class DiskInfoModel(BaseModel):
+    vendor: str = Field("", title="disk's manufacturer")
+    model: str = Field("", title="disk's model")
+
+
+class DiskModel(BaseModel):
+    path: Optional[str] = Field(None, title="disk's device path")
+    size: int = Field(0, title="size in bytes")
+    type: DiskTypeEnum = Field(DiskTypeEnum.NONE, title="disk type")
+    info: DiskInfoModel = Field(title="additional info about disk")
+
+
+class RejectedDiskModel(BaseModel):
+    disk: DiskModel = Field(title="rejected disk")
+    reasons: List[str] = Field([], title="reasons for rejection")
+
+
+class DiskSolution(BaseModel):
+    systemdisk: Optional[DiskModel] = Field(None, title="chosen system disk")
+    storage: List[DiskModel] = Field([], title="chosen storage disks")
+    storage_size: int = Field(0, title="total size for storage, in bytes")
+    rejected: List[RejectedDiskModel] = Field([], title="rejected disks")
+    possible: bool = Field(False, title="deployment possible")
+
+
+def _device_to_disk(device: VolumeDeviceModel) -> DiskModel:
+
+    def _get_disk_type(rotational: bool) -> DiskTypeEnum:
+        return DiskTypeEnum.HDD if rotational else DiskTypeEnum.SSD
+
+    return DiskModel(
+        path=device.path,
+        size=device.sys_api.size,
+        type=_get_disk_type(device.sys_api.rotational),
+        info=DiskInfoModel(
+            vendor=device.sys_api.vendor,
+            model=device.sys_api.model
+        )
+    )
+
+
+class Disks:
+
+    def __init__(self) -> None:
+        pass
+
+    @classmethod
+    def gen_solution(cls, gstate: GlobalState) -> DiskSolution:
+
+        nodeinfo: Optional[NodeInfoModel] = gstate.inventory.latest
+        assert nodeinfo
+
+        hdds: List[VolumeDeviceModel] = []
+        ssds: List[VolumeDeviceModel] = []
+        rejected: List[VolumeDeviceModel] = []
+
+        for device in nodeinfo.disks:
+            if not device.available:
+                rejected.append(device)
+                continue
+
+            if device.sys_api.rotational:
+                hdds.append(device)
+            else:
+                ssds.append(device)
+
+        def _get_candidates(
+            lst: List[VolumeDeviceModel]
+        ) -> Tuple[Optional[VolumeDeviceModel], List[VolumeDeviceModel]]:
+            systemdisk: Optional[VolumeDeviceModel] = None
+            storage: List[VolumeDeviceModel] = []
+            for entry in lst:
+                if not systemdisk:
+                    systemdisk = entry
+                elif systemdisk.sys_api.size > entry.sys_api.size:
+                    storage.append(systemdisk)
+                    systemdisk = entry
+                else:
+                    storage.append(entry)
+            return systemdisk, storage
+
+        candidate_storage: List[VolumeDeviceModel] = []
+        candidate_systemdisk: Optional[VolumeDeviceModel] = None
+        candidate_systemdisk_hdd, hdd_lst = _get_candidates(hdds)
+        candidate_systemdisk_ssd, ssd_lst = _get_candidates(ssds)
+
+        candidate_storage = hdd_lst + ssd_lst
+
+        if candidate_systemdisk_ssd:
+            candidate_systemdisk = candidate_systemdisk_ssd
+            if candidate_systemdisk_hdd:
+                candidate_storage.append(candidate_systemdisk_hdd)
+        elif candidate_systemdisk_hdd:
+            candidate_systemdisk = candidate_systemdisk_hdd
+
+        if len(hdds) + len(ssds) > 0:
+            assert candidate_systemdisk
+            assert len(candidate_storage) + 1 == len(hdds) + len(ssds)
+
+        solution = DiskSolution()
+        solution.possible = (candidate_systemdisk is not None)
+
+        for device in rejected:
+            solution.rejected.append(RejectedDiskModel(
+                disk=_device_to_disk(device),
+                reasons=device.rejected_reasons
+            ))
+
+        if not candidate_systemdisk:
+            return solution
+
+        solution.systemdisk = _device_to_disk(candidate_systemdisk)
+        total_storage = 0
+        for device in candidate_storage:
+            solution.storage.append(_device_to_disk(device))
+            total_storage += device.sys_api.size
+        solution.storage_size = total_storage
+
+        return solution

--- a/src/gravel/controllers/nodes/systemdisk.py
+++ b/src/gravel/controllers/nodes/systemdisk.py
@@ -1,0 +1,252 @@
+# project aquarium's backend
+# Copyright (C) 2021 SUSE, LLC.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+import shlex
+from typing import (
+    Dict,
+    Optional,
+    List,
+)
+from logging import Logger
+from pathlib import Path
+from fastapi.logger import logger as fastapi_logger
+from pydantic.main import BaseModel
+
+from gravel.cephadm.models import (
+    NodeInfoModel,
+    VolumeDeviceModel
+)
+from gravel.controllers.errors import GravelError
+from gravel.controllers.gstate import GlobalState
+from gravel.controllers.utils import aqr_run_cmd
+
+
+logger: Logger = fastapi_logger
+
+
+class UnknownDeviceError(GravelError):
+    pass
+
+
+class UnavailableDeviceError(GravelError):
+    pass
+
+
+class MountError(GravelError):
+    pass
+
+
+class LVMError(GravelError):
+    pass
+
+
+class SystemDiskNotMountedError(GravelError):
+    pass
+
+
+class OverlayError(GravelError):
+    pass
+
+
+class MountEntry(BaseModel):
+    source: str
+    dest: str
+
+
+def get_mounts() -> List[MountEntry]:
+    proc: Path = Path("/proc/mounts")
+    assert proc.exists()
+
+    lst: List[MountEntry] = []
+    with proc.open(mode="r", encoding="utf-8") as f:
+        for line in f.readlines():
+            fields: List[str] = line.split(" ")
+            if len(fields) < 2:
+                continue
+            lst.append(MountEntry(source=fields[0], dest=fields[1]))
+    return lst
+
+
+class SystemDisk:
+
+    _gstate: GlobalState
+    _overlaydirs: Dict[str, str] = {
+        "etc": "/etc",
+        "logs": "/var/log",
+        "etcd": "/var/lib/etcd",
+        "containers": "/var/lib/containers"
+    }
+    _bindmounts: Dict[str, str] = {
+        "ceph": "/var/lib/ceph"
+    }
+
+    def __init__(self, gstate: GlobalState) -> None:
+        self._gstate = gstate
+
+    @property
+    def mounted(self):
+        mounts: List[MountEntry] = get_mounts()
+        for entry in mounts:
+            if entry.source == "/dev/mapper/aquarium-systemdisk" and \
+               entry.dest == "/aquarium":
+                return True
+        return False
+
+    async def lvm(self, args: str) -> None:
+        cmd: List[str] = ["lvm"] + shlex.split(args)
+        retcode, _, err = await aqr_run_cmd(cmd)
+
+        if retcode != 0:
+            raise LVMError(msg=err)
+
+    async def create(self, devicestr: str) -> None:
+
+        logger.debug(f"prepare system disk: {devicestr}")
+        inventory: Optional[NodeInfoModel] = self._gstate.inventory.latest
+        assert inventory is not None
+
+        device: Optional[VolumeDeviceModel] = \
+            next((d for d in inventory.disks if d.path == devicestr), None)
+
+        # ascertain whether we can use this device
+        if not device:
+            raise UnknownDeviceError(f"device {devicestr} not known")
+        elif not device.available:
+            raise UnavailableDeviceError(f"device {devicestr} is not available")
+
+        # create partitions
+        logger.debug(f"prepare system disk: device: {device}")
+        devpath = device.path
+
+        def _create_overlay_dir(path: Path, dirname: str) -> None:
+            assert path.exists()
+            dirpath: Path = path.joinpath(dirname)
+            assert not dirpath.exists()
+            dirpath.mkdir()
+            dirpath.joinpath("overlay").mkdir()
+            dirpath.joinpath("temp").mkdir()
+
+        try:
+            # create lvm volume
+            await self.lvm(f"pvcreate {devpath}")
+            await self.lvm(f"vgcreate aquarium {devpath} --addtag @aquarium")
+            await self.lvm("lvcreate -l 100%FREE -n systemdisk aquarium")
+
+            lvmdev: Path = Path("/dev/mapper/aquarium-systemdisk")
+            assert lvmdev.exists()
+
+            # format with xfs
+            await aqr_run_cmd(shlex.split(f"mkfs.xfs -m bigtime=1 {lvmdev}"))
+
+            aqrmntpath: Path = Path("/aquarium")
+            aqrmntpath.mkdir(exist_ok=True)
+
+            await self.mount()
+
+            for d in self._overlaydirs.keys():
+                _create_overlay_dir(aqrmntpath, d)
+
+            # some directories (like ceph's) can't be overlayed due to weirdness
+            # ensued, so we'll bind mount them later.
+            for d in self._bindmounts.keys():
+                ourpath: Path = aqrmntpath.joinpath(d)
+                assert not ourpath.exists()
+                ourpath.mkdir()
+
+            await self.unmount()
+
+        except Exception as e:
+            logger.error(f"prepare system disk > {str(e)}")
+            logger.exception(e)
+            raise e
+
+    async def mount(self) -> None:
+        aqrmntpath: Path = Path("/aquarium")
+        aqrdevpath: Path = Path("/dev/mapper/aquarium-systemdisk")
+        assert aqrdevpath.exists()
+        aqrmntpath.mkdir(exist_ok=True)
+
+        aqrdev: str = aqrdevpath.as_posix()
+        aqrmnt: str = aqrmntpath.as_posix()
+
+        try:
+            await aqr_run_cmd(shlex.split(f"mount {aqrdev} {aqrmnt}"))
+        except Exception as e:
+            raise MountError(msg=str(e))
+
+    async def unmount(self) -> None:
+        aqrmnt: Path = Path("/aquarium")
+        if not aqrmnt.exists():
+            raise MountError(msg="/aquarium mount point does not exist")
+
+        try:
+            await aqr_run_cmd(shlex.split(f"umount {aqrmnt}"))
+        except Exception as e:
+            raise MountError(msg=str(e))
+
+    # lacking a better name atm, we're calling this function 'swap in', as in
+    # we're swapping these directories in, some being overlayed, others bind
+    # mounted.
+    async def enable(self) -> None:
+        if not self.mounted:
+            try:
+                await self.mount()
+            except MountError as e:
+                raise OverlayError(msg=e.message)
+
+        async def _overlay(lower: str, upper: str, work: str):
+            mntcmd = "mount -t overlay " \
+                     f"-o lowerdir={lower},upperdir={upper},workdir={work} " \
+                     f"overlay {lower}"
+            await aqr_run_cmd(shlex.split(mntcmd))
+
+        for upper, lower in self._overlaydirs.items():
+            aqrpath: Path = Path("/aquarium")
+            upperpath: Path = aqrpath.joinpath(upper)
+            overlaypath: Path = upperpath.joinpath("overlay")
+            temppath: Path = upperpath.joinpath("temp")
+            lowerpath: Path = Path(lower)
+            assert overlaypath.exists() and overlaypath.is_dir()
+            assert temppath.exists() and temppath.is_dir()
+
+            lowerpath.mkdir(parents=True, exist_ok=True)
+            assert lowerpath.exists() and lowerpath.is_dir()
+
+            try:
+                await _overlay(
+                    lower,
+                    overlaypath.as_posix(),
+                    temppath.as_posix()
+                )
+            except Exception as e:
+                raise OverlayError(
+                    f"unable to overlay {upper} on {lower}: {str(e)}"
+                )
+
+        for ours, theirs in self._bindmounts.items():
+            ourpath: Path = Path("/aquarium").joinpath(ours)
+            theirpath: Path = Path(theirs)
+            assert ourpath.exists()
+            theirpath.mkdir(parents=True, exist_ok=True)
+
+            try:
+                await aqr_run_cmd([
+                    "mount",
+                    "--bind",
+                    ourpath.as_posix(),
+                    theirpath.as_posix()
+                ])
+            except Exception as e:
+                raise MountError(
+                    f"unable to bind mount {ourpath} to {theirpath}: {str(e)}"
+                )

--- a/src/gravel/tests/unit/controllers/nodes/data/disks_local_inventory.json
+++ b/src/gravel/tests/unit/controllers/nodes/data/disks_local_inventory.json
@@ -1,0 +1,222 @@
+{
+    "hostname": "node1",
+    "model": " (Standard PC (i440FX + PIIX, 1996))",
+    "vendor": "QEMU",
+    "kernel": "5.12.4-1-default",
+    "operating_system": "Unknown",
+    "system_uptime": 2085.86,
+    "current_time": 1622300640,
+    "cpu": {
+      "arch": "x86_64",
+      "model": "AMD EPYC-Rome Processor",
+      "cores": 1,
+      "count": 1,
+      "threads": 1,
+      "load": {
+        "one_min": 0.05,
+        "five_min": 0.06,
+        "fifteen_min": 0.01
+      }
+    },
+    "nics": {
+      "eth0": {
+        "driver": "virtio_net",
+        "iftype": "physical",
+        "ipv4_address": "192.168.121.117/24",
+        "ipv6_address": "fe80::5054:ff:fe77:6297/64",
+        "lower_devs_list": [],
+        "mtu": 1500,
+        "nic_type": "ethernet",
+        "operstate": "up",
+        "speed": -1,
+        "upper_devs_list": []
+      },
+      "lo": {
+        "driver": "",
+        "iftype": "logical",
+        "ipv4_address": "127.0.0.1/8",
+        "ipv6_address": "::1/128",
+        "lower_devs_list": [],
+        "mtu": 65536,
+        "nic_type": "loopback",
+        "operstate": "unknown",
+        "speed": -1,
+        "upper_devs_list": []
+      }
+    },
+    "memory": {
+      "available_kb": 3608556,
+      "free_kb": 3508396,
+      "total_kb": 4013728
+    },
+    "disks": [
+      {
+        "available": true,
+        "device_id": "28383427",
+        "human_readable_type": "hdd",
+        "lsm_data": {},
+        "lvs": [],
+        "path": "/dev/vdb",
+        "rejected_reasons": [],
+        "sys_api": {
+          "human_readable_size": "8.00 GB",
+          "locked": 0,
+          "model": "",
+          "nr_requests": 256,
+          "partitions": {},
+          "removable": false,
+          "rev": "",
+          "ro": false,
+          "rotational": true,
+          "sas_address": "",
+          "sas_device_handle": "",
+          "scheduler_mode": "mq-deadline",
+          "sectors": 0,
+          "sectorsize": 512,
+          "size": 8589934592,
+          "support_discard": 512,
+          "vendor": "0x1af4"
+        }
+      },
+      {
+        "available": true,
+        "device_id": "33332520",
+        "human_readable_type": "hdd",
+        "lsm_data": {},
+        "lvs": [],
+        "path": "/dev/vdc",
+        "rejected_reasons": [],
+        "sys_api": {
+          "human_readable_size": "8.00 GB",
+          "locked": 0,
+          "model": "",
+          "nr_requests": 256,
+          "partitions": {},
+          "removable": false,
+          "rev": "",
+          "ro": false,
+          "rotational": true,
+          "sas_address": "",
+          "sas_device_handle": "",
+          "scheduler_mode": "mq-deadline",
+          "sectors": 0,
+          "sectorsize": 512,
+          "size": 8589934592,
+          "support_discard": 512,
+          "vendor": "0x1af4"
+        }
+      },
+      {
+        "available": true,
+        "device_id": "53506254",
+        "human_readable_type": "hdd",
+        "lsm_data": {},
+        "lvs": [],
+        "path": "/dev/vdd",
+        "rejected_reasons": [],
+        "sys_api": {
+          "human_readable_size": "8.00 GB",
+          "locked": 0,
+          "model": "",
+          "nr_requests": 256,
+          "partitions": {},
+          "removable": false,
+          "rev": "",
+          "ro": false,
+          "rotational": true,
+          "sas_address": "",
+          "sas_device_handle": "",
+          "scheduler_mode": "mq-deadline",
+          "sectors": 0,
+          "sectorsize": 512,
+          "size": 8589934592,
+          "support_discard": 512,
+          "vendor": "0x1af4"
+        }
+      },
+      {
+        "available": true,
+        "device_id": "18603158",
+        "human_readable_type": "hdd",
+        "lsm_data": {},
+        "lvs": [],
+        "path": "/dev/vde",
+        "rejected_reasons": [],
+        "sys_api": {
+          "human_readable_size": "8.00 GB",
+          "locked": 0,
+          "model": "",
+          "nr_requests": 256,
+          "partitions": {},
+          "removable": false,
+          "rev": "",
+          "ro": false,
+          "rotational": true,
+          "sas_address": "",
+          "sas_device_handle": "",
+          "scheduler_mode": "mq-deadline",
+          "sectors": 0,
+          "sectorsize": 512,
+          "size": 8589934592,
+          "support_discard": 512,
+          "vendor": "0x1af4"
+        }
+      },
+      {
+        "available": false,
+        "device_id": "",
+        "human_readable_type": "hdd",
+        "lsm_data": {},
+        "lvs": [],
+        "path": "/dev/vda",
+        "rejected_reasons": [
+          "locked",
+          "Has GPT headers"
+        ],
+        "sys_api": {
+          "human_readable_size": "24.00 GB",
+          "locked": 1,
+          "model": "",
+          "nr_requests": 256,
+          "partitions": {
+            "vda2": {
+              "start": "6144",
+              "sectors": "40960",
+              "sectorsize": 512,
+              "size": 20971520,
+              "human_readable_size": "20.00 MB",
+              "holders": []
+            },
+            "vda3": {
+              "start": "47104",
+              "sectors": "50284511",
+              "sectorsize": 512,
+              "size": 25745669632,
+              "human_readable_size": "23.98 GB",
+              "holders": []
+            },
+            "vda1": {
+              "start": "2048",
+              "sectors": "4096",
+              "sectorsize": 512,
+              "size": 2097152,
+              "human_readable_size": "2.00 MB",
+              "holders": []
+            }
+          },
+          "removable": false,
+          "rev": "",
+          "ro": false,
+          "rotational": true,
+          "sas_address": "",
+          "sas_device_handle": "",
+          "scheduler_mode": "mq-deadline",
+          "sectors": 0,
+          "sectorsize": 512,
+          "size": 25769803776,
+          "support_discard": 512,
+          "vendor": "0x1af4"
+        }
+      }
+    ]
+  }

--- a/src/gravel/tests/unit/controllers/nodes/data/disks_local_inventory_with_ssd.json
+++ b/src/gravel/tests/unit/controllers/nodes/data/disks_local_inventory_with_ssd.json
@@ -1,0 +1,222 @@
+{
+    "hostname": "node1",
+    "model": " (Standard PC (i440FX + PIIX, 1996))",
+    "vendor": "QEMU",
+    "kernel": "5.12.4-1-default",
+    "operating_system": "Unknown",
+    "system_uptime": 2085.86,
+    "current_time": 1622300640,
+    "cpu": {
+      "arch": "x86_64",
+      "model": "AMD EPYC-Rome Processor",
+      "cores": 1,
+      "count": 1,
+      "threads": 1,
+      "load": {
+        "one_min": 0.05,
+        "five_min": 0.06,
+        "fifteen_min": 0.01
+      }
+    },
+    "nics": {
+      "eth0": {
+        "driver": "virtio_net",
+        "iftype": "physical",
+        "ipv4_address": "192.168.121.117/24",
+        "ipv6_address": "fe80::5054:ff:fe77:6297/64",
+        "lower_devs_list": [],
+        "mtu": 1500,
+        "nic_type": "ethernet",
+        "operstate": "up",
+        "speed": -1,
+        "upper_devs_list": []
+      },
+      "lo": {
+        "driver": "",
+        "iftype": "logical",
+        "ipv4_address": "127.0.0.1/8",
+        "ipv6_address": "::1/128",
+        "lower_devs_list": [],
+        "mtu": 65536,
+        "nic_type": "loopback",
+        "operstate": "unknown",
+        "speed": -1,
+        "upper_devs_list": []
+      }
+    },
+    "memory": {
+      "available_kb": 3608556,
+      "free_kb": 3508396,
+      "total_kb": 4013728
+    },
+    "disks": [
+      {
+        "available": true,
+        "device_id": "28383427",
+        "human_readable_type": "hdd",
+        "lsm_data": {},
+        "lvs": [],
+        "path": "/dev/vdb",
+        "rejected_reasons": [],
+        "sys_api": {
+          "human_readable_size": "8.00 GB",
+          "locked": 0,
+          "model": "",
+          "nr_requests": 256,
+          "partitions": {},
+          "removable": false,
+          "rev": "",
+          "ro": false,
+          "rotational": true,
+          "sas_address": "",
+          "sas_device_handle": "",
+          "scheduler_mode": "mq-deadline",
+          "sectors": 0,
+          "sectorsize": 512,
+          "size": 8589934592,
+          "support_discard": 512,
+          "vendor": "0x1af4"
+        }
+      },
+      {
+        "available": true,
+        "device_id": "33332520",
+        "human_readable_type": "ssd",
+        "lsm_data": {},
+        "lvs": [],
+        "path": "/dev/vdc",
+        "rejected_reasons": [],
+        "sys_api": {
+          "human_readable_size": "8.00 GB",
+          "locked": 0,
+          "model": "",
+          "nr_requests": 256,
+          "partitions": {},
+          "removable": false,
+          "rev": "",
+          "ro": false,
+          "rotational": false,
+          "sas_address": "",
+          "sas_device_handle": "",
+          "scheduler_mode": "mq-deadline",
+          "sectors": 0,
+          "sectorsize": 512,
+          "size": 8589934592,
+          "support_discard": 512,
+          "vendor": "0x1af4"
+        }
+      },
+      {
+        "available": true,
+        "device_id": "53506254",
+        "human_readable_type": "hdd",
+        "lsm_data": {},
+        "lvs": [],
+        "path": "/dev/vdd",
+        "rejected_reasons": [],
+        "sys_api": {
+          "human_readable_size": "8.00 GB",
+          "locked": 0,
+          "model": "",
+          "nr_requests": 256,
+          "partitions": {},
+          "removable": false,
+          "rev": "",
+          "ro": false,
+          "rotational": true,
+          "sas_address": "",
+          "sas_device_handle": "",
+          "scheduler_mode": "mq-deadline",
+          "sectors": 0,
+          "sectorsize": 512,
+          "size": 8589934592,
+          "support_discard": 512,
+          "vendor": "0x1af4"
+        }
+      },
+      {
+        "available": true,
+        "device_id": "18603158",
+        "human_readable_type": "hdd",
+        "lsm_data": {},
+        "lvs": [],
+        "path": "/dev/vde",
+        "rejected_reasons": [],
+        "sys_api": {
+          "human_readable_size": "8.00 GB",
+          "locked": 0,
+          "model": "",
+          "nr_requests": 256,
+          "partitions": {},
+          "removable": false,
+          "rev": "",
+          "ro": false,
+          "rotational": true,
+          "sas_address": "",
+          "sas_device_handle": "",
+          "scheduler_mode": "mq-deadline",
+          "sectors": 0,
+          "sectorsize": 512,
+          "size": 8589934592,
+          "support_discard": 512,
+          "vendor": "0x1af4"
+        }
+      },
+      {
+        "available": false,
+        "device_id": "",
+        "human_readable_type": "hdd",
+        "lsm_data": {},
+        "lvs": [],
+        "path": "/dev/vda",
+        "rejected_reasons": [
+          "locked",
+          "Has GPT headers"
+        ],
+        "sys_api": {
+          "human_readable_size": "24.00 GB",
+          "locked": 1,
+          "model": "",
+          "nr_requests": 256,
+          "partitions": {
+            "vda2": {
+              "start": "6144",
+              "sectors": "40960",
+              "sectorsize": 512,
+              "size": 20971520,
+              "human_readable_size": "20.00 MB",
+              "holders": []
+            },
+            "vda3": {
+              "start": "47104",
+              "sectors": "50284511",
+              "sectorsize": 512,
+              "size": 25745669632,
+              "human_readable_size": "23.98 GB",
+              "holders": []
+            },
+            "vda1": {
+              "start": "2048",
+              "sectors": "4096",
+              "sectorsize": 512,
+              "size": 2097152,
+              "human_readable_size": "2.00 MB",
+              "holders": []
+            }
+          },
+          "removable": false,
+          "rev": "",
+          "ro": false,
+          "rotational": true,
+          "sas_address": "",
+          "sas_device_handle": "",
+          "scheduler_mode": "mq-deadline",
+          "sectors": 0,
+          "sectorsize": 512,
+          "size": 25769803776,
+          "support_discard": 512,
+          "vendor": "0x1af4"
+        }
+      }
+    ]
+  }

--- a/src/gravel/tests/unit/controllers/nodes/data/disks_single_volume.json
+++ b/src/gravel/tests/unit/controllers/nodes/data/disks_single_volume.json
@@ -1,0 +1,28 @@
+{
+    "available": true,
+    "device_id": "28383427",
+    "human_readable_type": "hdd",
+    "lsm_data": {},
+    "lvs": [],
+    "path": "/dev/vdb",
+    "rejected_reasons": [],
+    "sys_api": {
+      "human_readable_size": "8.00 GB",
+      "locked": 0,
+      "model": "",
+      "nr_requests": 256,
+      "partitions": {},
+      "removable": false,
+      "rev": "",
+      "ro": false,
+      "rotational": true,
+      "sas_address": "",
+      "sas_device_handle": "",
+      "scheduler_mode": "mq-deadline",
+      "sectors": 0,
+      "sectorsize": 512,
+      "size": 8589934592,
+      "support_discard": 512,
+      "vendor": "0x1af4"
+    }
+  }

--- a/src/gravel/tests/unit/controllers/nodes/test_deployment.py
+++ b/src/gravel/tests/unit/controllers/nodes/test_deployment.py
@@ -182,6 +182,7 @@ async def test_deploy(
     )
     from gravel.controllers.nodes.bootstrap import Bootstrap
     from gravel.controllers.orch.orchestrator import Orchestrator
+    from gravel.controllers.nodes.systemdisk import SystemDisk
 
     def mock_true(cls):  # type: ignore
         return True
@@ -211,6 +212,8 @@ async def test_deploy(
         "all_devices_assimilated",
         new=mock_true  # type: ignore
     )
+    mocker.patch.object(SystemDisk, "create")
+    mocker.patch.object(SystemDisk, "enable")
 
     called_postbootstrap = False
     called_finisher = False
@@ -231,7 +234,8 @@ async def test_deploy(
         DeploymentConfig(
             hostname="foobar",
             address="127.0.0.1",
-            token="myfancytoken"
+            token="myfancytoken",
+            systemdisk="/dev/foobar"
         ),
         post_bootstrap_cb=postbootstrap_cb,
         finisher=finisher_cb

--- a/src/gravel/tests/unit/controllers/nodes/test_disks.py
+++ b/src/gravel/tests/unit/controllers/nodes/test_disks.py
@@ -1,0 +1,97 @@
+# project aquarium's backend
+# Copyright (C) 2021 SUSE, LLC.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# pyright: reportPrivateUsage=false, reportUnknownMemberType=false
+# pyright: reportUnknownVariableType=false
+
+import os
+from typing import Callable
+from pytest_mock import MockerFixture
+
+from gravel.controllers.gstate import GlobalState
+
+DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
+
+
+def test_solution(
+    mocker: MockerFixture,
+    get_data_contents: Callable[[str, str], str],
+    gstate: GlobalState
+) -> None:
+
+    from gravel.cephadm.models import NodeInfoModel
+    from gravel.controllers.nodes.disks import Disks
+    from gravel.controllers.nodes.disks import DiskSolution
+
+    # we need to do creative mocking for a property that happens to be an
+    # attribute on a mock object itself.
+    #  https://docs.python.org/3/library/unittest.mock.html#unittest.mock.PropertyMock
+    fake_inventory = mocker.PropertyMock()
+    type(gstate.inventory).latest = fake_inventory  # type: ignore
+    fake_inventory.return_value = NodeInfoModel.parse_raw(
+        get_data_contents(DATA_DIR, "disks_local_inventory.json")
+    )
+
+    solution: DiskSolution = Disks.gen_solution(gstate)
+    assert solution.possible
+    assert solution.systemdisk is not None
+    assert len(solution.rejected) == 1
+    assert len(solution.storage) == 3
+    assert solution.systemdisk.path == "/dev/vdb"
+
+
+def test_device_to_disk(
+    mocker: MockerFixture,
+    get_data_contents: Callable[[str, str], str]
+) -> None:
+
+    from gravel.cephadm.models import VolumeDeviceModel
+    from gravel.controllers.nodes.disks import (
+        _device_to_disk,
+        DiskModel,
+        DiskTypeEnum
+    )
+
+    device: VolumeDeviceModel = VolumeDeviceModel.parse_raw(
+        get_data_contents(DATA_DIR, "disks_single_volume.json")
+    )
+    disk: DiskModel = _device_to_disk(device)
+
+    assert disk.path == "/dev/vdb"
+    assert disk.type == DiskTypeEnum.HDD
+
+
+def test_solution_with_ssd(
+    mocker: MockerFixture,
+    get_data_contents: Callable[[str, str], str],
+    gstate: GlobalState
+) -> None:
+    from gravel.cephadm.models import NodeInfoModel
+    from gravel.controllers.nodes.disks import Disks
+    from gravel.controllers.nodes.disks import DiskSolution
+
+    # we need to do creative mocking for a property that happens to be an
+    # attribute on a mock object itself.
+    #  https://docs.python.org/3/library/unittest.mock.html#unittest.mock.PropertyMock
+    fake_inventory = mocker.PropertyMock()
+    type(gstate.inventory).latest = fake_inventory  # type: ignore
+    fake_inventory.return_value = NodeInfoModel.parse_raw(
+        get_data_contents(DATA_DIR, "disks_local_inventory_with_ssd.json")
+    )
+
+    solution: DiskSolution = Disks.gen_solution(gstate)
+    assert solution.possible
+    assert solution.systemdisk is not None
+    assert len(solution.rejected) == 1
+    assert len(solution.storage) == 3
+    assert solution.systemdisk.path == "/dev/vdc"


### PR DESCRIPTION
## note before:

This PR does not propose itself to address all the needs for a system disk, nor the full impact of having, creating, or maintaining one. Instead, this is the building block on which further work should be performed.

Consider this PR as a draft, open for comments.

Consider tests to be an on-going task.

## what we do

* generate a potential solution for disk usage from the available devices, including a candidate device for system disk.
* create a system disk on initial node deploy.
* mount aquarium-specific directories from the system disk to the running system's root tree, either by overlaying them or bind mounting them.

## what we don't do

* mount the system disk on boot, should it be present.
* do all of the above for a node joining the system.
* present the user with the generated solution, and allow them to have an opinion.


Signed-off-by: Joao Eduardo Luis \<joao@suse.com>