### PR TITLE
gravel: cephadm/bootstrap: parser expects line before EOF

### DIFF
--- a/src/gravel/cephadm/cephadm.py
+++ b/src/gravel/cephadm/cephadm.py
@@ -131,6 +131,7 @@ class Cephadm:
             s = (
                 "[global]",
                 "osd_pool_default_size = 2",
+                ""
             )
             return "\n".join(s)
 


### PR DESCRIPTION
The config parser expects a blank line before EOF, otherwise it will
fail to parse the user-supplied config.

This is required as a prerequisite to merge #513 

Signed-off-by: Joao Eduardo Luis <joao@suse.com>