### PR TITLE
gravel: pass hostname as parameters to deploy & join (part 1)

### DIFF
--- a/src/glass/src/app/pages/install-wizard/install-create-wizard-page/install-create-wizard-page.component.spec.ts
+++ b/src/glass/src/app/pages/install-wizard/install-create-wizard-page/install-create-wizard-page.component.spec.ts
@@ -67,15 +67,6 @@ describe('InstallCreateWizardPageComponent', () => {
   }));
 
   it('should show notification only once [3]', fakeAsync(() => {
-    component.startBootstrap();
-    httpTesting
-      .match({ url: 'api/nodes/hostname', method: 'PUT' })[0]
-      .error(new ErrorEvent('Unknown error'), { status: 500 });
-    tick(5);
-    expect(toastrService.error).toHaveBeenCalledTimes(1);
-  }));
-
-  it('should show notification only once [4]', fakeAsync(() => {
     component.finishDeployment();
     httpTesting
       .match('api/nodes/deployment/finished')[0]

--- a/src/glass/src/app/pages/install-wizard/install-create-wizard-page/install-create-wizard-page.component.ts
+++ b/src/glass/src/app/pages/install-wizard/install-create-wizard-page/install-create-wizard-page.component.ts
@@ -148,16 +148,8 @@ export class InstallCreateWizardPageComponent implements OnInit {
    * This step starts the bootstrap process
    */
   startBootstrap(): void {
-    this.nodesService.setHostname(this.context.config.hostname).subscribe({
-      complete: () => {
-        this.blockUI.start(translate(TEXT('Please wait, checking node status ...')));
-        this.pollNodeStatus();
-      },
-      error: (err) => {
-        err.preventDefault();
-        this.handleError(err.message);
-      }
-    });
+    this.blockUI.start(translate(TEXT('Please wait, checking node status ...')));
+    this.pollNodeStatus();
   }
 
   finishDeployment(): void {
@@ -216,21 +208,26 @@ export class InstallCreateWizardPageComponent implements OnInit {
   private doBootstrap(): void {
     this.context.stepperVisible = false;
     this.blockUI.start(translate(TEXT('Please wait, bootstrapping will be started ...')));
-    this.nodesService.deploymentStart({ ntpaddr: this.context.config.ntpAddress }).subscribe({
-      next: (basicReplay: DeploymentBasicReply) => {
-        if (basicReplay.success) {
-          this.context.stage = 'bootstrapping';
-          this.blockUI.update(translate(TEXT('Please wait, bootstrapping in progress ...')));
-          this.pollBootstrapStatus();
-        } else {
-          this.handleError(TEXT('Failed to start bootstrapping the system.'));
+    this.nodesService
+      .deploymentStart({
+        ntpaddr: this.context.config.ntpAddress,
+        hostname: this.context.config.hostname
+      })
+      .subscribe({
+        next: (basicReplay: DeploymentBasicReply) => {
+          if (basicReplay.success) {
+            this.context.stage = 'bootstrapping';
+            this.blockUI.update(translate(TEXT('Please wait, bootstrapping in progress ...')));
+            this.pollBootstrapStatus();
+          } else {
+            this.handleError(TEXT('Failed to start bootstrapping the system.'));
+          }
+        },
+        error: (err) => {
+          err.preventDefault();
+          this.handleError(err.message);
         }
-      },
-      error: (err) => {
-        err.preventDefault();
-        this.handleError(err.message);
-      }
-    });
+      });
   }
 
   private pollBootstrapStatus(): void {

--- a/src/glass/src/app/pages/install-wizard/install-join-wizard-page/install-join-wizard-page.component.ts
+++ b/src/glass/src/app/pages/install-wizard/install-join-wizard-page/install-join-wizard-page.component.ts
@@ -17,7 +17,6 @@ import { MatStepper } from '@angular/material/stepper';
 import { marker as TEXT } from '@biesbjerg/ngx-translate-extract-marker';
 import _ from 'lodash';
 import { BlockUI, NgBlockUI } from 'ng-block-ui';
-import { concat } from 'rxjs';
 
 import { translate } from '~/app/i18n.helper';
 import { InstallWizardContext } from '~/app/pages/install-wizard/models/install-wizard-context.type';
@@ -120,25 +119,25 @@ export class InstallJoinWizardPageComponent implements OnInit {
     this.context.stage = 'joining';
     this.context.stepperVisible = false;
     this.blockUI.start(translate(TEXT('Please wait, start joining existing cluster ...')));
-    concat(
-      this.nodesService.setHostname(this.context.config.hostname),
-      this.nodesService.join({
+    this.nodesService
+      .join({
         address: `${this.context.config.address}:${this.context.config.port}`,
-        token: this.context.config.token
+        token: this.context.config.token,
+        hostname: this.context.config.hostname
       })
-    ).subscribe({
-      next: (success: boolean) => {
-        if (success) {
-          this.blockUI.update(
-            translate(TEXT('Please wait, joining existing cluster in progress ...'))
-          );
-          this.pollJoiningStatus();
-        } else {
-          this.handleError(TEXT('Failed to join existing cluster.'));
-        }
-      },
-      error: (err) => this.handleError(err.message)
-    });
+      .subscribe({
+        next: (success: boolean) => {
+          if (success) {
+            this.blockUI.update(
+              translate(TEXT('Please wait, joining existing cluster in progress ...'))
+            );
+            this.pollJoiningStatus();
+          } else {
+            this.handleError(TEXT('Failed to join existing cluster.'));
+          }
+        },
+        error: (err) => this.handleError(err.message)
+      });
   }
 
   private handleError(err: any): void {

--- a/src/glass/src/app/shared/services/api/nodes.service.spec.ts
+++ b/src/glass/src/app/shared/services/api/nodes.service.spec.ts
@@ -32,7 +32,12 @@ describe('NodesService', () => {
   });
 
   it('should call deployment start', () => {
-    service.deploymentStart({ ntpaddr: 'test.test.test' }).subscribe();
+    service
+      .deploymentStart({
+        ntpaddr: 'test.test.test',
+        hostname: 'foobar'
+      })
+      .subscribe();
     const req = httpTesting.expectOne('api/nodes/deployment/start');
     expect(req.request.method).toBe('POST');
   });

--- a/src/glass/src/app/shared/services/api/nodes.service.spec.ts
+++ b/src/glass/src/app/shared/services/api/nodes.service.spec.ts
@@ -20,7 +20,13 @@ describe('NodesService', () => {
   });
 
   it('should call start', () => {
-    service.join({ address: 'foo', token: 'ABCD-0123-5A6B-98FE' }).subscribe();
+    service
+      .join({
+        address: 'foo',
+        token: 'ABCD-0123-5A6B-98FE',
+        hostname: 'foobar'
+      })
+      .subscribe();
     const req = httpTesting.expectOne('api/nodes/join');
     expect(req.request.method).toBe('POST');
   });

--- a/src/glass/src/app/shared/services/api/nodes.service.ts
+++ b/src/glass/src/app/shared/services/api/nodes.service.ts
@@ -122,12 +122,4 @@ export class NodesService {
   deploymentDiskSolution(): Observable<DiskSolution> {
     return this.http.get<DiskSolution>(`${this.deploymentURL}/disksolution`);
   }
-
-  /**
-   * Setup hostname
-   */
-  setHostname(name: string): Observable<boolean> {
-    const request: SetHostnameRequest = { name };
-    return this.http.put<boolean>(`${this.url}/hostname`, request);
-  }
 }

--- a/src/glass/src/app/shared/services/api/nodes.service.ts
+++ b/src/glass/src/app/shared/services/api/nodes.service.ts
@@ -10,6 +10,7 @@ export type DeploymentStartRequest = {
 export type JoinNodeRequest = {
   address: string;
   token: string;
+  hostname: string;
 };
 
 export type TokenReply = {

--- a/src/glass/src/app/shared/services/api/nodes.service.ts
+++ b/src/glass/src/app/shared/services/api/nodes.service.ts
@@ -4,6 +4,7 @@ import { Observable } from 'rxjs';
 
 export type DeploymentStartRequest = {
   ntpaddr: string;
+  hostname: string;
 };
 
 export type JoinNodeRequest = {

--- a/src/gravel/api/nodes.py
+++ b/src/gravel/api/nodes.py
@@ -146,7 +146,7 @@ async def node_deploy(request: Request, req_params: StartDeploymentRequest) \
     if success:
         logger.debug("api > start deployment")
 
-    return DeployStartReplyModel(success=True, error=error)
+    return DeployStartReplyModel(success=success, error=error)
 
 
 @router.get("/deployment/status", response_model=DeployStatusReplyModel)

--- a/src/gravel/api/nodes.py
+++ b/src/gravel/api/nodes.py
@@ -229,20 +229,6 @@ async def nodes_get_token(request: Request):
     )
 
 
-@router.put("/hostname", response_model=bool)
-async def put_hostname(request: Request, req: SetHostnameRequest) -> bool:
-    nodemgr: NodeMgr = request.app.state.nodemgr
-    if nodemgr.deployment_state.deployed or nodemgr.deployment_state.ready:
-        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                            detail="Node already deployed")
-    try:
-        await nodemgr.set_hostname(req.name)
-    except Exception as e:
-        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                            detail=str(e))
-    return True
-
-
 router.add_websocket_route(  # pyright: reportUnknownMemberType=false
     "/nodes/ws",
     IncomingConnection

--- a/src/gravel/api/nodes.py
+++ b/src/gravel/api/nodes.py
@@ -37,6 +37,7 @@ from gravel.controllers.nodes.errors import (
 )
 from gravel.controllers.nodes.mgr import (
     DeployParamsModel,
+    JoinParamsModel,
     NodeMgr
 )
 
@@ -74,6 +75,7 @@ class DeployStatusReplyModel(BaseModel):
 class NodeJoinRequestModel(BaseModel):
     address: str
     token: str
+    hostname: str
 
 
 class TokenReplyModel(BaseModel):
@@ -210,7 +212,12 @@ async def node_join(req: NodeJoinRequestModel, request: Request):
             detail="leader address and token are required"
         )
 
-    return await request.app.state.nodemgr.join(req.address, req.token)
+    nodemgr = request.app.state.nodemgr
+    return await nodemgr.join(
+        req.address,
+        req.token,
+        JoinParamsModel(hostname=req.hostname)
+    )
 
 
 @router.get("/token", response_model=TokenReplyModel)

--- a/src/gravel/api/nodes.py
+++ b/src/gravel/api/nodes.py
@@ -35,7 +35,10 @@ from gravel.controllers.nodes.errors import (
     NodeNotDeployedError,
     NodeNotStartedError
 )
-from gravel.controllers.nodes.mgr import NodeMgr
+from gravel.controllers.nodes.mgr import (
+    DeployParamsModel,
+    NodeMgr
+)
 
 
 logger: Logger = fastapi_logger
@@ -77,10 +80,6 @@ class TokenReplyModel(BaseModel):
     token: str
 
 
-class StartDeploymentRequest(BaseModel):
-    ntpaddr: str = Field(title="NTP server address")
-
-
 class SetHostnameRequest(BaseModel):
     name: str = Field(min_length=1, title="The system hostname")
 
@@ -103,8 +102,10 @@ async def node_get_disk_solution(request: Request) -> DiskSolution:
 
 
 @router.post("/deployment/start", response_model=DeployStartReplyModel)
-async def node_deploy(request: Request, req_params: StartDeploymentRequest) \
-        -> DeployStartReplyModel:
+async def node_deploy(
+    request: Request,
+    req_params: DeployParamsModel
+) -> DeployStartReplyModel:
     """
     Start deploying this node. The host will be configured according to user
     specification; a minimal Ceph cluster will be bootstrapped; and a token for
@@ -119,7 +120,7 @@ async def node_deploy(request: Request, req_params: StartDeploymentRequest) \
     error = DeployErrorModel()
 
     try:
-        await request.app.state.nodemgr.deploy(req_params.ntpaddr)
+        await request.app.state.nodemgr.deploy(req_params)
     except NodeCantDeployError as e:
         logger.error(f"api > can't deploy: {e.message}")
         success = False

--- a/src/gravel/controllers/nodes/mgr.py
+++ b/src/gravel/controllers/nodes/mgr.py
@@ -535,12 +535,6 @@ class NodeMgr:
         except Exception as e:
             raise NodeError(str(e))
 
-    def _get_hostname(self) -> str:
-        return ""
-
-    def _get_address(self) -> str:
-        return ""
-
     async def _incoming_msg_task(self) -> None:
         logger.info("start handling incoming messages")
         while not self._shutting_down:

--- a/src/gravel/controllers/nodes/mgr.py
+++ b/src/gravel/controllers/nodes/mgr.py
@@ -35,7 +35,6 @@ from gravel.controllers.nodes.deployment import (
     DeploymentState,
     NodeDeployment
 )
-from gravel.controllers.nodes.host import HostnameCtlError, set_hostname
 from gravel.controllers.orch.ceph import (
     CephCommandError,
     Mon
@@ -319,19 +318,6 @@ class NodeMgr:
 
         tokenstr = '-'.join(gen() for _ in range(4))
         return tokenstr
-
-    async def set_hostname(self, name: str) -> None:
-        logger.info(f"set hostname '{name}'")
-        try:
-            set_hostname(name)
-        except HostnameCtlError as e:
-            logger.error(f"set hostname: {e.message}")
-            raise e
-        except Exception as e:
-            logger.error(f"set hostname: {str(e)}")
-            raise NodeError(f"setting hostname: {str(e)}")
-        self._state.hostname = name
-        await self._save_state()
 
     async def join(
         self,


### PR DESCRIPTION
We are now passing the user-specified hostname as parameters to the deploy and join endpoints, so we can set the hostname as part of a node's deployment process.

We are also removing the endpoint that allows to set the hostname because we suspect changing a hostname after a node has been deployed will not be a trivial task, and we currently have no other use for this endpoint.

~Depends on #581~

Signed-off-by: Joao Eduardo Luis \<joao@suse.com>