### PR TITLE
tools/libaqr: check deployment start error

### DIFF
--- a/tools/libaqr/deployment.py
+++ b/tools/libaqr/deployment.py
@@ -147,7 +147,9 @@ class Deployment:
             with vagrant.deployment(self._path) as deployment:
                 if deployment.running or deployment.preparing:
                     raise DeploymentRunningError()
-                deployment.start(conservative=conservative)
+                ret, err = deployment.start(conservative=conservative)
+                if not ret:
+                    raise AqrError('Cannot start deployment: unknown vagrant error')
         except AqrError as e:
             raise e
 


### PR DESCRIPTION
If vagrant up fails when trying to start a deployment status is not
checked. Thif patch address this issue.

Signed-off-by: Kyr Shatskyy <kyrylo.shatskyy@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [issue id or URL on https://github.com/aquarist-labs/aquarium/issues, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The component is the short name of a major module or subsystem, something 
like "tools", "gravel", "glass", "doc", etc.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://github.com/aquarist-labs/aquarium/blob/main/CONTRIBUTING.md

-->

## Checklist
- [ ] References issues, create if required
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test tumbleweed`
- `jenkins run tumbleweed`
- `jenkins test leap`
- `jenkins run leap`

</details>
