### PR TITLE
images/aquarium/config.sh: Don't call baseCleanMount

### DIFF
--- a/images/aquarium/config.sh
+++ b/images/aquarium/config.sh
@@ -108,7 +108,4 @@ baseInsertService aquarium-boot
 baseInsertService sshd
 baseInsertService aquarium
 
-# Not compatible with set -e
-baseCleanMount || true
-
 exit 0


### PR DESCRIPTION
Remove baseCleanMount at the end. The function is deprecated in kiwi
and newer kiwi versions call exit 1, failing build-image.sh

Signed-off-by: Marcel Lauhoff <marcel.lauhoff@suse.com>