### PR TITLE
glass: fix languages dropdown list

### DIFF
--- a/src/glass/src/app/shared/components/language-button/language-button.component.html
+++ b/src/glass/src/app/shared/components/language-button/language-button.component.html
@@ -1,4 +1,6 @@
-<div ngbDropdown>
+<div ngbDropdown
+     display="dynamic"
+     placement="bottom-right">
   <button class="btn btn-simple"
           title="{{ 'Language' | translate }}"
           ngbDropdownToggle>


### PR DESCRIPTION
The languages dropdown is cut in the installer layout. Fix the dropdown in order to show the whole menu.

![Screenshot_2021-09-29_10-28-43](https://user-images.githubusercontent.com/8761082/135235125-7edc1937-a880-415f-abd6-509e188704cb.png)

->

![Screenshot_2021-09-29_10-39-29](https://user-images.githubusercontent.com/8761082/135235154-1e6c2d3f-b8a2-41f7-8d6c-b7486b2e18fd.png)


Signed-off-by: Tatjana Dehler <tdehler@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [issue id or URL on https://github.com/aquarist-labs/aquarium/issues, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The component is the short name of a major module or subsystem, something 
like "tools", "gravel", "glass", "doc", etc.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://github.com/aquarist-labs/aquarium/blob/main/CONTRIBUTING.md

-->

## Checklist
- [ ] References issues, create if required
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test tumbleweed`
- `jenkins run tumbleweed`
- `jenkins test leap`
- `jenkins run leap`

</details>
