### PR TITLE
gravel: inventory: log probe times at debug level unless > 30 seconds

### DIFF
--- a/src/gravel/controllers/resources/inventory.py
+++ b/src/gravel/controllers/resources/inventory.py
@@ -70,7 +70,11 @@ class Inventory(Ticker):
         start: int = int(time.monotonic())
         nodeinfo = await cephadm.get_node_info()
         diff: int = int(time.monotonic()) - start
-        logger.info(f"probing took {diff} seconds")
+        log_message = f"probing took {diff} seconds"
+        if diff > 30:
+            logger.info(log_message)
+        else:
+            logger.debug(log_message)
         self._latest = nodeinfo
         await self._publish()
 


### PR DESCRIPTION
Previously, every minute, we'd see "inventory -- probing took 5 seconds"
in the log, which seems mostly like unimportant noise to me, so I've
dropped this to debug level, provided the probe doesn't take more than
30 seconds to complete.  If it's taking *that* long, maybe we do care
to investigate further (although the choice of 30 seconds is pretty
arbitrary on my part).

Signed-off-by: Tim Serong <tserong@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [issue id or URL on https://github.com/aquarist-labs/aquarium/issues, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The component is the short name of a major module or subsystem, something 
like "tools", "gravel", "glass", "doc", etc.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://github.com/aquarist-labs/aquarium/blob/main/CONTRIBUTING.md

-->

## Checklist
- [ ] References issues, create if required
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test tumbleweed`
- `jenkins run tumbleweed`
- `jenkins test leap`
- `jenkins run leap`

</details>
