### PR TITLE
tools: Adds force option on box destroy

### DIFF
--- a/tools/libaqua/cli.py
+++ b/tools/libaqua/cli.py
@@ -392,9 +392,10 @@ def cmd_start(ctx: AppCtx, name: str, conservative: bool) -> None:
 
 
 @app.command("stop")
+@click.option("-f", "--force", flag_value=True)
 @click.argument("name", required=True, type=str)
 @pass_appctx
-def cmd_stop(ctx: AppCtx, name: str) -> None:
+def cmd_stop(ctx: AppCtx, name: str, force: bool) -> None:
     """
     Stop deployment; destroys running machines
     """
@@ -402,7 +403,7 @@ def cmd_stop(ctx: AppCtx, name: str) -> None:
     assert deployment
 
     try:
-        deployment.stop()
+        deployment.stop(force=force)
     except AqrError as e:
         click.secho(f"Error: {e.message}", fg="red")
         sys.exit(e.errno)

--- a/tools/libaqua/deployment.py
+++ b/tools/libaqua/deployment.py
@@ -153,13 +153,13 @@ class Deployment:
         except AqrError as e:
             raise e
 
-    def stop(self, interactive: bool = True) -> None:
+    def stop(self, force: bool = False) -> None:
         """ Stop deployment """
         try:
             with vagrant.deployment(self._path) as deployment:
                 if deployment.shutoff or deployment.notcreated:
                     return  # nothing to do.
-                deployment.stop(interactive=interactive)
+                deployment.stop(force=force)
         except AqrError as e:
             raise e
 

--- a/tools/libaqua/vagrant.py
+++ b/tools/libaqua/vagrant.py
@@ -56,9 +56,9 @@ class Vagrant:
             return False, err
         return True, None
 
-    def stop(self, interactive: bool = True) -> Tuple[bool, Optional[str]]:
+    def stop(self, force: bool = False) -> Tuple[bool, Optional[str]]:
         cmd = "vagrant destroy"
-        if not interactive:
+        if force:
             cmd += " --force"
         retcode, _, err = self._run(cmd, interactive=True)
         if retcode != 0:


### PR DESCRIPTION
This is helpful if aqrdev is used inside a script where user approval
just delays.

Signed-off-by: Stephan Müller <smueller@suse.com>

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test tumbleweed`
- `jenkins run tumbleweed`
- `jenkins test leap`
- `jenkins run leap`

</details>
