### PR TITLE
images: fix network not starting on boot

### DIFF
--- a/images/aquarium/config.xml
+++ b/images/aquarium/config.xml
@@ -166,6 +166,9 @@
     <packages type="image" profiles="Vagrant,Vagrant-x86_64,Vagrant-VirtualBox-x86_64,Vagrant-aarch64">
         <!-- vagrant-libvirt uses nfs for synced folders -->
         <package name="nfs-client"/>
+
+        <!-- adds entropy to Vagrant boxes -->
+        <package name="haveged"/>
     </packages>
     <packages type="image" profiles="SelfInstall">
         <package name="dracut-kiwi-oem-dump"/>

--- a/images/aquarium/config.xml
+++ b/images/aquarium/config.xml
@@ -186,6 +186,11 @@
         <package name="gawk"/>
         <package name="issue-generator"/>
 
+        <!-- network utilities -->
+        <package name="iputils"/>
+        <package name="iproute2"/>
+        <package name="wicked"/>
+
         <!-- Vagrant sudo-->
         <package name="sudo"/>
         <package name="openssh"/>


### PR DESCRIPTION
The image stopped working at some point in the last few days. Turns out `wicked` was no longer being installed. My suspicion is that we were installing it as a dependency for something, and said dependency was dropped.

Signed-off-by: Joao Eduardo Luis \<joao@suse.com>