### PR TITLE
gravel: A failing JWT authentication should log out the user

### DIFF
--- a/src/gravel/api/__init__.py
+++ b/src/gravel/api/__init__.py
@@ -34,8 +34,11 @@ class JWTAuthSchema(OAuth2PasswordBearer):
             # Fallback: Try to get it from the headers.
             token = await super().__call__(request)
         # Decode token and do the following checks:
-        jwt_mgr = JWTMgr(state.gstate.config.options.auth)
-        raw_token: JWT = jwt_mgr.get_raw_access_token(token)
+        try:
+            jwt_mgr = JWTMgr(state.gstate.config.options.auth)
+            raw_token: JWT = jwt_mgr.get_raw_access_token(token)
+        except Exception as e:
+            raise HTTPException(status_code=401, detail=str(e))
         # - Is the token revoked?
         deny_list = JWTDenyList(state.gstate.store)
         await deny_list.load()


### PR DESCRIPTION
Fixes: https://github.com/aquarist-labs/aquarium/issues/657

Signed-off-by: Volker Theile <vtheile@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [issue id or URL on https://github.com/aquarist-labs/aquarium/issues, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The component is the short name of a major module or subsystem, something 
like "tools", "gravel", "glass", "doc", etc.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://github.com/aquarist-labs/aquarium/blob/main/CONTRIBUTING.md

-->

## Checklist
- [x] References issues, create if required
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test tumbleweed`
- `jenkins run tumbleweed`
- `jenkins test leap`
- `jenkins run leap`

</details>
