### PR TITLE
deps: Fix potential dependency issues on dev machines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ src/.coverage
 src/gravel/cephadm/cephadm.bin
 tests/vagrant/deployments/
 tests/vagrant/setups/
+tools/venv
 venv/
 virtualenv/
 wheelhouse/

--- a/.wasser/config.yaml
+++ b/.wasser/config.yaml
@@ -55,11 +55,11 @@ routines:
         sudo systemctl start libvirtd
     - name: create foo
       command: |
-        source aquarium/venv/bin/activate
+        source aquarium/tools/venv/bin/activate
         cd aquarium && ./tools/aqua create foo
     - name: start foo
       command: |
-        source aquarium/venv/bin/activate
+        source aquarium/tools/venv/bin/activate
         cd aquarium && ./tools/aqua start foo --conservative
     - name: dump aquarium service log
       command: |

--- a/doc/from-zero-to-hero.md
+++ b/doc/from-zero-to-hero.md
@@ -224,6 +224,12 @@ those changes.
 
 3. `sudo ./tools/run_aquarium.sh`
 
+3. a) you can use `--use-venv` to have a virtual-env created inside the
+      current-working-directory (as "venv") in which the dependencies are
+      installed. This is separate to the virtual-env that was created earlier
+      by `setup-dev.sh` which is used for the purposes of the tools inside
+      `tools/` (such as `aqua`).
+
 4. access your newly running environment at `http://localhost:1337`
 
 And this should cover the initial steps to allow one to start hacking on

--- a/doc/from-zero-to-hero.md
+++ b/doc/from-zero-to-hero.md
@@ -113,7 +113,7 @@ as well as bare-metal hardware environments.
    The script can also replace and rebuild a new pyenv python for you. Just
    reply yes when it ask you cleanup and reinstall pyenv.
 
-4. run `source venv/bin/activate`.
+4. run `source tools/venv/bin/activate`.
 
    You are now in the virtual environment with all the python packages
    in the required versions. If you want to exit and return to your

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,6 +1,5 @@
 aiofiles
 bcrypt==3.2.0
-click==7.1.2
 fastapi==0.63.0
 h11==0.12.0
 pydantic==1.7.3
@@ -11,5 +10,3 @@ uvicorn==0.13.3
 pip
 websockets==8.1
 PyYAML==5.4.1
-kiwi==9.23.56
-kiwi-boxed-plugin==0.2.15

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,0 +1,5 @@
+aiohttp
+click==7.1.2
+pydantic==1.7.3
+kiwi==9.23.56
+kiwi-boxed-plugin==0.2.15

--- a/tools/setup-dev.sh
+++ b/tools/setup-dev.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
 
-dependencies_opensuse_tumbleweed=(
+dependencies_opensuse=(
   "btrfsprogs"
   "git"
   "kpartx"
   "make"
   "python3"
   "python3-kiwi"
+  "python3-devel"
   "nodejs-common"
   "npm"
   "vagrant"
@@ -78,7 +79,7 @@ dependencies_ubuntu=(
   "libvirt-daemon-system"
 )
 
-dependencies_build_python_leap=(
+dependencies_build_python_opensuse=(
   "gcc"
   "automake"
   "bzip2"
@@ -194,7 +195,7 @@ if ${show_dependencies} ; then
 
   case $osid in
     opensuse-tumbleweed | opensuse-leap)
-      echo "  > ${dependencies_opensuse_tumbleweed[*]}"
+      echo "  > ${dependencies_opensuse[*]}"
       ;;
     debian)
       echo "  > ${dependencies_debian[*]}"
@@ -205,7 +206,7 @@ if ${show_dependencies} ; then
     *)
       echo "error: unsupported distribution"
       echo "These are the packages you might need:"
-      echo "  > ${dependencies_opensuse_tumbleweed[*]}"
+      echo "  > ${dependencies_opensuse[*]}"
       exit 1
       ;;
   esac
@@ -218,13 +219,13 @@ if ! ${skip_install_deps} ; then
   case $osid in
     opensuse-tumbleweed | opensuse-leap)
       echo "=> try installing dependencies"
-      sudo zypper --non-interactive install ${dependencies_opensuse_tumbleweed[*]} || {
+      sudo zypper --non-interactive install ${dependencies_opensuse[*]} || {
         echo "Dependency installation failed"
         exit 1
       }
       if [ -n "$pyenv_python" ] ; then
         echo "=> try installing dependencies for building python because --pyenv-python requested"
-        sudo zypper --non-interactive install ${dependencies_build_python_leap[*]} || {
+        sudo zypper --non-interactive install ${dependencies_build_python_opensuse[*]} || {
           echo "Dependency installation failed"
           exit 1
       }


### PR DESCRIPTION
Because setup-dev.sh is ran on the developers machine, it is not okay
to use the system packages which may conflict with the requirements.txt
aquarium is trying to install (for example, the system packages may
already supply a dependency which will mean that pip will then not
install it into the venv).

Instead we should ensure the venv is created without system packages.
This is what is eventually copied into the virtual machine. Before we
copy it in though we need to re-enable the system packages for
librados to work, so we do that manually with sed.

Signed-off-by: Joshua Hesketh <josh@nitrotech.org>