### PR TITLE
gravel: fix NFS info to reflect Ceph cmd return

### DIFF
--- a/src/gravel/controllers/orch/nfs.py
+++ b/src/gravel/controllers/orch/nfs.py
@@ -23,7 +23,7 @@ from gravel.controllers.orch.ceph import CephCommandError, Mgr
 
 class NFSDaemonModel(BaseModel):
     hostname: str
-    ip: List[str]
+    ip: str
     port: int
 
 
@@ -118,7 +118,9 @@ class NFSService(NFS):
 
         ret: List[NFSServiceModel] = []
         for service_id in res:
-            daemons = parse_obj_as(List[NFSDaemonModel], res[service_id])
+            daemons = parse_obj_as(
+                List[NFSDaemonModel], res[service_id]["backend"]
+            )
             ret.append(NFSServiceModel(service_id=service_id, daemons=daemons))
         return ret
 


### PR DESCRIPTION
I received an validation error: 

```pydantic.error_wrappers.ValidationError: 1 validation error for ParsingModel[List[gravel.controllers.orch.nfs.NFSDaemonModel]] __root__```
```value is not a valid list (type=type_error.list)```

when calling GET `/nfs/service/{service_id}`.

I'm not fully sure if it is what the endpoint is suppose to return. But at least it fixes the error 500 returned by the API currently.
If the return value is incorrect now, just let me know and I'll adapt the PR accordingly.

Signed-off-by: Tatjana Dehler <tdehler@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [issue id or URL on https://github.com/aquarist-labs/aquarium/issues, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The component is the short name of a major module or subsystem, something 
like "tools", "gravel", "glass", "doc", etc.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://github.com/aquarist-labs/aquarium/blob/main/CONTRIBUTING.md

-->

## Checklist
- [ ] References issues, create if required
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test tumbleweed`
- `jenkins run tumbleweed`
- `jenkins test leap`
- `jenkins run leap`

</details>
