### PR TITLE
tools/setup-dev: use nodejs 16.x instead of 15.x

### DIFF
--- a/tools/setup-dev.sh
+++ b/tools/setup-dev.sh
@@ -197,8 +197,8 @@ if ! ${skip_install_deps} ; then
       fi
       ;;
     debian)
-      echo "=> installing nodejs15.x repo to apt source"
-      wget -qO - https://deb.nodesource.com/setup_15.x | sudo bash -
+      echo "=> installing nodejs16.x repo to apt source"
+      wget -qO - https://deb.nodesource.com/setup_16.x | sudo bash -
       echo "=> installing kiwi repo public key"
       sudo wget -qO - https://download.opensuse.org/repositories/Virtualization:/Appliances:/Builder/Debian_10/Release.key | sudo apt-key add -
       echo "=> installing kiwi repo to apt source"
@@ -217,8 +217,8 @@ if ! ${skip_install_deps} ; then
       fi
       ;;
     ubuntu)
-      echo "=> installing nodejs15.x repo to apt source"
-      wget -qO - https://deb.nodesource.com/setup_15.x | sudo bash -
+      echo "=> installing nodejs16.x repo to apt source"
+      wget -qO - https://deb.nodesource.com/setup_16.x | sudo bash -
       echo "=> installing kiwi repo public key"
       sudo wget -qO - https://download.opensuse.org/repositories/Virtualization:/Appliances:/Builder/xUbuntu_20.10/Release.key | sudo apt-key add -
       echo "=> installing kiwi repo to apt source"


### PR DESCRIPTION
The nodejs 15.x is deprecated and not actively supported anymore.
It is kindly adviced to switch to any of 12.x, 14.x or 16.x

Signed-off-by: Kyr Shatskyy <kyrylo.shatskyy@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [issue id or URL on https://github.com/aquarist-labs/aquarium/issues, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The component is the short name of a major module or subsystem, something 
like "tools", "gravel", "glass", "doc", etc.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://github.com/aquarist-labs/aquarium/blob/main/CONTRIBUTING.md

-->

## Checklist
- [ ] References issues, create if required
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test tumbleweed`
- `jenkins run tumbleweed`
- `jenkins test leap`
- `jenkins run leap`

</details>
