### PR TITLE
.github: drop `jenkins test` command

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -35,9 +35,8 @@ https://github.com/aquarist-labs/aquarium/blob/main/CONTRIBUTING.md
 <details>
 <summary>Show available Jenkins commands</summary>
 
-- `jenkins test tumbleweed`
 - `jenkins run tumbleweed`
-- `jenkins test leap`
 - `jenkins run leap`
+- `jenkins run ubuntu`
 
 </details>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,7 +161,8 @@ when a pull request is opened. We also have two Jenkins jobs that run
 automatically, to build an Aquarium image and run it on openSUSE
 Tumbleweed and openSUSE Leap. If these tests fail and you need to trigger
 a re-run, add a comment to the PR which says `jenkins run tumbleweed` or
-`jenkins run leap` as needed.
+`jenkins run leap` as needed. Optionally there can be tests triggered
+using `jenkins run ubuntu` for Ubuntu distro.
 
 ## Be Respectful
 


### PR DESCRIPTION
There may be a confusion between which command is better to use
`jenkins test` or `jenkins run`, so we better drop one of them
from the docs and hints.

Also adding info about Ubuntu trigger phrase.

Signed-off-by: Kyr Shatskyy <kyrylo.shatskyy@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [issue id or URL on https://github.com/aquarist-labs/aquarium/issues, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The component is the short name of a major module or subsystem, something 
like "tools", "gravel", "glass", "doc", etc.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://github.com/aquarist-labs/aquarium/blob/main/CONTRIBUTING.md

-->

## Checklist
- [ ] References issues, create if required
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test tumbleweed`
- `jenkins run tumbleweed`
- `jenkins test leap`
- `jenkins run leap`

</details>
