### PR TITLE
tools: Add the missing --port option to the usage/help text

### DIFF
--- a/tools/run_aquarium.sh
+++ b/tools/run_aquarium.sh
@@ -12,6 +12,7 @@ options:
   -d|--debug          Enable debug logging to stdout
   -c|--config PATH    Set config directory to PATH
   -n|--new            Run as new deployment; blows config path if it exists
+  -p|--port           Bind to a socket with this port
   --use-venv          Run inside a python virtualenv
   -h|--help           This message
 


### PR DESCRIPTION
Signed-off-by: Volker Theile <vtheile@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [issue id or URL on https://github.com/aquarist-labs/aquarium/issues, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The component is the short name of a major module or subsystem, something 
like "tools", "gravel", "glass", "doc", etc.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://github.com/aquarist-labs/aquarium/blob/main/CONTRIBUTING.md

-->

## Checklist
- [ ] References issues, create if required
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test tumbleweed`
- `jenkins run tumbleweed`
- `jenkins test leap`
- `jenkins run leap`

</details>
