### PR TITLE
[tool] Update kiwi and box version requirement to update the build

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -12,5 +12,5 @@ pip
 websockets==8.1
 PyYAML==5.4.1
 git+https://github.com/aquarist-labs/aetcd3/@edf633045ce61c7bbac4d4a6ca15b14f8acfe9cd
-kiwi
-kiwi-boxed-plugin
+kiwi==9.23.56
+kiwi-boxed-plugin==0.2.15


### PR DESCRIPTION
As title, kiwi update a new release the old version build images are no longer exist. So I need to update the version number in order to allow the build to work for all the platforms.  


Signed-off-by: Alex Lau (AvengerMoJo) <alau@suse.com>


