### PR TITLE
gravel/glass: user management - prevent the current user from disabling himself

### DIFF
--- a/tests/suites/smoke/test_api_user.py
+++ b/tests/suites/smoke/test_api_user.py
@@ -1,0 +1,48 @@
+# project aquarium's testing battery
+# Copyright (C) 2021 SUSE, LLC.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+from libaqr.testing import TestCase, caseunit, requirements
+from libaqr.http import conn
+
+
+@requirements(
+    disks=1,
+    nodes=1,
+    nics=1
+)
+class TestAPIUser(TestCase):
+
+    @caseunit
+    async def fail_update_user(self) -> None:
+        async with conn() as session:
+            res = await session.post(
+                "/user/create",
+                json={
+                    "username": "foo",
+                    "password": "1234",
+                    "full_name": "Foo Buz",
+                    "disabled": False
+                }
+            )
+            assert res.status == 200
+
+            res = await session.patch(
+                "/user/foo",
+                json={
+                    "username": "foo",
+                    "password": "",
+                    "full_name": "Foo Bar",
+                    "disabled": True
+                }
+            )
+            assert res.status == 400


### PR DESCRIPTION
Handle this behaviour completely in the backend, no need to do any checks in the frontend.

Fixes: https://github.com/aquarist-labs/aquarium/issues/607

Signed-off-by: Volker Theile <vtheile@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [issue id or URL on https://github.com/aquarist-labs/aquarium/issues, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The component is the short name of a major module or subsystem, something 
like "tools", "gravel", "glass", "doc", etc.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://github.com/aquarist-labs/aquarium/blob/main/CONTRIBUTING.md

-->

## Checklist
- [x] References issues, create if required
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test tumbleweed`
- `jenkins run tumbleweed`
- `jenkins test leap`
- `jenkins run leap`

</details>
