### PR TITLE
[RFC] tools: Add pre-commit config

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 80

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,24 @@
+repos:
+-   repo: https://github.com/ambv/black
+    rev: 21.7b0
+    hooks:
+    - id: black
+      language_version: python3.8
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.0.1
+    hooks:
+    - id: trailing-whitespace
+    - id: check-yaml
+    - id: check-added-large-files
+    - id: end-of-file-fixer
+    - id: check-docstring-first
+    - id: debug-statements
+    - id: requirements-txt-fixer
+-   repo: https://gitlab.com/pycqa/flake8
+    rev: 3.9.2
+    hooks:
+    - id: flake8
+-   repo: https://github.com/pycqa/isort
+    rev: 5.9.3
+    hooks:
+      - id: isort


### PR DESCRIPTION
Add configuration for https://pre-commit.com - "A framework for
managing and maintaining multi-language pre-commit hooks."

Hooks:

black and isort like we already have in our tox
configuration

flake8 - "Your Tool For Style Guide Enforcement"

tailing-whitespace - Removes tailing whitespace
check-yaml - Simple yaml checker. Mostly for the config itself
check-added-large-files - Prevents adding large files
end-of-file-fixer - Always have a newline at the end of a file
check-docstring-first - Code must come after a docstring
debug-statements - e.g python debugger imports
requirements-txt-fixer - Sort requirements.txt alphabetically
