### PR TITLE
aquarium: address multiple issues when running on real hardware

### DIFF
--- a/images/aquarium/config.xml
+++ b/images/aquarium/config.xml
@@ -73,7 +73,7 @@
             bootloader="grub2"
             bootloader_console="gfxterm"
             firmware="uefi"
-            kernelcmdline="quiet systemd.show_status=yes console=ttyS0,115200 console=tty0 net.ifnames=0 root=/dev/vda3 disk=/dev/vda"
+            kernelcmdline="quiet systemd.show_status=yes console=ttyS0,115200 console=tty0 root=/dev/vda3 disk=/dev/vda"
             bootpartition="false"
             bootkernel="custom"
             devicepersistency="by-uuid"
@@ -90,7 +90,7 @@
             bootloader="grub2"
             bootloader_console="gfxterm"
             firmware="uefi"
-            kernelcmdline="quiet systemd.show_status=yes console=ttyS0,115200 console=tty0 net.ifnames=0 root=/dev/sda3 disk=/dev/sda"
+            kernelcmdline="quiet systemd.show_status=yes console=ttyS0,115200 console=tty0 root=/dev/sda3 disk=/dev/sda"
             bootpartition="false"
             bootkernel="custom"
             devicepersistency="by-uuid"
@@ -109,7 +109,7 @@
             initrd_system="dracut"
             installiso="true"
             installboot="install"
-            kernelcmdline="quiet systemd.show_status=yes console=ttyS0,115200 console=tty0 rd.kiwi.ramdisk ramdisk_size=4096000 net.ifnames=0"
+            kernelcmdline="quiet systemd.show_status=yes console=ttyS0,115200 console=tty0 rd.kiwi.ramdisk ramdisk_size=4096000"
             devicepersistency="by-uuid"
         >
             <oemconfig>

--- a/images/aquarium/root/etc/sysconfig/network/ifcfg-eth0
+++ b/images/aquarium/root/etc/sysconfig/network/ifcfg-eth0
@@ -1,4 +1,0 @@
-BOOTPROTO='dhcp'
-MTU=''
-REMOTE_IPADDR=''
-STARTMODE='onboot'

--- a/images/aquarium/root/etc/udev/rules.d/10-aqr-nics.rules
+++ b/images/aquarium/root/etc/udev/rules.d/10-aqr-nics.rules
@@ -1,0 +1,1 @@
+ACTION=="add", SUBSYSTEM=="net", RUN+="/usr/share/aquarium/boot/add-nic.sh"

--- a/images/aquarium/root/usr/lib/systemd/system/aquarium-boot.service
+++ b/images/aquarium/root/usr/lib/systemd/system/aquarium-boot.service
@@ -3,11 +3,13 @@
 
 [Unit]
 Description=Aquarium Boot Setup Service
-
-After=local-fs.target
+After=sysinit.target
+Before=chronyd.service network.target
+DefaultDependencies=no
 
 [Service]
+Type=oneshot
 ExecStart=/bin/bash /usr/share/aquarium/boot/aqrbootsetup.sh
 
 [Install]
-WantedBy=sysinit.target
+WantedBy=chronyd.service network.target

--- a/src/boot/add-nic.sh
+++ b/src/boot/add-nic.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# project aquarium's backend
+# Copyright (C) 2021 SUSE, LLC.
+
+cat > /etc/sysconfig/network/ifcfg-${INTERFACE} << EOF
+BOOTPROTO='dhcp'
+MTU=''
+REMOTE_IPADDR=''
+STARTMODE='onboot'
+EOF
+

--- a/src/boot/aqrbootsetup.sh
+++ b/src/boot/aqrbootsetup.sh
@@ -18,6 +18,8 @@ function overlay() {
   lower=${1}
   upper=${2}
 
+  [[ ! -d "${lower}" ]] && mkdir -p ${lower}
+
   aqrdir=/aquarium/${upper}
   mount -t overlay \
     -o lowerdir=${lower},upperdir=${aqrdir}/overlay,workdir=${aqrdir}/temp \
@@ -53,6 +55,13 @@ overlay /var/lib/containers containers || exit 1
 overlay /root roothome || exit 1
 
 # bind mount
+[[ ! -d "/var/lib/ceph" ]] && mkdir -p /var/lib/ceph
 mount --bind /aquarium/ceph /var/lib/ceph || exit 1
 
 echo "Aquarium system disk mounted successfully"
+
+# The system obtains its hostname right at the beginning of boot, before disks
+# have been mounted or udev and lvm have been setup to allow us to mount them.
+# Because of that, let's set up the hostname once we do have the disks mounted.
+echo "Setup host from system disk"
+hostnamectl set-hostname $(cat /etc/hostname)

--- a/src/gravel/controllers/orch/orchestrator.py
+++ b/src/gravel/controllers/orch/orchestrator.py
@@ -103,6 +103,10 @@ class Orchestrator:
         entry: OrchDevicesPerHostModel = res[0]
         assert entry.name == hostname
 
+        if len(entry.devices) == 0:
+            logger.debug("devices not yet probed on host, must wait")
+            return False
+
         hostdevs: Dict[str, bool] = {}
         for dev in entry.devices:
             hostdevs[dev.path] = dev.available

--- a/src/gravel/controllers/orch/orchestrator.py
+++ b/src/gravel/controllers/orch/orchestrator.py
@@ -11,6 +11,7 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 
+import asyncio
 from typing import Any, Dict, List, Optional
 import yaml
 
@@ -46,6 +47,17 @@ class Orchestrator:
         cmd = {"prefix": "orch host ls"}
         res = self.call(cmd)
         return parse_obj_as(List[OrchHostListModel], res)
+
+    def host_exists(self, hostname: str) -> bool:
+        hosts: List[OrchHostListModel] = self.host_ls()
+        for h in hosts:
+            if h.hostname == hostname:
+                return True
+        return False
+
+    async def wait_host_added(self, hostname: str) -> None:
+        while not self.host_exists(hostname):
+            await asyncio.sleep(1.0)
 
     def devices_ls(
         self,

--- a/src/gravel/controllers/orch/orchestrator.py
+++ b/src/gravel/controllers/orch/orchestrator.py
@@ -108,7 +108,8 @@ class Orchestrator:
             hostdevs[dev.path] = dev.available
         for dev in devs:
             assert dev in hostdevs
-            if hostdevs[dev]:  # if available, not yet assimilated
+            if hostdevs[dev]:
+                # if available, not yet assimilated
                 return False
         return True
 


### PR DESCRIPTION
In this patch set we cover quite a few things, which presented themselves while running on real hardware:

- network interfaces are now populated from udev rules, allowing us to support any number of NICs, and will be configured to use dhcp by default so we can access the server and (eventually) further configure the network;
- we now wait for the seed host to be added to the underlying Ceph cluster before we wait for disk devices to be assimilated -- running on real hardware made this behavior visible, while it doesn't show up while running on Vagrant;
- we now wait for devices to be probed on the host before checking whether they are still available -- real hardware will take a lot longer to probe than the vagrant machines, especially with more disks;
- we had to change the `aquarium-boot.service` unit file to ensure correct ordering of operations, so we are able to mount the systemdisk at the right time;
- we have to configure the hostname manually during `aquarium-boot.service` execution, should a system disk be present, because otherwise we will be ignoring a previously set hostname -- this results from the hostname being picked very early in the boot process, before we can mount the system disk's overlays and bind mounts.

Signed-off-by: Joao Eduardo Luis \<joao@suse.com>