### PR TITLE
gravel: handle systemdisk on boot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ dist: submodules glass
 		xargs cp --parents --target-directory=$(TAR_USR) && \
 	cp --target-directory=$(TAR_USR) ./aquarium.py && \
 	cp -R --parents --target-directory=$(TAR_USR) glass/dist && \
+	cp -R --target-directory=$(TAR_USR) boot && \
 	cp --target-directory=$(TAR_SBIN) ./gravel/ceph.git/src/cephadm/cephadm
 	# Copy aquarium service
 	cp systemd/aquarium.service $(TAR_UNIT)

--- a/doc/dev/gravel/systemd-boot.md
+++ b/doc/dev/gravel/systemd-boot.md
@@ -1,0 +1,45 @@
+# Aquarium systemd boot process
+
+## aquarium-boot
+
+`systemd` unit that will be running after `local-fs.target`, runs
+`/usr/share/aquarium/boot/aqrbootsetup.sh`, which tries to find an LVM disk
+tagged with `@aquarium`. If such a disk is found, the disk will be mounted in
+`/aquarium` and several operation critical directories will either be overlayed
+over existing system directories, or bind mounted to specific places.
+
+### Overlayed directories
+
+These are
+
+* `/etc`, so we can keep track of system configuration files that were changed
+  for Aquarium's operations. This includes Ceph's systemd unit files.
+
+* `/var/log`, so logs are persisted between runs.
+
+* `/var/lib/etcd`, where we keep this node's etcd persistent db.
+
+* `/var/lib/containers`, where container images are kept.
+
+### Bind mounted directories
+
+* `/var/lib/ceph`, where we'll keep Ceph's persistent data. This directory
+  cannot be overlayed, because overlaying causes Ceph to misbehave. Reasons
+  unknown.
+  
+### Known issues
+
+Unfortunately we have been unable to ensure we overlay `/etc` at a time before
+`systemd` reads the contents of `/etc/systemd`. Therefore, we are overlaying
+`/etc` contents after systemd already has a list of units to be started. This
+means that the Ceph units are not started automatically during boot, because
+from `systemd`'s point of view they did not exist when it looked for them.
+
+This means the onus of starting the `ceph.target` falls on Aquarium.
+
+
+## aquarium
+
+`systemd` unit that will be running after `network.target`, runs Aquarium from
+`/usr/lib/share/aquarium`.
+

--- a/images/aquarium/config.sh
+++ b/images/aquarium/config.sh
@@ -107,6 +107,7 @@ fi
 
 pip install fastapi uvicorn \
     git+https://github.com/aquarist-labs/aetcd3/@edf633045ce61c7bbac4d4a6ca15b14f8acfe9cd
+baseInsertService aquarium-boot
 baseInsertService sshd
 baseInsertService aquarium
 

--- a/images/aquarium/root/usr/lib/systemd/system/aquarium-boot.service
+++ b/images/aquarium/root/usr/lib/systemd/system/aquarium-boot.service
@@ -1,0 +1,13 @@
+# project aquarium's boot setup
+# Copyright (C) 2021 SUSE, LLC.
+
+[Unit]
+Description=Aquarium Boot Setup Service
+
+After=local-fs.target
+
+[Service]
+ExecStart=/bin/bash /usr/share/aquarium/boot/aqrbootsetup.sh
+
+[Install]
+WantedBy=sysinit.target

--- a/src/boot/aqrbootsetup.sh
+++ b/src/boot/aqrbootsetup.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+#
+# project aquarium's boot setup
+# Copyright (C) 2021 SUSE, LLC.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+
+function overlay() {
+  lower=${1}
+  upper=${2}
+
+  aqrdir=/aquarium/${upper}
+  mount -t overlay \
+    -o lowerdir=${lower},upperdir=${aqrdir}/overlay,workdir=${aqrdir}/temp \
+    overlay ${lower} || return 1
+}
+
+systemdisk=$(lvm lvs --noheadings -o vg_name,lv_name @aquarium |
+             sed 's/^[ ]\+//' | tr ' ' '-')
+
+[[ -z "${systemdisk}" ]] && \
+  echo "Aquarium system disk not found, assuming new deployment" && \
+  exit 0
+
+[[ "${systemdisk}" != "aquarium-systemdisk" ]] && \
+  echo "Unknown system disk, expected aquarium-systemdisk" >/dev/stderr && \
+  exit 1
+
+[[ ! -d "/aquarium" ]] && \
+  (mkdir /aquarium || (echo "error creating /aquarium" && exit 1))
+
+[[ ! -e "/dev/mapper/aquarium-systemdisk" ]] && \
+  echo "Unable to find aquarium block device" && \
+  exit 1
+
+# mount system disk
+mount /dev/mapper/aquarium-systemdisk /aquarium
+
+# overlay
+overlay /etc etc || exit 1
+overlay /var/log logs || exit 1
+overlay /var/lib/etcd etcd || exit 1
+overlay /var/lib/containers containers || exit 1
+
+# bind mount
+mount --bind /aquarium/ceph /var/lib/ceph || exit 1
+
+echo "Aquarium system disk mounted successfully"

--- a/src/gravel/controllers/nodes/etcd.py
+++ b/src/gravel/controllers/nodes/etcd.py
@@ -110,6 +110,7 @@ async def spawn_etcd(
         return [
             'podman', 'run',
             '--rm',
+            '--replace',
             '--net=host',
             '--entrypoint', '/usr/local/bin/etcd',
             '-v', f'{data_dir}:{data_dir}',

--- a/src/gravel/controllers/nodes/mgr.py
+++ b/src/gravel/controllers/nodes/mgr.py
@@ -265,7 +265,7 @@ class NodeMgr:
         self._init_stage = NodeInitStage.AVAILABLE
 
     async def _node_start(self) -> None:
-        """ node is ready to accept incoming messages, if leader """
+        """ node is ready to accept incoming messages """
         assert self._state
         assert self.deployment_state.ready or self.deployment_state.deployed
 
@@ -276,7 +276,7 @@ class NodeMgr:
 
         self._init_stage = NodeInitStage.STARTED
 
-        logger.info("start leader node")
+        logger.info("Start connection manager")
         self._incoming_task = asyncio.create_task(self._incoming_msg_task())
         self._connmgr.start_receiving()
 


### PR DESCRIPTION
This patchset makes the image recognize the system disk on boot, and overlays or bind mounts the right directories inn the right places.

Signed-off-by: Joao Eduardo Luis \<joao@suse.com>