### PR TITLE
images/aquarium: add password to vagrant user

### DIFF
--- a/images/aquarium/config.sh
+++ b/images/aquarium/config.sh
@@ -77,9 +77,6 @@ fi
 if [[ "$kiwi_profiles" == *"Vagrant"* ]]; then
 	# insert the default insecure ssh key from here:
 	# https://github.com/hashicorp/vagrant/blob/master/keys/vagrant.pub
-	useradd vagrant
-	groupadd vagrant
-	usermod -a -G vagrant vagrant
 	mkdir -p /home/vagrant/.ssh/
 	echo "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkTkyrtvp9eWW6A8YVr+kz4TjGYe7gHzIw+niNltGEFHzD8+v1I2YJ6oXevct1YeS0o9HZyN1Q9qgCgzUFtdOKLv6IedplqoPkcmF0aYet2PkEDo3MlTBckFXPITAMzF8dJSIFo9D8HfdOV0IAdx4O7PtixWKn5y2hMNG0zQPyUecp4pzC6kivAIhyfHilFR61RGL+GPXQ2MWZWFYbAGjyiYJnAmCP3NOTd0jMZEnDkbUvxhMmBYSdETk1rRgm+R4LOzFUGaHqHDLKLX+FIPKcF96hrucXzcWyLbIbEgE98OHlnVYCzRdK8jlqm8tehUc9c9WhQ== vagrant insecure public key" > /home/vagrant/.ssh/authorized_keys
 	chmod 0600 /home/vagrant/.ssh/authorized_keys

--- a/images/aquarium/config.xml
+++ b/images/aquarium/config.xml
@@ -120,6 +120,13 @@
     <users>
          <user password="aquarium" home="/home/aquarium" name="aquarium" groups="aquarium"  pwdformat="plain"/>
     </users>
+    <users profiles="Vagrant">
+        <user password="vagrant"
+              home="/home/vagrant"
+              name="vagrant"
+              groups="vagrant"
+              pwdformat="plain"/>
+    </users>
 
     <repository type="rpm-md" alias="kiwi" priority="1">
         <source path="obs://Virtualization:Appliances:Builder/openSUSE_Tumbleweed"/>


### PR DESCRIPTION
As of today, for some reason, the vagrant image ceased to work due to
the 'vagrant' user being passwordless. To address this, let's create the
user in the config.xml kiwi file, with a default password of 'vagrant',
but only for images being built for Vagrant.

Signed-off-by: Joao Eduardo Luis \<joao@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [issue id or URL on https://github.com/aquarist-labs/aquarium/issues, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The component is the short name of a major module or subsystem, something 
like "tools", "gravel", "glass", "doc", etc.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://github.com/aquarist-labs/aquarium/blob/main/CONTRIBUTING.md

-->

## Checklist
- [ ] References issues, create if required
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test tumbleweed`
- `jenkins run tumbleweed`
- `jenkins test leap`
- `jenkins run leap`

</details>
