### PR TITLE
gravel: support system disk on joining node, assimilate devices individually (part 2)

### DIFF
--- a/images/aquarium/config.xml
+++ b/images/aquarium/config.xml
@@ -165,6 +165,7 @@
         <package name="python38-pip"/>
         <package name="python38-aiofiles"/>
         <package name="python38-requests"/>
+        <package name="python38-PyYAML"/>
         <package name="python3-rados"/>
         <package name="etcdctl"/>
         <archive name="aquarium.tar.gz"/>

--- a/src/boot/aqrbootsetup.sh
+++ b/src/boot/aqrbootsetup.sh
@@ -50,6 +50,7 @@ overlay /etc etc || exit 1
 overlay /var/log logs || exit 1
 overlay /var/lib/etcd etcd || exit 1
 overlay /var/lib/containers containers || exit 1
+overlay /root roothome || exit 1
 
 # bind mount
 mount --bind /aquarium/ceph /var/lib/ceph || exit 1

--- a/src/gravel/api/orch.py
+++ b/src/gravel/api/orch.py
@@ -95,29 +95,6 @@ def get_devices(request: Request) -> Dict[str, HostsDevicesModel]:
     return host_devs
 
 
-@router.post("/devices/assimilate", response_model=bool)
-async def assimilate_devices(request: Request) -> bool:
-
-    try:
-        orch = Orchestrator(request.app.state.gstate.ceph_mgr)
-        orch.assimilate_all_devices()
-    except Exception as e:
-        logger.error(str(e))
-        return False
-
-    return True
-
-
-@router.get("/devices/all_assimilated", response_model=bool)
-async def all_devices_assimilated(request: Request) -> bool:
-    try:
-        orch = Orchestrator(request.app.state.gstate.ceph_mgr)
-        return orch.all_devices_assimilated()
-    except Exception as e:
-        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                            detail=str(e))
-
-
 @router.get("/pubkey")
 async def get_pubkey(request: Request) -> str:
     try:

--- a/src/gravel/api/services.py
+++ b/src/gravel/api/services.py
@@ -134,7 +134,10 @@ async def create_service(
         raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR,
                             detail=str(e))
     except NotReadyError:
-        raise HTTPException(status.HTTP_425_TOO_EARLY)
+        raise HTTPException(
+            status_code=status.HTTP_428_PRECONDITION_REQUIRED,
+            detail="node not ready yet"
+        )
     return CreateResponse(success=True)
 
 
@@ -153,7 +156,10 @@ async def get_statistics(request: Request) -> Dict[str, ServiceStorageModel]:
     try:
         return services.get_stats()
     except NotReadyError:
-        raise HTTPException(status.HTTP_425_TOO_EARLY)
+        raise HTTPException(
+            status_code=status.HTTP_428_PRECONDITION_REQUIRED,
+            detail="node not ready yet"
+        )
 
 
 @router.get(

--- a/src/gravel/controllers/nodes/deployment.py
+++ b/src/gravel/controllers/nodes/deployment.py
@@ -59,6 +59,7 @@ from gravel.controllers.nodes.messages import (
 from gravel.controllers.nodes.ntp import set_ntp_addr
 from gravel.controllers.nodes.etcd import spawn_etcd
 from gravel.controllers.nodes.systemdisk import SystemDisk
+from gravel.controllers.orch.models import OrchHostListModel
 from gravel.controllers.orch.orchestrator import Orchestrator
 
 
@@ -386,6 +387,25 @@ class NodeDeployment:
             )
         )
         await conn.close()
+
+        def host_added():
+            orch = Orchestrator(self._gstate.ceph_mgr)
+            logger.debug("join > obtain existing hosts")
+            hosts: List[OrchHostListModel] = orch.host_ls()
+            logger.debug(f"join > current hosts: {hosts}")
+            for h in hosts:
+                if h.hostname == hostname:
+                    return True
+            return False
+
+        while not host_added():
+            logger.debug("join > wait for host to be added")
+            await asyncio.sleep(1.0)
+
+        try:
+            await self._assimilate_devices(hostname, disks.storage)
+        except DeploymentError as e:
+            raise NodeCantJoinError(e.message)
 
         self._state.mark_ready()
         return True

--- a/src/gravel/controllers/nodes/mgr.py
+++ b/src/gravel/controllers/nodes/mgr.py
@@ -32,6 +32,7 @@ from gravel.cephadm.models import NodeInfoModel
 from gravel.controllers.gstate import GlobalState
 from gravel.controllers.nodes.deployment import (
     DeploymentConfig,
+    DeploymentDisksConfig,
     DeploymentState,
     NodeDeployment
 )
@@ -383,7 +384,12 @@ class NodeMgr:
         if not disk_solution.possible:
             raise NodeCantDeployError("no possible deployment solution found")
         assert disk_solution.systemdisk is not None
-        logger.debug(f"mgr > deploy > disk solution: {disk_solution}")
+
+        disks = DeploymentDisksConfig(system=disk_solution.systemdisk.path)
+        disks.storage = [
+            d.path for d in disk_solution.storage if d.path is not None
+        ]
+        logger.debug(f"mgr > deploy > disks: {disks}")
 
         # check parameters
         if not params.ntpaddr or len(params.ntpaddr) == 0:
@@ -401,8 +407,8 @@ class NodeMgr:
                 hostname=params.hostname,
                 address=self._state.address,
                 token=self._token,
-                systemdisk=disk_solution.systemdisk.path,
-                ntp_addr=params.ntpaddr
+                ntp_addr=params.ntpaddr,
+                disks=disks
             ),
             self._post_bootstrap_finisher,
             self._finish_deployment

--- a/src/gravel/controllers/nodes/systemdisk.py
+++ b/src/gravel/controllers/nodes/systemdisk.py
@@ -84,7 +84,8 @@ class SystemDisk:
         "etc": "/etc",
         "logs": "/var/log",
         "etcd": "/var/lib/etcd",
-        "containers": "/var/lib/containers"
+        "containers": "/var/lib/containers",
+        "roothome": "/root"
     }
     _bindmounts: Dict[str, str] = {
         "ceph": "/var/lib/ceph"

--- a/src/gravel/controllers/orch/ceph.py
+++ b/src/gravel/controllers/orch/ceph.py
@@ -150,13 +150,14 @@ class Ceph:
             raise CephError(str(e))
 
     def _cmd(self, func: Callable[[str, bytes], Any],
-             cmd: Dict[str, Any]
+             cmd: Dict[str, Any],
+             inbuf: bytes = b""
              ) -> Any:
         self.assert_is_ready()
         cmdstr: str = json.dumps(cmd)
 
         try:
-            rc, out, outstr = func(cmdstr, b"")
+            rc, out, outstr = func(cmdstr, inbuf)
         except Exception as e:
             raise CephCommandError(str(e))
 
@@ -178,9 +179,9 @@ class Ceph:
         self.connect()
         return self._cmd(self.cluster.mon_command, cmd)
 
-    def mgr(self, cmd: Dict[str, Any]) -> Any:
+    def mgr(self, cmd: Dict[str, Any], inbuf: bytes = b"") -> Any:
         self.connect()
-        return self._cmd(self.cluster.mgr_command, cmd)
+        return self._cmd(self.cluster.mgr_command, cmd, inbuf)
 
 
 class Mgr:
@@ -189,8 +190,8 @@ class Mgr:
     def __init__(self, ceph: Ceph):
         self.ceph = ceph
 
-    def call(self, cmd: Dict[str, Any]) -> Any:
-        return self.ceph.mgr(cmd)
+    def call(self, cmd: Dict[str, Any], inbuf: bytes = b"") -> Any:
+        return self.ceph.mgr(cmd, inbuf=inbuf)
 
 
 class Mon:

--- a/src/gravel/tests/unit/controllers/orch/data/device_ls_not_available.json
+++ b/src/gravel/tests/unit/controllers/orch/data/device_ls_not_available.json
@@ -1,0 +1,180 @@
+
+[
+  {
+    "addr": "asd",
+    "devices": [
+      {
+        "available": false,
+        "device_id": "63192323",
+        "human_readable_type": "hdd",
+        "lsm_data": {},
+        "lvs": [
+          {
+            "comment": "not used by ceph",
+            "name": "systemdisk"
+          }
+        ],
+        "path": "/dev/vdb",
+        "rejected_reasons": [
+          "Insufficient space (<10 extents) on vgs",
+          "LVM detected",
+          "locked"
+        ],
+        "sys_api": {
+          "human_readable_size": "8.00 GB",
+          "locked": 1,
+          "model": "",
+          "nr_requests": "256",
+          "partitions": {},
+          "path": "/dev/vdb",
+          "removable": "0",
+          "rev": "",
+          "ro": "0",
+          "rotational": "1",
+          "sas_address": "",
+          "sas_device_handle": "",
+          "scheduler_mode": "mq-deadline",
+          "sectors": 0,
+          "sectorsize": "512",
+          "size": 8589934592.0,
+          "support_discard": "512",
+          "vendor": "0x1af4"
+        }
+      },
+      {
+        "available": false,
+        "device_id": "95775920",
+        "human_readable_type": "hdd",
+        "lsm_data": {},
+        "lvs": [
+          {
+            "block_uuid": "qWmaa0-Ydh2-EV43-eK6P-3av1-7vOA-PUxtNV",
+            "cluster_fsid": "ede3c202-d191-11eb-9c72-525400efb582",
+            "cluster_name": "ceph",
+            "name": "osd-block-e4858c14-033a-4cea-8fae-4f6edd919df3",
+            "osd_fsid": "e4858c14-033a-4cea-8fae-4f6edd919df3",
+            "osd_id": "0",
+            "osdspec_affinity": "None",
+            "type": "block"
+          }
+        ],
+        "path": "/dev/vdc",
+        "rejected_reasons": [
+          "Insufficient space (<10 extents) on vgs",
+          "LVM detected",
+          "locked"
+        ],
+        "sys_api": {
+          "human_readable_size": "8.00 GB",
+          "locked": 1,
+          "model": "",
+          "nr_requests": "256",
+          "partitions": {},
+          "path": "/dev/vdc",
+          "removable": "0",
+          "rev": "",
+          "ro": "0",
+          "rotational": "1",
+          "sas_address": "",
+          "sas_device_handle": "",
+          "scheduler_mode": "mq-deadline",
+          "sectors": 0,
+          "sectorsize": "512",
+          "size": 8589934592.0,
+          "support_discard": "512",
+          "vendor": "0x1af4"
+        }
+      },
+      {
+        "available": false,
+        "device_id": "22507780",
+        "human_readable_type": "hdd",
+        "lsm_data": {},
+        "lvs": [
+          {
+            "block_uuid": "ZFlBpo-fPR2-brT4-HepS-S4rl-tK3Y-1h36wU",
+            "cluster_fsid": "ede3c202-d191-11eb-9c72-525400efb582",
+            "cluster_name": "ceph",
+            "name": "osd-block-401a61fa-85ce-4425-ba64-a334de80048e",
+            "osd_fsid": "401a61fa-85ce-4425-ba64-a334de80048e",
+            "osd_id": "1",
+            "osdspec_affinity": "None",
+            "type": "block"
+          }
+        ],
+        "path": "/dev/vdd",
+        "rejected_reasons": [
+          "Insufficient space (<10 extents) on vgs",
+          "LVM detected",
+          "locked"
+        ],
+        "sys_api": {
+          "human_readable_size": "8.00 GB",
+          "locked": 1,
+          "model": "",
+          "nr_requests": "256",
+          "partitions": {},
+          "path": "/dev/vdd",
+          "removable": "0",
+          "rev": "",
+          "ro": "0",
+          "rotational": "1",
+          "sas_address": "",
+          "sas_device_handle": "",
+          "scheduler_mode": "mq-deadline",
+          "sectors": 0,
+          "sectorsize": "512",
+          "size": 8589934592.0,
+          "support_discard": "512",
+          "vendor": "0x1af4"
+        }
+      },
+      {
+        "available": false,
+        "device_id": "15926218",
+        "human_readable_type": "hdd",
+        "lsm_data": {},
+        "lvs": [
+          {
+            "block_uuid": "01OkBn-Sidv-2GI5-2joX-fRcj-ECcP-cSj027",
+            "cluster_fsid": "ede3c202-d191-11eb-9c72-525400efb582",
+            "cluster_name": "ceph",
+            "name": "osd-block-66a1ebf3-3d44-490a-b466-23e365665cb0",
+            "osd_fsid": "66a1ebf3-3d44-490a-b466-23e365665cb0",
+            "osd_id": "2",
+            "osdspec_affinity": "None",
+            "type": "block"
+          }
+        ],
+        "path": "/dev/vde",
+        "rejected_reasons": [
+          "Insufficient space (<10 extents) on vgs",
+          "LVM detected",
+          "locked"
+        ],
+        "sys_api": {
+          "human_readable_size": "8.00 GB",
+          "locked": 1,
+          "model": "",
+          "nr_requests": "256",
+          "partitions": {},
+          "path": "/dev/vde",
+          "removable": "0",
+          "rev": "",
+          "ro": "0",
+          "rotational": "1",
+          "sas_address": "",
+          "sas_device_handle": "",
+          "scheduler_mode": "mq-deadline",
+          "sectors": 0,
+          "sectorsize": "512",
+          "size": 8589934592.0,
+          "support_discard": "512",
+          "vendor": "0x1af4"
+        }
+      }
+    ],
+    "labels": [],
+    "name": "asd"
+  }
+]

--- a/src/gravel/tests/unit/controllers/orch/test_orchestrator.py
+++ b/src/gravel/tests/unit/controllers/orch/test_orchestrator.py
@@ -1,0 +1,74 @@
+# project aquarium's backend
+# Copyright (C) 2021 SUSE, LLC.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# pyright: reportUnknownMemberType=false
+
+import json
+import os
+from typing import Callable, List
+from pydantic import parse_obj_as
+from pytest_mock import MockerFixture
+
+from gravel.controllers.gstate import GlobalState
+from gravel.controllers.orch.models import OrchDevicesPerHostModel
+from gravel.controllers.orch.orchestrator import Orchestrator
+
+
+DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
+
+
+def test_device_ls(
+    get_data_contents: Callable[[str, str], str],
+    mocker: MockerFixture,
+    gstate: GlobalState
+) -> None:
+
+    orch = Orchestrator(gstate.ceph_mgr)
+    orch.call = mocker.MagicMock(
+        return_value=json.loads(
+            get_data_contents(DATA_DIR, "device_ls_not_available.json")
+        )
+    )
+    res: List[OrchDevicesPerHostModel] = orch.devices_ls()
+    assert res[0].name == "asd"
+
+
+def test_devices_assimilated(
+    get_data_contents: Callable[[str, str], str],
+    mocker: MockerFixture,
+    gstate: GlobalState
+) -> None:
+
+    def device_ls_gen():
+        raw = json.loads(
+            get_data_contents(DATA_DIR, "device_ls_not_available.json")
+        )
+        devicels = parse_obj_as(List[OrchDevicesPerHostModel], raw)
+        yield devicels
+        devicels[0].devices[1].available = True
+        yield devicels
+
+    from gravel.controllers.orch.orchestrator import Orchestrator
+
+    orch = Orchestrator(gstate.ceph_mgr)
+
+    devicegen = device_ls_gen()
+    orch.devices_ls = mocker.MagicMock(
+        return_value=next(devicegen)
+    )
+    assert orch.devices_assimilated("asd", ["/dev/vdb", "/dev/vdc"])
+
+    orch.devices_ls = mocker.MagicMock(
+        return_value=next(devicegen)
+    )
+    assert not orch.devices_assimilated("asd", ["/dev/vdc"])

--- a/src/requirements-test.txt
+++ b/src/requirements-test.txt
@@ -7,3 +7,4 @@ pytest-cov
 pytest-datadir
 pytest-mock
 requests
+types-PyYAML

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -7,4 +7,5 @@ starlette==0.13.6
 uvicorn==0.13.3
 pip
 websockets==8.1
+PyYAML==5.4.1
 git+https://github.com/aquarist-labs/aetcd3/@edf633045ce61c7bbac4d4a6ca15b14f8acfe9cd


### PR DESCRIPTION
With this patch set we now support system disk creation on a joining node, as well as assimilating devices individually (instead of a blanket `all available`), both on a seed node and on a joining node.

~This patch set depends on merging #575  and  #581~

Signed-off-by: Joao Eduardo Luis \<joao@suse.com>