### PR TITLE
Add support for isort

### DIFF
--- a/src/aquarium.py
+++ b/src/aquarium.py
@@ -16,32 +16,32 @@
 import logging
 import logging.config
 import os
-from fastapi import FastAPI
-from fastapi.staticfiles import StaticFiles
-from fastapi.logger import logger as fastapi_logger
-import uvicorn
 
+import uvicorn
+from fastapi import FastAPI
+from fastapi.logger import logger as fastapi_logger
+from fastapi.staticfiles import StaticFiles
+
+from gravel.api import (
+    auth,
+    devices,
+    local,
+    nfs,
+    nodes,
+    orch,
+    services,
+    status,
+    user,
+)
 from gravel.cephadm.cephadm import Cephadm
 from gravel.controllers.gstate import GlobalState, setup_logging
 from gravel.controllers.nodes.mgr import NodeMgr
 from gravel.controllers.orch.ceph import Ceph, Mgr, Mon
-from gravel.controllers.resources.inventory import Inventory
 from gravel.controllers.resources.devices import Devices
+from gravel.controllers.resources.inventory import Inventory
 from gravel.controllers.resources.status import Status
 from gravel.controllers.resources.storage import Storage
 from gravel.controllers.services import Services
-
-from gravel.api import (
-    orch,
-    status,
-    services,
-    nodes,
-    local,
-    devices,
-    nfs,
-    auth,
-    user,
-)
 
 logger: logging.Logger = fastapi_logger
 

--- a/src/gravel/api/__init__.py
+++ b/src/gravel/api/__init__.py
@@ -11,11 +11,12 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 
-from fastapi import HTTPException, Request
-from fastapi.security import OAuth2PasswordBearer
 from typing import Optional
 
-from gravel.controllers.auth import JWTDenyList, JWTMgr, JWT, UserMgr, UserModel
+from fastapi import HTTPException, Request
+from fastapi.security import OAuth2PasswordBearer
+
+from gravel.controllers.auth import JWT, JWTDenyList, JWTMgr, UserMgr, UserModel
 
 
 class JWTAuthSchema(OAuth2PasswordBearer):

--- a/src/gravel/api/auth.py
+++ b/src/gravel/api/auth.py
@@ -12,15 +12,15 @@
 # GNU General Public License for more details.
 
 from logging import Logger
+
+from fastapi import Depends, HTTPException, Request, Response, status
 from fastapi.logger import logger as fastapi_logger
 from fastapi.routing import APIRouter
-from fastapi import HTTPException, Request, Response, Depends, status
 from fastapi.security import OAuth2PasswordRequestForm
 from pydantic import BaseModel, Field
 
 from gravel.api import jwt_auth_scheme
-from gravel.controllers.auth import JWTDenyList, JWTMgr, JWT, UserMgr
-
+from gravel.controllers.auth import JWT, JWTDenyList, JWTMgr, UserMgr
 
 logger: Logger = fastapi_logger
 

--- a/src/gravel/api/devices.py
+++ b/src/gravel/api/devices.py
@@ -13,6 +13,7 @@
 
 from logging import Logger
 from typing import Dict
+
 from fastapi import Depends, Request
 from fastapi.logger import logger as fastapi_logger
 from fastapi.routing import APIRouter

--- a/src/gravel/api/local.py
+++ b/src/gravel/api/local.py
@@ -13,16 +13,16 @@
 
 from logging import Logger
 from typing import List
+
+from fastapi import Depends, HTTPException, Request, status
 from fastapi.logger import logger as fastapi_logger
 from fastapi.routing import APIRouter
-from fastapi import Depends, HTTPException, Request, status
 from pydantic import BaseModel, Field
 
 from gravel.api import jwt_auth_scheme
 from gravel.cephadm.models import NodeInfoModel, VolumeDeviceModel
-from gravel.controllers.nodes.mgr import NodeMgr
 from gravel.controllers.nodes.deployment import NodeStageEnum
-
+from gravel.controllers.nodes.mgr import NodeMgr
 
 logger: Logger = fastapi_logger
 

--- a/src/gravel/api/nfs.py
+++ b/src/gravel/api/nfs.py
@@ -14,22 +14,20 @@
 from logging import Logger
 from typing import List, Optional
 
-from fastapi import Depends, HTTPException, status, Request
+from fastapi import Depends, HTTPException, Request, status
 from fastapi.logger import logger as fastapi_logger
 from fastapi.routing import APIRouter
-
 from pydantic import BaseModel
 
 from gravel.api import jwt_auth_scheme
 from gravel.controllers.orch.nfs import (
-    NFSError,
     NFSBackingStoreEnum,
+    NFSError,
     NFSExport,
     NFSExportModel,
     NFSService,
     NFSServiceModel,
 )
-
 
 logger: Logger = fastapi_logger
 

--- a/src/gravel/api/nodes.py
+++ b/src/gravel/api/nodes.py
@@ -13,6 +13,7 @@
 
 from logging import Logger
 from typing import List, Optional
+
 from fastapi import Depends, HTTPException, Request, status
 from fastapi.logger import logger as fastapi_logger
 from fastapi.routing import APIRouter
@@ -25,7 +26,7 @@ from gravel.controllers.nodes.deployment import (
     DeploymentState,
     NodeStageEnum,
 )
-from gravel.controllers.nodes.disks import DiskSolution, Disks
+from gravel.controllers.nodes.disks import Disks, DiskSolution
 from gravel.controllers.nodes.errors import (
     NodeAlreadyJoiningError,
     NodeCantDeployError,
@@ -38,7 +39,6 @@ from gravel.controllers.nodes.mgr import (
     JoinParamsModel,
     NodeMgr,
 )
-
 
 logger: Logger = fastapi_logger
 router = APIRouter(prefix="/nodes", tags=["nodes"])

--- a/src/gravel/api/orch.py
+++ b/src/gravel/api/orch.py
@@ -12,16 +12,16 @@
 # GNU General Public License for more details.
 
 from logging import Logger
-from fastapi.routing import APIRouter
-from fastapi.logger import logger as fastapi_logger
-from fastapi import Depends, HTTPException, status, Request
-from pydantic import BaseModel
 from typing import Dict, List
+
+from fastapi import Depends, HTTPException, Request, status
+from fastapi.logger import logger as fastapi_logger
+from fastapi.routing import APIRouter
+from pydantic import BaseModel
 
 from gravel.api import jwt_auth_scheme
 from gravel.controllers.orch.models import OrchDevicesPerHostModel
 from gravel.controllers.orch.orchestrator import Orchestrator
-
 
 logger: Logger = fastapi_logger
 

--- a/src/gravel/api/services.py
+++ b/src/gravel/api/services.py
@@ -13,9 +13,10 @@
 
 from logging import Logger
 from typing import Dict, List, Optional
+
+from fastapi import Depends, HTTPException, Request, status
 from fastapi.logger import logger as fastapi_logger
 from fastapi.routing import APIRouter
-from fastapi import Depends, HTTPException, Request, status
 from pydantic import BaseModel
 from pydantic.fields import Field
 
@@ -37,7 +38,6 @@ from gravel.controllers.services import (
     ServiceTypeEnum,
     UnknownServiceError,
 )
-
 
 logger: Logger = fastapi_logger
 router: APIRouter = APIRouter(prefix="/services", tags=["services"])

--- a/src/gravel/api/status.py
+++ b/src/gravel/api/status.py
@@ -12,11 +12,12 @@
 # GNU General Public License for more details.
 
 from logging import Logger
-from typing import Optional
 from pathlib import Path
+from typing import Optional
+
 from fastapi import Depends, HTTPException, Request, status
-from fastapi.routing import APIRouter
 from fastapi.logger import logger as fastapi_logger
+from fastapi.routing import APIRouter
 from pydantic import BaseModel, Field
 
 from gravel.api import jwt_auth_scheme
@@ -27,7 +28,6 @@ from gravel.controllers.resources.status import (
     OverallClientIORateModel,
     Status,
 )
-
 
 logger: Logger = fastapi_logger
 

--- a/src/gravel/api/user.py
+++ b/src/gravel/api/user.py
@@ -12,14 +12,14 @@
 # GNU General Public License for more details.
 
 from logging import Logger
+from typing import List
+
+from fastapi import Depends, HTTPException, Request, status
 from fastapi.logger import logger as fastapi_logger
 from fastapi.routing import APIRouter
-from fastapi import Depends, HTTPException, Request, status
-from typing import List
 
 from gravel.api import jwt_auth_scheme
 from gravel.controllers.auth import JWT, UserMgr, UserModel
-
 
 logger: Logger = fastapi_logger
 

--- a/src/gravel/cephadm/cephadm.py
+++ b/src/gravel/cephadm/cephadm.py
@@ -16,14 +16,13 @@ import json
 import os
 import tempfile
 import time
-
 from io import StringIO
 from logging import Logger
-from typing import Callable, IO, List, Optional, Tuple
+from typing import IO, Callable, List, Optional, Tuple
 
 import pydantic
-from pydantic.tools import parse_obj_as
 from fastapi.logger import logger as fastapi_logger
+from pydantic.tools import parse_obj_as
 
 from .models import (
     HostFactsModel,
@@ -33,7 +32,6 @@ from .models import (
     NodeMemoryInfoModel,
     VolumeDeviceModel,
 )
-
 
 logger: Logger = fastapi_logger
 

--- a/src/gravel/cephadm/models.py
+++ b/src/gravel/cephadm/models.py
@@ -12,6 +12,7 @@
 # GNU General Public License for more details.
 
 from typing import Any, Dict, List, Optional
+
 from pydantic import BaseModel
 from pydantic.fields import Field
 

--- a/src/gravel/controllers/auth.py
+++ b/src/gravel/controllers/auth.py
@@ -11,14 +11,13 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 
-import bcrypt
 import json
-import jwt
 import uuid
-
 from datetime import datetime, timezone
-from typing import Dict, List, Optional, Union, NamedTuple
+from typing import Dict, List, NamedTuple, Optional, Union
 
+import bcrypt
+import jwt
 from fastapi import Request, Response
 from fastapi.security.utils import get_authorization_scheme_param
 from pydantic import BaseModel, Field

--- a/src/gravel/controllers/config.py
+++ b/src/gravel/controllers/config.py
@@ -14,11 +14,10 @@
 import os
 from logging import Logger
 from pathlib import Path
-from typing import Type, TypeVar
-from pydantic import BaseModel, Field
-from typing import Optional
+from typing import Optional, Type, TypeVar
 
 from fastapi.logger import logger as fastapi_logger
+from pydantic import BaseModel, Field
 
 from . import utils
 

--- a/src/gravel/controllers/gstate.py
+++ b/src/gravel/controllers/gstate.py
@@ -14,11 +14,13 @@
 from __future__ import annotations
 
 import asyncio
-import time
-from abc import ABC, abstractmethod
 import logging.config
+import time
+import typing
+from abc import ABC, abstractmethod
 from logging import Logger
 from typing import Dict
+
 from fastapi.logger import logger as fastapi_logger
 
 from gravel.cephadm.cephadm import Cephadm
@@ -26,11 +28,9 @@ from gravel.controllers.config import Config
 from gravel.controllers.kv import KV
 from gravel.controllers.orch.ceph import Mgr, Mon
 
-import typing
-
 if typing.TYPE_CHECKING:
-    from gravel.controllers.resources.inventory import Inventory
     from gravel.controllers.resources.devices import Devices
+    from gravel.controllers.resources.inventory import Inventory
     from gravel.controllers.resources.status import Status
     from gravel.controllers.resources.storage import Storage
     from gravel.controllers.services import Services

--- a/src/gravel/controllers/kv.py
+++ b/src/gravel/controllers/kv.py
@@ -12,13 +12,13 @@
 # GNU General Public License for more details.
 
 import asyncio
-from typing import Callable, Optional, List
-import aetcd3
-import aetcd3.locks
-import aetcd3.events
-import grpclib.exceptions
-
 from logging import Logger
+from typing import Callable, List, Optional
+
+import aetcd3
+import aetcd3.events
+import aetcd3.locks
+import grpclib.exceptions
 from fastapi.logger import logger as fastapi_logger
 
 logger: Logger = fastapi_logger

--- a/src/gravel/controllers/nodes/bootstrap.py
+++ b/src/gravel/controllers/nodes/bootstrap.py
@@ -15,12 +15,12 @@ import asyncio
 from enum import Enum
 from logging import Logger
 from typing import Awaitable, Callable, Optional
+
 from fastapi.logger import logger as fastapi_logger
 
 from gravel.cephadm.cephadm import Cephadm
 from gravel.controllers.errors import GravelError
 from gravel.controllers.gstate import GlobalState
-
 
 logger: Logger = fastapi_logger  # required to provide type-hint to pylance
 

--- a/src/gravel/controllers/nodes/conn.py
+++ b/src/gravel/controllers/nodes/conn.py
@@ -12,9 +12,10 @@
 # GNU General Public License for more details.
 
 from __future__ import annotations
+
 import asyncio
-from typing import Tuple, Optional, Any, cast
 from logging import Logger
+from typing import Any, Optional, Tuple, cast
 
 import websockets
 from fastapi import status

--- a/src/gravel/controllers/nodes/deployment.py
+++ b/src/gravel/controllers/nodes/deployment.py
@@ -18,24 +18,25 @@ from logging import Logger
 from pathlib import Path
 from typing import Awaitable, Callable, List, Optional
 from uuid import UUID
-from pydantic import BaseModel, Field
+
 from fastapi.logger import logger as fastapi_logger
+from pydantic import BaseModel, Field
 
 from gravel.controllers.errors import GravelError
 from gravel.controllers.gstate import GlobalState
 from gravel.controllers.nodes.bootstrap import Bootstrap, BootstrapError
 from gravel.controllers.nodes.conn import ConnMgr
-
 from gravel.controllers.nodes.errors import (
     NodeAlreadyJoiningError,
     NodeBootstrappingError,
     NodeCantDeployError,
     NodeCantJoinError,
+    NodeChronyRestartError,
     NodeError,
     NodeHasBeenDeployedError,
     NodeHasJoinedError,
-    NodeChronyRestartError,
 )
+from gravel.controllers.nodes.etcd import spawn_etcd
 from gravel.controllers.nodes.host import HostnameCtlError, set_hostname
 from gravel.controllers.nodes.messages import (
     ErrorMessageModel,
@@ -46,10 +47,8 @@ from gravel.controllers.nodes.messages import (
     WelcomeMessageModel,
 )
 from gravel.controllers.nodes.ntp import set_ntp_addr
-from gravel.controllers.nodes.etcd import spawn_etcd
 from gravel.controllers.nodes.systemdisk import SystemDisk
 from gravel.controllers.orch.orchestrator import Orchestrator
-
 
 logger: Logger = fastapi_logger
 

--- a/src/gravel/controllers/nodes/disks.py
+++ b/src/gravel/controllers/nodes/disks.py
@@ -14,12 +14,12 @@
 from enum import Enum
 from logging import Logger
 from typing import List, Optional, Tuple
+
 from fastapi.logger import logger as fastapi_logger
 from pydantic import BaseModel, Field
 
 from gravel.cephadm.models import NodeInfoModel, VolumeDeviceModel
 from gravel.controllers.gstate import GlobalState
-
 
 logger: Logger = fastapi_logger
 

--- a/src/gravel/controllers/nodes/etcd.py
+++ b/src/gravel/controllers/nodes/etcd.py
@@ -13,14 +13,15 @@
 
 import asyncio
 import multiprocessing
-from pathlib import Path
 import shlex
-from typing import List, Optional
 from logging import Logger
+from pathlib import Path
+from typing import List, Optional
+
 from fastapi.logger import logger as fastapi_logger
 
-from gravel.controllers.gstate import GlobalState
 from gravel.controllers.errors import GravelError
+from gravel.controllers.gstate import GlobalState
 
 
 class ContainerFetchError(GravelError):

--- a/src/gravel/controllers/nodes/messages.py
+++ b/src/gravel/controllers/nodes/messages.py
@@ -12,8 +12,8 @@
 # GNU General Public License for more details.
 
 from enum import Enum
-from uuid import UUID
 from typing import Any
+from uuid import UUID
 
 from pydantic import BaseModel
 

--- a/src/gravel/controllers/nodes/mgr.py
+++ b/src/gravel/controllers/nodes/mgr.py
@@ -12,69 +12,61 @@
 # GNU General Public License for more details.
 
 import asyncio
+import random
 from enum import Enum
 from logging import Logger
-from uuid import UUID, uuid4
-import random
-from typing import (
-    Dict,
-    List,
-    Optional,
-)
 from pathlib import Path
+from typing import Dict, List, Optional
+from uuid import UUID, uuid4
 
 import aetcd3
-from pydantic import BaseModel, Field
 from fastapi import status
 from fastapi.logger import logger as fastapi_logger
+from pydantic import BaseModel, Field
+
 from gravel.cephadm.cephadm import CephadmError
 from gravel.cephadm.models import NodeInfoModel
-from gravel.controllers.auth import UserModel, UserMgr
+from gravel.controllers.auth import UserMgr, UserModel
 from gravel.controllers.gstate import GlobalState
+from gravel.controllers.nodes.conn import (
+    ConnMgr,
+    IncomingConnection,
+    get_conn_mgr,
+)
 from gravel.controllers.nodes.deployment import (
     DeploymentConfig,
     DeploymentDisksConfig,
     DeploymentState,
     NodeDeployment,
 )
-from gravel.controllers.orch.ceph import CephCommandError, Mon
-
+from gravel.controllers.nodes.disks import Disks
 from gravel.controllers.nodes.errors import (
+    NodeAlreadyJoiningError,
+    NodeCantDeployError,
     NodeCantJoinError,
+    NodeError,
     NodeNetworkAddressNotAvailable,
     NodeNotDeployedError,
     NodeNotStartedError,
     NodeShuttingDownError,
-    NodeAlreadyJoiningError,
-    NodeCantDeployError,
-    NodeError,
-)
-from gravel.controllers.nodes.conn import (
-    ConnMgr,
-    get_conn_mgr,
-    IncomingConnection,
-)
-from gravel.controllers.nodes.messages import (
-    ErrorMessageModel,
-    MessageModel,
-    JoinMessageModel,
-    ReadyToAddMessageModel,
-    WelcomeMessageModel,
-    MessageTypeEnum,
 )
 from gravel.controllers.nodes.etcd import (
     ContainerFetchError,
     etcd_pull_image,
     spawn_etcd,
 )
-from gravel.controllers.orch.orchestrator import (
-    Orchestrator,
-    OrchHostListModel,
+from gravel.controllers.nodes.messages import (
+    ErrorMessageModel,
+    JoinMessageModel,
+    MessageModel,
+    MessageTypeEnum,
+    ReadyToAddMessageModel,
+    WelcomeMessageModel,
 )
+from gravel.controllers.orch.ceph import CephCommandError, Mon
+from gravel.controllers.orch.orchestrator import Orchestrator, OrchHostListModel
 from gravel.controllers.resources.inventory_sub import Subscriber
-from gravel.controllers.nodes.disks import Disks
 from gravel.controllers.utils import aqr_run_cmd
-
 
 logger: Logger = fastapi_logger
 

--- a/src/gravel/controllers/nodes/ntp.py
+++ b/src/gravel/controllers/nodes/ntp.py
@@ -16,6 +16,7 @@ from logging import Logger
 from pathlib import Path
 
 from fastapi.logger import logger as fastapi_logger
+
 from gravel.controllers.nodes.errors import NodeChronyRestartError
 from gravel.controllers.utils import aqr_run_cmd
 

--- a/src/gravel/controllers/nodes/systemdisk.py
+++ b/src/gravel/controllers/nodes/systemdisk.py
@@ -12,13 +12,10 @@
 # GNU General Public License for more details.
 
 import shlex
-from typing import (
-    Dict,
-    Optional,
-    List,
-)
 from logging import Logger
 from pathlib import Path
+from typing import Dict, List, Optional
+
 from fastapi.logger import logger as fastapi_logger
 from pydantic.main import BaseModel
 
@@ -26,7 +23,6 @@ from gravel.cephadm.models import NodeInfoModel, VolumeDeviceModel
 from gravel.controllers.errors import GravelError
 from gravel.controllers.gstate import GlobalState
 from gravel.controllers.utils import aqr_run_cmd
-
 
 logger: Logger = fastapi_logger
 

--- a/src/gravel/controllers/orch/ceph.py
+++ b/src/gravel/controllers/orch/ceph.py
@@ -13,21 +13,15 @@
 
 from __future__ import annotations
 
-from json.decoder import JSONDecodeError
-from pydantic.tools import parse_obj_as
 import json
-from pathlib import Path
-from typing import (
-    Callable,
-    Dict,
-    Any,
-    List,
-    Optional,
-    Union,
-)
-from logging import Logger
-from fastapi.logger import logger as fastapi_logger
 import sys
+from json.decoder import JSONDecodeError
+from logging import Logger
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Union
+
+from fastapi.logger import logger as fastapi_logger
+from pydantic.tools import parse_obj_as
 
 from gravel.controllers.orch.models import (
     CephDFModel,

--- a/src/gravel/controllers/orch/cephfs.py
+++ b/src/gravel/controllers/orch/cephfs.py
@@ -15,8 +15,8 @@ import errno
 from typing import List, Optional
 
 from pydantic.tools import parse_obj_as
-from gravel.controllers.orch.ceph import CephCommandError, Mgr, Mon
 
+from gravel.controllers.orch.ceph import CephCommandError, Mgr, Mon
 from gravel.controllers.orch.models import (
     CephFSAuthorizationModel,
     CephFSListEntryModel,

--- a/src/gravel/controllers/orch/models.py
+++ b/src/gravel/controllers/orch/models.py
@@ -12,6 +12,7 @@
 # GNU General Public License for more details.
 
 from typing import Any, Dict, List
+
 from pydantic import BaseModel, Field
 
 from gravel.cephadm.models import VolumeDeviceModel

--- a/src/gravel/controllers/orch/nfs.py
+++ b/src/gravel/controllers/orch/nfs.py
@@ -15,8 +15,8 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from pydantic.tools import parse_obj_as
 from pydantic import BaseModel
+from pydantic.tools import parse_obj_as
 
 from gravel.controllers.orch.ceph import CephCommandError, Mgr
 

--- a/src/gravel/controllers/orch/orchestrator.py
+++ b/src/gravel/controllers/orch/orchestrator.py
@@ -12,18 +12,18 @@
 # GNU General Public License for more details.
 
 import asyncio
-from typing import Any, Dict, List, Optional
-import yaml
-
 from logging import Logger
+from typing import Any, Dict, List, Optional
+
+import yaml
 from fastapi.logger import logger as fastapi_logger
 from pydantic.tools import parse_obj_as
+
 from gravel.controllers.orch.ceph import CephCommandError, Mgr
 from gravel.controllers.orch.models import (
     OrchDevicesPerHostModel,
     OrchHostListModel,
 )
-
 
 logger: Logger = fastapi_logger
 

--- a/src/gravel/controllers/resources/devices.py
+++ b/src/gravel/controllers/resources/devices.py
@@ -13,19 +13,19 @@
 
 from logging import Logger
 from typing import Dict, List
-from fastapi.logger import logger as fastapi_logger
-from pydantic import Field, BaseModel
 
+from fastapi.logger import logger as fastapi_logger
+from pydantic import BaseModel, Field
+
+from gravel.cephadm.models import VolumeDeviceModel
 from gravel.controllers.gstate import Ticker
 from gravel.controllers.nodes.mgr import NodeMgr
 from gravel.controllers.orch.ceph import Mgr, Mon
-from gravel.cephadm.models import VolumeDeviceModel
 from gravel.controllers.orch.models import (
     CephOSDDFModel,
     OrchDevicesPerHostModel,
 )
 from gravel.controllers.orch.orchestrator import Orchestrator
-
 
 logger: Logger = fastapi_logger
 

--- a/src/gravel/controllers/resources/inventory.py
+++ b/src/gravel/controllers/resources/inventory.py
@@ -12,16 +12,18 @@
 # GNU General Public License for more details.
 
 from __future__ import annotations
-from logging import Logger
+
 import time
+from logging import Logger
 from typing import Awaitable, Callable, List, Optional
+
 from fastapi.logger import logger as fastapi_logger
-from gravel.cephadm.models import NodeInfoModel
-from gravel.controllers.gstate import Ticker, GlobalState
+
 from gravel.cephadm.cephadm import Cephadm
+from gravel.cephadm.models import NodeInfoModel
+from gravel.controllers.gstate import GlobalState, Ticker
 from gravel.controllers.nodes.mgr import NodeMgr
 from gravel.controllers.resources.inventory_sub import Subscriber
-
 
 logger: Logger = fastapi_logger
 

--- a/src/gravel/controllers/resources/inventory_sub.py
+++ b/src/gravel/controllers/resources/inventory_sub.py
@@ -12,7 +12,9 @@
 # GNU General Public License for more details.
 
 from __future__ import annotations
+
 from typing import Awaitable, Callable
+
 from gravel.cephadm.models import NodeInfoModel
 
 

--- a/src/gravel/controllers/resources/status.py
+++ b/src/gravel/controllers/resources/status.py
@@ -13,18 +13,18 @@
 
 from logging import Logger
 from typing import Dict, List, Optional
+
 from fastapi.logger import logger as fastapi_logger
 from pydantic import BaseModel, Field
 
-from gravel.controllers.gstate import Ticker, GlobalState
+from gravel.controllers.gstate import GlobalState, Ticker
+from gravel.controllers.nodes.mgr import NodeMgr
 from gravel.controllers.orch.ceph import Mon
 from gravel.controllers.orch.models import (
     CephOSDPoolStatsModel,
     CephStatusModel,
 )
-from gravel.controllers.nodes.mgr import NodeMgr
-from gravel.controllers.services import ServiceTypeEnum, Services
-
+from gravel.controllers.services import Services, ServiceTypeEnum
 
 logger: Logger = fastapi_logger
 

--- a/src/gravel/controllers/resources/storage.py
+++ b/src/gravel/controllers/resources/storage.py
@@ -13,13 +13,14 @@
 
 from logging import Logger
 from typing import Dict
+
 from fastapi.logger import logger as fastapi_logger
 from pydantic.fields import Field
 from pydantic.main import BaseModel
+
 from gravel.controllers.gstate import Ticker
 from gravel.controllers.nodes.mgr import NodeMgr
 from gravel.controllers.orch.ceph import Mon
-
 
 logger: Logger = fastapi_logger
 

--- a/src/gravel/controllers/services.py
+++ b/src/gravel/controllers/services.py
@@ -12,13 +12,15 @@
 # GNU General Public License for more details.
 
 from enum import Enum
-from typing import Dict, List, Optional, Tuple
 from logging import Logger
+from typing import Dict, List, Optional, Tuple
+
 from fastapi.logger import logger as fastapi_logger
 from pydantic import BaseModel
 from pydantic.fields import Field
-from gravel.controllers.nodes.mgr import NodeMgr
 
+from gravel.controllers.gstate import GlobalState, Ticker
+from gravel.controllers.nodes.mgr import NodeMgr
 from gravel.controllers.orch.cephfs import CephFS, CephFSError
 from gravel.controllers.orch.models import (
     CephFSListEntryModel,
@@ -30,10 +32,8 @@ from gravel.controllers.orch.nfs import (
     NFSExport,
     NFSService,
 )
-from gravel.controllers.gstate import Ticker, GlobalState
 from gravel.controllers.resources.devices import DeviceHostModel, Devices
 from gravel.controllers.resources.storage import Storage, StoragePoolModel
-
 
 logger: Logger = fastapi_logger
 

--- a/src/gravel/controllers/utils.py
+++ b/src/gravel/controllers/utils.py
@@ -17,10 +17,10 @@ import string
 from logging import Logger
 from pathlib import Path
 from typing import List, Optional, Tuple, Type, TypeVar
+
+from fastapi.logger import logger as fastapi_logger
 from pydantic import BaseModel
 from pydantic.tools import parse_file_as
-from fastapi.logger import logger as fastapi_logger
-
 
 logger: Logger = fastapi_logger
 

--- a/src/gravel/tests/conftest.py
+++ b/src/gravel/tests/conftest.py
@@ -11,33 +11,22 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 
-import httpx
 import logging
 import os
-import pytest
 import sys
+from types import SimpleNamespace
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple, cast
 
+import httpx
+import pytest
+from _pytest.fixtures import SubRequest
 from asgi_lifespan import LifespanManager
+from fastapi import FastAPI
 from pyfakefs import fake_filesystem  # pyright: reportMissingTypeStubs=false
 from pytest_mock import MockerFixture
-from types import SimpleNamespace
-from typing import (
-    Any,
-    Awaitable,
-    Callable,
-    Dict,
-    List,
-    Optional,
-    Tuple,
-    cast,
-)
-from _pytest.fixtures import SubRequest
-
-from fastapi import FastAPI
 
 from gravel.controllers.gstate import GlobalState
 from gravel.controllers.kv import KV
-
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
 
@@ -204,21 +193,22 @@ async def aquarium_startup(
     get_data_contents: Callable[[str, str], str], mocker: MockerFixture
 ):
     async def startup(aquarium_app: FastAPI, aquarium_api: FastAPI):
+        from fastapi.logger import logger as fastapi_logger
+
         from gravel.cephadm.cephadm import Cephadm
-        from gravel.controllers.nodes.mgr import (
-            NodeMgr,
-            NodeError,
-            NodeInitStage,
-        )
-        from gravel.controllers.resources.inventory import Inventory
-        from gravel.controllers.resources.devices import Devices
-        from gravel.controllers.resources.status import Status
-        from gravel.controllers.resources.storage import Storage
-        from gravel.controllers.services import Services, ServiceModel
-        from gravel.controllers.orch.ceph import Ceph, Mgr, Mon
         from gravel.controllers.nodes.deployment import NodeDeployment
         from gravel.controllers.nodes.errors import NodeCantDeployError
-        from fastapi.logger import logger as fastapi_logger
+        from gravel.controllers.nodes.mgr import (
+            NodeError,
+            NodeInitStage,
+            NodeMgr,
+        )
+        from gravel.controllers.orch.ceph import Ceph, Mgr, Mon
+        from gravel.controllers.resources.devices import Devices
+        from gravel.controllers.resources.inventory import Inventory
+        from gravel.controllers.resources.status import Status
+        from gravel.controllers.resources.storage import Storage
+        from gravel.controllers.services import ServiceModel, Services
 
         logger: logging.Logger = fastapi_logger
 

--- a/src/gravel/tests/unit/cephadm/test_cephadm.py
+++ b/src/gravel/tests/unit/cephadm/test_cephadm.py
@@ -11,11 +11,11 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 
-from typing import Any, Callable, Dict, List, Optional, Tuple
 import json
 import os
-import pytest
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
+import pytest
 from pytest_mock import MockerFixture
 
 from gravel.cephadm.cephadm import Cephadm, CephadmError
@@ -24,7 +24,6 @@ from gravel.cephadm.models import (
     NodeInfoModel,
     VolumeDeviceModel,
 )
-
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
 

--- a/src/gravel/tests/unit/controllers/nodes/test_deployment.py
+++ b/src/gravel/tests/unit/controllers/nodes/test_deployment.py
@@ -15,6 +15,7 @@
 # pyright: reportUnknownVariableType=false
 
 from typing import Awaitable, Callable, List, Optional, cast
+
 import pytest
 from pytest_mock import MockerFixture
 
@@ -25,9 +26,9 @@ from gravel.controllers.nodes.deployment import DeploymentDisksConfig
 @pytest.mark.asyncio
 async def test_state(mocker: MockerFixture, gstate: GlobalState):
     from gravel.controllers.nodes.deployment import (
+        DeploymentErrorEnum,
         DeploymentState,
         NodeStageEnum,
-        DeploymentErrorEnum,
     )
 
     mocker.patch.object(DeploymentState, "_load_stage")
@@ -101,8 +102,8 @@ async def test_deployment_progress(mocker: MockerFixture, gstate: GlobalState):
 
     from gravel.controllers.nodes.conn import ConnMgr
     from gravel.controllers.nodes.deployment import (
-        NodeDeployment,
         DeploymentErrorEnum,
+        NodeDeployment,
         ProgressEnum,
     )
 
@@ -157,14 +158,14 @@ async def test_deployment_progress(mocker: MockerFixture, gstate: GlobalState):
 
 @pytest.mark.asyncio
 async def test_deploy(mocker: MockerFixture, gstate: GlobalState):
+    from gravel.controllers.nodes.bootstrap import Bootstrap
     from gravel.controllers.nodes.conn import ConnMgr
     from gravel.controllers.nodes.deployment import (
-        NodeDeployment,
         DeploymentConfig,
+        NodeDeployment,
     )
-    from gravel.controllers.nodes.bootstrap import Bootstrap
-    from gravel.controllers.orch.orchestrator import Orchestrator
     from gravel.controllers.nodes.systemdisk import SystemDisk
+    from gravel.controllers.orch.orchestrator import Orchestrator
 
     def mock_devices_assimilated(
         cls, hostname: str, devs: List[str]  # type: ignore

--- a/src/gravel/tests/unit/controllers/nodes/test_disks.py
+++ b/src/gravel/tests/unit/controllers/nodes/test_disks.py
@@ -16,6 +16,7 @@
 
 import os
 from typing import Callable
+
 from pytest_mock import MockerFixture
 
 from gravel.controllers.gstate import GlobalState
@@ -30,8 +31,7 @@ def test_solution(
 ) -> None:
 
     from gravel.cephadm.models import NodeInfoModel
-    from gravel.controllers.nodes.disks import Disks
-    from gravel.controllers.nodes.disks import DiskSolution
+    from gravel.controllers.nodes.disks import Disks, DiskSolution
 
     fake_inventory: NodeInfoModel = NodeInfoModel.parse_raw(
         get_data_contents(DATA_DIR, "disks_local_inventory.json")
@@ -52,9 +52,9 @@ def test_device_to_disk(
 
     from gravel.cephadm.models import VolumeDeviceModel
     from gravel.controllers.nodes.disks import (
-        _device_to_disk,
         DiskModel,
         DiskTypeEnum,
+        _device_to_disk,
     )
 
     device: VolumeDeviceModel = VolumeDeviceModel.parse_raw(
@@ -72,8 +72,7 @@ def test_solution_with_ssd(
     gstate: GlobalState,
 ) -> None:
     from gravel.cephadm.models import NodeInfoModel
-    from gravel.controllers.nodes.disks import Disks
-    from gravel.controllers.nodes.disks import DiskSolution
+    from gravel.controllers.nodes.disks import Disks, DiskSolution
 
     fake_inventory: NodeInfoModel = NodeInfoModel.parse_raw(
         get_data_contents(DATA_DIR, "disks_local_inventory_with_ssd.json")

--- a/src/gravel/tests/unit/controllers/nodes/test_etcd.py
+++ b/src/gravel/tests/unit/controllers/nodes/test_etcd.py
@@ -16,9 +16,10 @@
 
 
 from typing import Callable, List, cast
+
 import pytest
-from pytest_mock import MockerFixture
 from pyfakefs import fake_filesystem
+from pytest_mock import MockerFixture
 
 from gravel.controllers.gstate import GlobalState
 from gravel.tests.unit.asyncio import FakeProcess
@@ -129,8 +130,8 @@ async def test_fail_etcd_pull_image(
 
     mocker.patch("asyncio.create_subprocess_exec", new=mock_subprocess)
     from gravel.controllers.nodes.etcd import (
-        etcd_pull_image,
         ContainerFetchError,
+        etcd_pull_image,
     )
 
     try:

--- a/src/gravel/tests/unit/controllers/nodes/test_host.py
+++ b/src/gravel/tests/unit/controllers/nodes/test_host.py
@@ -15,10 +15,10 @@
 
 import os
 from typing import Callable, List, Optional, Tuple
-import pytest
-from pytest_mock import MockerFixture
-from pyfakefs import fake_filesystem
 
+import pytest
+from pyfakefs import fake_filesystem
+from pytest_mock import MockerFixture
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
 
@@ -47,7 +47,7 @@ async def test_set_hostname(
     ) -> Tuple[int, Optional[str], Optional[str]]:
         return 1, None, "oops"
 
-    from gravel.controllers.nodes.host import set_hostname, HostnameCtlError
+    from gravel.controllers.nodes.host import HostnameCtlError, set_hostname
 
     mocker.patch("socket.gethostname", return_value="myhostname")
 

--- a/src/gravel/tests/unit/controllers/nodes/test_mgr.py
+++ b/src/gravel/tests/unit/controllers/nodes/test_mgr.py
@@ -15,9 +15,10 @@
 # pyright: reportUnknownMemberType=false, reportUnknownVariableType=false
 
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple, cast
+
 import pytest
-from pytest_mock import MockerFixture
 from pyfakefs import fake_filesystem
+from pytest_mock import MockerFixture
 
 from gravel.controllers.gstate import GlobalState
 from gravel.controllers.nodes.conn import IncomingConnection
@@ -107,8 +108,8 @@ async def test_mgr_start(
     mocker: MockerFixture,
 ) -> None:
 
-    from gravel.controllers.nodes.mgr import NodeError, NodeStateModel
     from gravel.controllers.nodes.deployment import NodeStageEnum
+    from gravel.controllers.nodes.mgr import NodeError, NodeStateModel
 
     nodemgr = NodeMgr(gstate)
     assert nodemgr._state
@@ -227,8 +228,8 @@ async def test_node_start(
     nodemgr: NodeMgr,
 ) -> None:
 
-    from gravel.controllers.nodes.mgr import NodeInitStage
     from gravel.controllers.nodes.deployment import NodeStageEnum
+    from gravel.controllers.nodes.mgr import NodeInitStage
 
     nodemgr._deployment._state._stage = NodeStageEnum.READY
 
@@ -292,7 +293,7 @@ async def test_start_ceph(gstate: GlobalState, mocker: MockerFixture) -> None:
 
 def test_node_shutdown(gstate: GlobalState, mocker: MockerFixture) -> None:
 
-    from gravel.controllers.nodes.mgr import NodeMgr, NodeInitStage
+    from gravel.controllers.nodes.mgr import NodeInitStage, NodeMgr
 
     class FakeTask:
         called = False
@@ -323,11 +324,11 @@ def test_generate_token(gstate: GlobalState) -> None:
 async def test_join_checks(gstate: GlobalState) -> None:
 
     from gravel.controllers.nodes.mgr import (
+        JoinParamsModel,
         NodeCantJoinError,
-        NodeNotStartedError,
         NodeError,
         NodeInitStage,
-        JoinParamsModel,
+        NodeNotStartedError,
     )
 
     nodemgr = NodeMgr(gstate)
@@ -369,12 +370,12 @@ async def test_join_check_disk_solution(
     gstate: GlobalState, mocker: MockerFixture, nodemgr: NodeMgr
 ) -> None:
 
+    from gravel.controllers.nodes.disks import DiskSolution
     from gravel.controllers.nodes.mgr import (
+        JoinParamsModel,
         NodeCantJoinError,
         NodeInitStage,
-        JoinParamsModel,
     )
-    from gravel.controllers.nodes.disks import DiskSolution
 
     nodemgr._init_stage = NodeInitStage.AVAILABLE
 
@@ -418,9 +419,10 @@ async def test_join(
 ) -> None:
 
     from uuid import UUID
-    from gravel.controllers.nodes.mgr import NodeInitStage, JoinParamsModel
-    from gravel.controllers.nodes.disks import DiskSolution, DiskModel
+
     from gravel.controllers.nodes.deployment import DeploymentDisksConfig
+    from gravel.controllers.nodes.disks import DiskModel, DiskSolution
+    from gravel.controllers.nodes.mgr import JoinParamsModel, NodeInitStage
 
     def mock_solution(gstate: GlobalState) -> DiskSolution:
         return DiskSolution(
@@ -493,13 +495,13 @@ async def test_join(
 @pytest.mark.asyncio
 async def test_deploy_checks(gstate: GlobalState, nodemgr: NodeMgr) -> None:
 
+    from gravel.controllers.nodes.deployment import NodeStageEnum
     from gravel.controllers.nodes.mgr import (
+        DeployParamsModel,
+        NodeCantDeployError,
         NodeInitStage,
         NodeNotStartedError,
-        NodeCantDeployError,
-        DeployParamsModel,
     )
-    from gravel.controllers.nodes.deployment import NodeStageEnum
 
     nodemgr._init_stage = NodeInitStage.NONE
     throws = False
@@ -556,8 +558,8 @@ async def test_deploy_checks(gstate: GlobalState, nodemgr: NodeMgr) -> None:
 async def test_deploy_check_disk_solution(
     gstate: GlobalState, mocker: MockerFixture, nodemgr: NodeMgr
 ) -> None:
-    from gravel.controllers.nodes.mgr import NodeInitStage, NodeCantDeployError
     from gravel.controllers.nodes.disks import DiskSolution
+    from gravel.controllers.nodes.mgr import NodeCantDeployError, NodeInitStage
 
     nodemgr._init_stage = NodeInitStage.AVAILABLE
 
@@ -598,10 +600,10 @@ async def test_deploy(
     gstate: GlobalState, mocker: MockerFixture, nodemgr: NodeMgr
 ) -> None:
 
-    from gravel.controllers.nodes.mgr import NodeInitStage
-    from gravel.controllers.nodes.disks import DiskSolution, DiskModel
-    from gravel.controllers.nodes.deployment import DeploymentConfig
     from gravel.controllers.auth import UserMgr, UserModel
+    from gravel.controllers.nodes.deployment import DeploymentConfig
+    from gravel.controllers.nodes.disks import DiskModel, DiskSolution
+    from gravel.controllers.nodes.mgr import NodeInitStage
 
     called_mock_deploy = False
 
@@ -775,11 +777,11 @@ async def test_finish_deployment(
     gstate: GlobalState, mocker: MockerFixture, nodemgr: NodeMgr
 ) -> None:
 
+    from gravel.controllers.nodes.deployment import NodeStageEnum
     from gravel.controllers.nodes.mgr import (
         NodeAlreadyJoiningError,
         NodeNotDeployedError,
     )
-    from gravel.controllers.nodes.deployment import NodeStageEnum
 
     orig_mark_ready = nodemgr._deployment._state.mark_ready
     nodemgr._deployment._state.mark_ready = mocker.MagicMock()
@@ -839,12 +841,13 @@ async def test_handle_join(
 ) -> None:
 
     from fastapi import status
+
     from gravel.controllers.nodes.messages import (
-        MessageModel,
-        JoinMessageModel,
         ErrorMessageModel,
-        WelcomeMessageModel,
+        JoinMessageModel,
+        MessageModel,
         MessageTypeEnum,
+        WelcomeMessageModel,
     )
 
     nodemgr._token = "751b-51fd-10d7-f7b4"

--- a/src/gravel/tests/unit/controllers/nodes/test_systemdisk.py
+++ b/src/gravel/tests/unit/controllers/nodes/test_systemdisk.py
@@ -16,12 +16,12 @@
 
 import os
 from typing import Callable, List, Optional, Tuple
+
 import pytest
-from pytest_mock import MockerFixture
 from pyfakefs import fake_filesystem
+from pytest_mock import MockerFixture
 
 from gravel.controllers.gstate import GlobalState
-
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
 
@@ -33,7 +33,7 @@ def test_get_mounts(fs: fake_filesystem.FakeFilesystem) -> None:
         target_path="/proc/mounts",
     )
 
-    from gravel.controllers.nodes.systemdisk import get_mounts, MountEntry
+    from gravel.controllers.nodes.systemdisk import MountEntry, get_mounts
 
     lst: List[MountEntry] = get_mounts()
     found = False
@@ -53,7 +53,7 @@ def test_silly_mounts(fs: fake_filesystem.FakeFilesystem) -> None:
         target_path="/proc/mounts",
     )
 
-    from gravel.controllers.nodes.systemdisk import get_mounts, MountEntry
+    from gravel.controllers.nodes.systemdisk import MountEntry, get_mounts
 
     lst: List[MountEntry] = get_mounts()
     assert len(lst) == 2
@@ -116,7 +116,7 @@ async def test_lvm(mocker: MockerFixture, gstate: GlobalState) -> None:
     mocker.patch(
         "gravel.controllers.nodes.systemdisk.aqr_run_cmd", new=mock_success_call
     )
-    from gravel.controllers.nodes.systemdisk import SystemDisk, LVMError
+    from gravel.controllers.nodes.systemdisk import LVMError, SystemDisk
 
     systemdisk = SystemDisk(gstate)
     await systemdisk.lvm("foo bar baz")
@@ -150,8 +150,8 @@ async def test_create(
 
     from gravel.controllers.nodes.systemdisk import (
         SystemDisk,
-        UnknownDeviceError,
         UnavailableDeviceError,
+        UnknownDeviceError,
     )
     from gravel.controllers.resources.inventory import Inventory, NodeInfoModel
 
@@ -203,7 +203,7 @@ async def test_mount_error(
     mocker.patch(
         "gravel.controllers.nodes.systemdisk.aqr_run_cmd", new=mock_call
     )
-    from gravel.controllers.nodes.systemdisk import SystemDisk, MountError
+    from gravel.controllers.nodes.systemdisk import MountError, SystemDisk
 
     systemdisk = SystemDisk(gstate)
     asserted = False
@@ -237,7 +237,7 @@ async def test_unmount_error(
     mocker.patch(
         "gravel.controllers.nodes.systemdisk.aqr_run_cmd", new=mock_call
     )
-    from gravel.controllers.nodes.systemdisk import SystemDisk, MountError
+    from gravel.controllers.nodes.systemdisk import MountError, SystemDisk
 
     systemdisk = SystemDisk(gstate)
     throws = False
@@ -266,9 +266,9 @@ async def test_enable(
 ) -> None:
 
     from gravel.controllers.nodes.systemdisk import (
-        SystemDisk,
         MountError,
         OverlayError,
+        SystemDisk,
     )
 
     async def mount_fail() -> None:

--- a/src/gravel/tests/unit/controllers/orch/test_ceph.py
+++ b/src/gravel/tests/unit/controllers/orch/test_ceph.py
@@ -13,9 +13,9 @@
 
 import json
 import os
-import pytest
-
 from typing import Any, Callable, Dict, Generator
+
+import pytest
 from pyfakefs import fake_filesystem  # pyright: reportMissingTypeStubs=false
 from pytest_mock import MockerFixture
 

--- a/src/gravel/tests/unit/controllers/orch/test_orchestrator.py
+++ b/src/gravel/tests/unit/controllers/orch/test_orchestrator.py
@@ -16,13 +16,13 @@
 import json
 import os
 from typing import Callable, List
+
 from pydantic import parse_obj_as
 from pytest_mock import MockerFixture
 
 from gravel.controllers.gstate import GlobalState
 from gravel.controllers.orch.models import OrchDevicesPerHostModel
 from gravel.controllers.orch.orchestrator import Orchestrator
-
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
 

--- a/src/gravel/tests/unit/controllers/resources/test_inventory.py
+++ b/src/gravel/tests/unit/controllers/resources/test_inventory.py
@@ -15,13 +15,13 @@
 
 import os
 from typing import Callable
+
 import pytest
 from pytest_mock import MockerFixture
 
 from gravel.cephadm.models import NodeInfoModel
 from gravel.controllers.gstate import GlobalState
 from gravel.controllers.resources.inventory import Inventory
-
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
 

--- a/src/gravel/tests/unit/controllers/test_auth.py
+++ b/src/gravel/tests/unit/controllers/test_auth.py
@@ -15,7 +15,7 @@
 
 import pytest
 
-from gravel.controllers.auth import JWT, JWTDenyList, JWTMgr, UserModel, UserMgr
+from gravel.controllers.auth import JWT, JWTDenyList, JWTMgr, UserMgr, UserModel
 from gravel.controllers.config import AuthOptionsModel
 from gravel.controllers.gstate import GlobalState
 

--- a/src/gravel/tests/unit/controllers/test_config.py
+++ b/src/gravel/tests/unit/controllers/test_config.py
@@ -12,6 +12,7 @@
 # GNU General Public License for more details.
 
 from pathlib import Path
+
 from pyfakefs import fake_filesystem  # pyright: reportMissingTypeStubs=false
 
 from gravel.controllers.config import Config

--- a/src/gravel/tests/unit/controllers/test_gstate.py
+++ b/src/gravel/tests/unit/controllers/test_gstate.py
@@ -12,6 +12,7 @@
 # GNU General Public License for more details.
 
 import asyncio
+
 import pytest
 
 from gravel.controllers.gstate import GlobalState

--- a/src/gravel/tests/unit/controllers/test_services.py
+++ b/src/gravel/tests/unit/controllers/test_services.py
@@ -13,9 +13,9 @@
 
 # pyright: reportPrivateUsage=false
 
-import pytest
 from typing import List
 
+import pytest
 from pytest_mock import MockerFixture
 
 from gravel.controllers.gstate import GlobalState
@@ -47,7 +47,7 @@ async def test_create(services: Services, gstate: GlobalState):
 
 @pytest.mark.asyncio
 async def test_create_fail_allocation(services: Services):
-    from gravel.controllers.services import ServiceTypeEnum, NotEnoughSpaceError
+    from gravel.controllers.services import NotEnoughSpaceError, ServiceTypeEnum
 
     with pytest.raises(NotEnoughSpaceError):
         await services.create("foobar", ServiceTypeEnum.CEPHFS, 3000, 2)
@@ -55,7 +55,7 @@ async def test_create_fail_allocation(services: Services):
 
 @pytest.mark.asyncio
 async def test_create_exists(services: Services):
-    from gravel.controllers.services import ServiceTypeEnum, ServiceExistsError
+    from gravel.controllers.services import ServiceExistsError, ServiceTypeEnum
 
     await services.create("foobar", ServiceTypeEnum.CEPHFS, 1000, 1)
     with pytest.raises(ServiceExistsError):
@@ -64,7 +64,7 @@ async def test_create_exists(services: Services):
 
 @pytest.mark.asyncio
 async def test_create_over_allocated(services: Services):
-    from gravel.controllers.services import ServiceTypeEnum, NotEnoughSpaceError
+    from gravel.controllers.services import NotEnoughSpaceError, ServiceTypeEnum
 
     await services.create("foobar", ServiceTypeEnum.CEPHFS, 1000, 2)
     with pytest.raises(NotEnoughSpaceError):
@@ -76,7 +76,7 @@ async def test_create_over_allocated(services: Services):
 async def test_create_not_ready(
     mocker: MockerFixture, services: Services
 ) -> None:
-    from gravel.controllers.services import ServiceTypeEnum, NotReadyError
+    from gravel.controllers.services import NotReadyError, ServiceTypeEnum
 
     services._is_ready = mocker.MagicMock(return_value=False)  # type: ignore
     try:

--- a/src/gravel/tests/unit/controllers/test_utils.py
+++ b/src/gravel/tests/unit/controllers/test_utils.py
@@ -11,10 +11,11 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 
+import asyncio
 from typing import List
+
 import pytest
 from pytest_mock import MockerFixture
-import asyncio
 
 from gravel.tests.unit.asyncio import FakeProcess
 

--- a/src/gravel/typings/aetcd3/client.pyi
+++ b/src/gravel/typings/aetcd3/client.pyi
@@ -3,13 +3,13 @@
 
 # pyright: reportMissingTypeStubs=false
 from typing import (
+    IO,
     Any,
     AsyncIterator,
     Awaitable,
     Callable,
     Dict,
     Generator,
-    IO,
     List,
     Optional,
     Tuple,

--- a/src/gravel/typings/aetcd3/locks.pyi
+++ b/src/gravel/typings/aetcd3/locks.pyi
@@ -3,6 +3,7 @@
 
 # pyright: reportMissingTypeStubs=false
 from typing import Optional
+
 import aetcd3
 from aetcd3.etcdrpc.rpc_pb2 import LeaseKeepAliveResponse
 

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -12,3 +12,13 @@ extend-exclude = '''
   )/
 )
 '''
+
+[tool.isort]
+profile = "black"
+multi_line_output = 3
+include_trailing_comma = true
+force_grid_wrap = 0
+use_parentheses = true
+ensure_newline_before_comments = true
+line_length = 80
+extend_skip_glob = ["glass/*", "gravel/ceph.git/*"]

--- a/src/tox.ini
+++ b/src/tox.ini
@@ -50,22 +50,26 @@ commands =
 basepython = python3
 deps =
     black
+    isort
 modules =
     aquarium.py
     gravel
 commands =
     black {posargs:{[testenv:lint]modules}}
+    isort {posargs:{[testenv:lint]modules}}
 
 [testenv:lint]
 basepython = python3
 skip_install = true
 deps =
     black
+    isort
 modules =
     aquarium.py
     gravel
 commands =
     black --check --diff {posargs:{[testenv:lint]modules}}
+    isort --check-only --diff {posargs:{[testenv:lint]modules}}
 
 [testenv:clean]
 deps = coverage


### PR DESCRIPTION
To further help with consistency across files, use isort to ensure
python imports are done in a logical and predictable way.