### PR TITLE
tools/aqrdev: add --trace option for detailed logging

### DIFF
--- a/tools/aqrdev
+++ b/tools/aqrdev
@@ -511,14 +511,18 @@ def cmd_list(ctx: AppCtx, verbose: bool) -> None:
         click.secho("No deployments found", fg="cyan")
         return
 
-    json_lst: List[Dict[str, Any]] = []
-    for deployment in deployments:
 
-        if ctx.json:
-            json_lst.append(
-                json.loads(deployment.meta.json())
-            )
-            continue
+    if ctx.json:
+        json_list = [json.loads(_.meta.json()) for _ in deployments]
+        print(json.dumps(json_list))
+        return
+
+    if not verbose:
+        for _ in deployments:
+            print(_.name)
+        return
+
+    for deployment in deployments:
 
         header = chr(0x25cf)
         click.secho("{} {}".format(
@@ -533,16 +537,12 @@ def cmd_list(ctx: AppCtx, verbose: bool) -> None:
                 click.style(value, fg="white")
             ))
 
-        if verbose:
-            treeline = chr(0x251c)
-            treeend = chr(0x2514)
+        treeline = chr(0x251c)
+        treeend = chr(0x2514)
 
-            boxname = deployment.box if deployment.box else "unknown"
-            _print(treeline, "created on", str(deployment.created_on))
-            _print(treeend, "box", boxname)
-
-    if ctx.json:
-        print(json.dumps(json_lst))
+        boxname = deployment.box if deployment.box else "unknown"
+        _print(treeline, "created on", str(deployment.created_on))
+        _print(treeend, "box", boxname)
 
 
 #

--- a/tools/aqrdev
+++ b/tools/aqrdev
@@ -315,14 +315,9 @@ def cmd_create(
         return
 
     try:
-        deployment_path = ctx.deployments_path
-        if not deployment_path.exists():
-            deployment_path.mkdir()
-        assert deployment_path.exists()
-
         Deployment.create(
             name, box, provider, num_nodes, num_disks, num_nics,
-            deployment_path, find_root()
+            ctx.deployments_path, find_root()
         )
     except DeploymentPathNotFoundError:
         click.secho("Unable to find deployments path", fg="red")

--- a/tools/aqrdev
+++ b/tools/aqrdev
@@ -46,8 +46,7 @@ from libaqr.misc import (
 )
 from libaqr.vagrant import Vagrant
 
-logging.basicConfig(level=logging.INFO)
-logger: logging.Logger = logging.getLogger("aquarium")
+logger: logging.Logger = None
 
 from functools import partial
 click.option = partial(click.option, show_default=True)
@@ -108,12 +107,21 @@ pass_appctx = make_pass_decorator(AppCtx)
 
 @click.group()
 @click.option("-d", "--debug", flag_value=True)
+@click.option("-t", "--trace", flag_value=True)
 @click.option("--json", flag_value=True)
 @click.pass_context
-def app(ctx: click.Context, debug: bool, json: bool) -> None:
+def app(ctx: click.Context, debug: bool, json: bool, trace: bool) -> None:
 
     if debug:
-        logger.setLevel(logging.DEBUG)
+        logging.basicConfig(level=logging.DEBUG)
+    elif trace:
+        format_str = '%(asctime)s %(levelname)s:%(module)s:%(funcName)s:%(lineno)s:%(message)s'
+        logging.basicConfig(level=logging.DEBUG, format=format_str)
+    else:
+        logging.basicConfig(level=logging.INFO)
+
+    global logger
+    logger = logging.getLogger("aquarium")
 
     rootpath: Optional[Path] = None
 

--- a/tools/libaqr/deployment.py
+++ b/tools/libaqr/deployment.py
@@ -87,9 +87,6 @@ class Deployment:
         mount_path: Optional[Path] = None
     ) -> Deployment:
 
-        if not deployments_path.exists():
-            raise FileNotFoundError(deployments_path)
-
         path = deployments_path.joinpath(name)
         if path.exists():
             logger.debug(f"deployment path exists: '{path}'")
@@ -101,7 +98,7 @@ class Deployment:
 
         try:
             logger.debug(f"creating deployment '{name}'")
-            path.mkdir()
+            path.mkdir(parents=True)
         except Exception as e:
             logger.error(f"unable to create deployment: {str(e)}")
             raise AqrError(f"error creating deployment '{name}': {str(e)}")


### PR DESCRIPTION
The --trace options is an alternative to --debug but
it also includes module name and line number where
the message is produced as well as function name.

Signed-off-by: Kyr Shatskyy <kyrylo.shatskyy@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [issue id or URL on https://github.com/aquarist-labs/aquarium/issues, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The component is the short name of a major module or subsystem, something 
like "tools", "gravel", "glass", "doc", etc.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://github.com/aquarist-labs/aquarium/blob/main/CONTRIBUTING.md

-->

## Checklist
- [ ] References issues, create if required
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test tumbleweed`
- `jenkins run tumbleweed`
- `jenkins test leap`
- `jenkins run leap`

</details>
