### PR TITLE
glass: Display error notifications only once

### DIFF
--- a/src/glass/src/app/pages/install-wizard/install-create-wizard-page/install-create-wizard-page.component.spec.ts
+++ b/src/glass/src/app/pages/install-wizard/install-create-wizard-page/install-create-wizard-page.component.spec.ts
@@ -1,17 +1,21 @@
 /* eslint-disable max-len */
-import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HTTP_INTERCEPTORS } from '@angular/common/http';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
 import { TranslateModule } from '@ngx-translate/core';
-import { ToastrModule } from 'ngx-toastr';
+import { ToastrModule, ToastrService } from 'ngx-toastr';
 
 import { InstallCreateWizardPageComponent } from '~/app/pages/install-wizard/install-create-wizard-page/install-create-wizard-page.component';
 import { PagesModule } from '~/app/pages/pages.module';
+import { HttpErrorInterceptorService } from '~/app/shared/services/http-error-interceptor.service';
 
 describe('InstallCreateWizardPageComponent', () => {
   let component: InstallCreateWizardPageComponent;
   let fixture: ComponentFixture<InstallCreateWizardPageComponent>;
+  let httpTesting: HttpTestingController;
+  let toastrService: ToastrService;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -22,6 +26,13 @@ describe('InstallCreateWizardPageComponent', () => {
         RouterTestingModule,
         ToastrModule.forRoot(),
         TranslateModule.forRoot()
+      ],
+      providers: [
+        {
+          provide: HTTP_INTERCEPTORS,
+          useClass: HttpErrorInterceptorService,
+          multi: true
+        }
       ]
     }).compileComponents();
   });
@@ -29,10 +40,47 @@ describe('InstallCreateWizardPageComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(InstallCreateWizardPageComponent);
     component = fixture.componentInstance;
+    httpTesting = TestBed.inject(HttpTestingController);
+    toastrService = TestBed.inject(ToastrService);
+    spyOn(toastrService, 'error');
     fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should show notification only once [1]', fakeAsync(() => {
+    httpTesting
+      .expectOne({ url: 'api/nodes/deployment/status', method: 'GET' })
+      .error(new ErrorEvent('Unknown error'), { status: 500 });
+    tick(5);
+    expect(toastrService.error).toHaveBeenCalledTimes(1);
+  }));
+
+  it('should show notification only once [2]', fakeAsync(() => {
+    httpTesting
+      .expectOne({ url: 'api/local/status', method: 'GET' })
+      .error(new ErrorEvent('Unknown error'), { status: 500 });
+    tick(5);
+    expect(toastrService.error).toHaveBeenCalledTimes(1);
+  }));
+
+  it('should show notification only once [3]', fakeAsync(() => {
+    component.startBootstrap();
+    httpTesting
+      .match({ url: 'api/orch/hostname', method: 'PUT' })[0]
+      .error(new ErrorEvent('Unknown error'), { status: 500 });
+    tick(5);
+    expect(toastrService.error).toHaveBeenCalledTimes(1);
+  }));
+
+  it('should show notification only once [4]', fakeAsync(() => {
+    component.finishDeployment();
+    httpTesting
+      .match('api/nodes/deployment/finished')[0]
+      .error(new ErrorEvent('Unknown error'), { status: 500 });
+    tick(5);
+    expect(toastrService.error).toHaveBeenCalledTimes(1);
+  }));
 });

--- a/src/glass/src/app/pages/install-wizard/install-create-wizard-page/install-create-wizard-page.component.ts
+++ b/src/glass/src/app/pages/install-wizard/install-create-wizard-page/install-create-wizard-page.component.ts
@@ -123,6 +123,7 @@ export class InstallCreateWizardPageComponent implements OnInit {
         }
       },
       error: (err) => {
+        err.preventDefault();
         this.stepper!.linear = true;
         this.handleError(err.message);
       }
@@ -143,7 +144,10 @@ export class InstallCreateWizardPageComponent implements OnInit {
         this.blockUI.start(translate(TEXT('Please wait, checking node status ...')));
         this.pollNodeStatus();
       },
-      error: (err) => this.handleError(err.message)
+      error: (err) => {
+        err.preventDefault();
+        this.handleError(err.message);
+      }
     });
   }
 
@@ -160,14 +164,17 @@ export class InstallCreateWizardPageComponent implements OnInit {
           this.handleError(TEXT('Unable to finish deployment.'));
         }
       },
-      (err) => this.handleError(err)
+      (err) => {
+        err.preventDefault();
+        this.handleError(err.message);
+      }
     );
   }
 
-  private handleError(err: any): void {
+  private handleError(message: string): void {
     this.context.stepperVisible = true;
     this.blockUI.stop();
-    this.notificationService.show(err.toString(), {
+    this.notificationService.show(message, {
       type: 'error'
     });
   }
@@ -190,7 +197,10 @@ export class InstallCreateWizardPageComponent implements OnInit {
             this.doBootstrap();
           }
         },
-        (err) => this.handleError(err.message)
+        (err) => {
+          err.preventDefault();
+          this.handleError(err.message);
+        }
       );
   }
 
@@ -204,14 +214,13 @@ export class InstallCreateWizardPageComponent implements OnInit {
           this.blockUI.update(translate(TEXT('Please wait, bootstrapping in progress ...')));
           this.pollBootstrapStatus();
         } else {
-          this.context.stepperVisible = true;
-          this.blockUI.stop();
-          this.notificationService.show(TEXT('Failed to start bootstrapping the system.'), {
-            type: 'error'
-          });
+          this.handleError(TEXT('Failed to start bootstrapping the system.'));
         }
       },
-      error: (err) => this.handleError(err)
+      error: (err) => {
+        err.preventDefault();
+        this.handleError(err.message);
+      }
     });
   }
 
@@ -251,7 +260,10 @@ export class InstallCreateWizardPageComponent implements OnInit {
               break;
           }
         },
-        () => this.handleError(TEXT('Failed to bootstrap the system.'))
+        (err) => {
+          err.preventDefault();
+          this.handleError(TEXT('Failed to bootstrap the system.'));
+        }
       );
   }
 }

--- a/src/glass/src/app/shared/components/declarative-form/declarative-form.component.html
+++ b/src/glass/src/app/shared/components/declarative-form/declarative-form.component.html
@@ -5,7 +5,7 @@
     <div [innerHTML]="config?.hint! | translate"></div>
   </glass-alert-panel>
   <p *ngIf="config?.subtitle"
-       [innerHTML]="config?.subtitle! | translate">
+     [innerHTML]="config?.subtitle! | translate">
   </p>
   <form *ngIf="formGroup && config"
         [formGroup]="formGroup"


### PR DESCRIPTION
In the install wizard error notifications are displayed twice, the first notification is shown automatically by the HTTP error interceptor and the second one by the install wizard. To prevent the duplicate notification 'preventDefault' must be called.

Additionally a HTML linter error has been fixed.

Signed-off-by: Volker Theile <vtheile@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [issue id or URL on https://github.com/aquarist-labs/aquarium/issues, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The component is the short name of a major module or subsystem, something 
like "tools", "gravel", "glass", "doc", etc.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://github.com/aquarist-labs/aquarium/blob/main/CONTRIBUTING.md

-->

## Checklist
- [ ] References issues, create if required
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test tumbleweed`
- `jenkins run tumbleweed`
- `jenkins test leap`
- `jenkins run leap`

</details>
