### PR TITLE
glass: Use bootstrap in datatable action dropdown

### DIFF
--- a/src/glass/src/app/shared/components/datatable/datatable.component.html
+++ b/src/glass/src/app/shared/components/datatable/datatable.component.html
@@ -102,22 +102,17 @@
 <ng-template #renderActionButton
              let-items="items"
              let-row="row">
-  <button *ngIf="items.length"
-          mat-icon-button
-          [matMenuTriggerFor]="renderActionMenu"
-          [matMenuTriggerData]="{items: items, row: row}">
-    <mat-icon svgIcon="mdi:dots-vertical"></mat-icon>
-  </button>
-</ng-template>
-
-<mat-menu #renderActionMenu="matMenu">
-  <ng-template matMenuContent
-               let-items="items"
-               let-row="row">
-    <button *ngFor="let item of items"
-            mat-menu-item
-            (click)="item.callback(row)">
-      <span>{{ item.title | translate }}</span>
+  <div ngbDropdown>
+    <button class="btn"
+            title="{{ 'Actions' | translate }}"
+            ngbDropdownToggle>
+      <i class="mdi mdi-dots-vertical"></i>
     </button>
-  </ng-template>
-</mat-menu>
+    <div ngbDropdownMenu>
+      <button ngbDropdownItem *ngFor="let item of items"
+              (click)="item.callback(row)">
+        <span>{{ item.title | translate }}</span>
+      </button>
+    </div>
+  </div>
+</ng-template>

--- a/src/glass/src/app/shared/components/datatable/datatable.component.scss
+++ b/src/glass/src/app/shared/components/datatable/datatable.component.scss
@@ -6,3 +6,13 @@ th.sortable {
     vertical-align: middle;
   }
 }
+
+.dropdown-toggle {
+  text-decoration: none;
+  &:focus {
+    box-shadow: none;
+  }
+  &::after {
+    display: none;
+  }
+}

--- a/src/glass/src/app/shared/components/datatable/datatable.component.spec.ts
+++ b/src/glass/src/app/shared/components/datatable/datatable.component.spec.ts
@@ -178,4 +178,12 @@ describe('DatatableComponent', () => {
     expect(component.sortHeader).toBe('inside.color');
     expect(component.filteredData).toEqual([data.a, data.c, data.b]);
   });
+
+  // This resolve the issue that the action menu closes on data refresh without a seen change.
+  it('should cache the current view', () => {
+    fixture.detectChanges();
+    const oldTableData = component.filteredData;
+    component.data = [data.c, data.b, data.a];
+    expect(oldTableData).toBe(component.filteredData);
+  });
 });

--- a/src/glass/src/app/shared/components/datatable/datatable.component.ts
+++ b/src/glass/src/app/shared/components/datatable/datatable.component.ts
@@ -100,6 +100,7 @@ export class DatatableComponent implements OnInit, OnDestroy {
   protected subscriptions: Subscription = new Subscription();
 
   private sortableColumns: string[] = [];
+  private tableData: DatatableData[] = [];
 
   constructor(private ngZone: NgZone) {}
 
@@ -202,10 +203,14 @@ export class DatatableComponent implements OnInit, OnDestroy {
   }
 
   get filteredData(): DatatableData[] {
-    return _.orderBy(this.data, [this.sortHeader], [this.sortDirection]).slice(
+    const filtered = _.orderBy(this.data, [this.sortHeader], [this.sortDirection]).slice(
       (this.page - 1) * this.pageSize,
       (this.page - 1) * this.pageSize + this.pageSize
     );
+    if (!_.isEqual(filtered, this.tableData)) {
+      this.tableData = filtered;
+    }
+    return this.tableData;
   }
 
   private getSortProp(column: DatatableColumn) {


### PR DESCRIPTION

![actionMenuBootstrapped](https://user-images.githubusercontent.com/16167865/133458026-8777f9ac-24ce-4dfb-a598-6ef2fcdcbf22.png)

---

glass: Use bootstrap in datatable action dropdown

Signed-off-by: Stephan Müller <smueller@suse.com>

---

glass: Cache shown table data

If `data` is updated and the resulting shown page won't change
the current seen table, the table itself will not be re-rendered
as `filteredData` will still result the same object as before.

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test tumbleweed`
- `jenkins run tumbleweed`
- `jenkins test leap`
- `jenkins run leap`

</details>
