### PR TITLE
glass: make cypress wait for elements to be visible

### DIFF
--- a/src/glass/cypress/integration/dive_into_aquarium.js
+++ b/src/glass/cypress/integration/dive_into_aquarium.js
@@ -1,8 +1,9 @@
 describe('Dive into Aquarium', () => {
   it('Visit the first tank', () => {
     cy.visit('/');
-    cy.contains('Create new cluster');
+    cy.contains('Create new cluster').should('be.visible');
     cy.clickButton('Create');
+    cy.contains('This wizard will guide you through the installation process').should('be.visible');
     cy.contains('Start');
     cy.contains('Networking');
     cy.contains('Time');
@@ -11,12 +12,14 @@ describe('Dive into Aquarium', () => {
     cy.contains('Finish');
     cy.contains('Next');
     cy.clickButton('Next');
-    cy.contains('Hostname');
+    cy.contains('Hostname').should('be.visible');
     cy.contains('div', 'Hostname').find('input').type('foohost{enter}');
     cy.clickButton('Next');
-    cy.contains('Use an NTP host on the Internet').click();
+    cy.contains('Use an NTP host on the Internet').should('be.visible').click();
     cy.clickButton('Next');
+    cy.contains('The following devices have been identified in the system').should('be.visible');
     cy.clickButton('Next');
+    cy.contains('Aquarium will now install and setup the core system.').should('be.visible');
     cy.clickButton('Install');
   });
 });


### PR DESCRIPTION
This adds a bunch of ".should('be.visible')" calls to slow cypress
down a bit, and wait for each page of the setup wizard to render
completely before trying to hit the Next/Install buttons.

Signed-off-by: Tim Serong <tserong@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [issue id or URL on https://github.com/aquarist-labs/aquarium/issues, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The component is the short name of a major module or subsystem, something 
like "tools", "gravel", "glass", "doc", etc.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://github.com/aquarist-labs/aquarium/blob/main/CONTRIBUTING.md

-->

## Checklist
- [ ] References issues, create if required
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test tumbleweed`
- `jenkins run tumbleweed`
- `jenkins test leap`
- `jenkins run leap`

</details>
