### PR TITLE
Glass: Add 'paragraph' form field

### DIFF
--- a/src/glass/src/app/shared/components/declarative-form/declarative-form.component.html
+++ b/src/glass/src/app/shared/components/declarative-form/declarative-form.component.html
@@ -366,6 +366,20 @@
               </div>
             </div>
           </ng-template>
+
+          <ng-template [ngSwitchCase]="'paragraph'">
+            <div class="form-paragraph">
+              <div *ngIf="field.title"
+                   class="title">
+                {{ field.title | translate }}
+              </div>
+              <hr *ngIf="field.hasDivider">
+              <div *ngIf="field.text"
+                   class="text">
+                {{ field.text | translate }}
+              </div>
+            </div>
+          </ng-template>
         </ng-container>
       </ng-template>
     </ng-container>

--- a/src/glass/src/app/shared/components/declarative-form/declarative-form.component.scss
+++ b/src/glass/src/app/shared/components/declarative-form/declarative-form.component.scss
@@ -6,6 +6,24 @@
   }
 }
 
+.form-paragraph {
+  .title {
+    @extend .h4;
+  }
+
+  hr {
+    @extend .mt-1;
+    @extend .mb-1;
+
+    width: 100%;
+  }
+
+  .text {
+    @extend .text-muted;
+    @extend .mb-2;
+  }
+}
+
 .form-container {
   align-items: baseline;
 

--- a/src/glass/src/app/shared/components/declarative-form/declarative-form.component.ts
+++ b/src/glass/src/app/shared/components/declarative-form/declarative-form.component.ts
@@ -125,6 +125,7 @@ export class DeclarativeFormComponent implements DeclarativeForm, OnInit, OnDest
     _.forEach(fields, (field: FormFieldConfig) => {
       _.defaultsDeep(field, {
         hasCopyToClipboardButton: false,
+        hasDivider: false,
         placeholder: '',
         options: {}
       });
@@ -142,7 +143,7 @@ export class DeclarativeFormComponent implements DeclarativeForm, OnInit, OnDest
     _.forEach(
       _.filter(fields, (field) => _.isFunction(field.onValueChanges)),
       (field: FormFieldConfig) => {
-        const control: AbstractControl | null = this.getControl(field.name);
+        const control: AbstractControl | null = this.getControl(field.name!);
         if (control) {
           this.subscriptions.add(
             control.valueChanges.subscribe((value: any) => {
@@ -185,7 +186,7 @@ export class DeclarativeFormComponent implements DeclarativeForm, OnInit, OnDest
   createForm(): FormGroup {
     const controlsConfig: Record<string, FormControl> = {};
     _.forEach(this.getFields(), (field: FormFieldConfig) => {
-      controlsConfig[field.name] = DeclarativeFormComponent.createFormControl(field);
+      controlsConfig[field.name!] = DeclarativeFormComponent.createFormControl(field);
     });
     return this.formBuilder.group(controlsConfig);
   }
@@ -195,7 +196,7 @@ export class DeclarativeFormComponent implements DeclarativeForm, OnInit, OnDest
   }
 
   onCopyToClipboard(field: FormFieldConfig): void {
-    const text = this.formGroup?.get(field.name)?.value;
+    const text = this.formGroup?.get(field.name!)?.value;
     const messages = {
       success: TEXT('Copied text to the clipboard successfully.'),
       error: TEXT('Failed to copy text to the clipboard.')
@@ -221,9 +222,9 @@ export class DeclarativeFormComponent implements DeclarativeForm, OnInit, OnDest
   get values(): DeclarativeFormValues {
     const values = this.formGroup?.getRawValue() ?? {};
     _.forEach(this.getFields(), (field: FormFieldConfig) => {
-      const value = values[field.name];
+      const value = values[field.name!];
       if (value) {
-        values[field.name] = this.convertToRaw(value, field);
+        values[field.name!] = this.convertToRaw(value, field);
       }
     });
     return values;
@@ -260,13 +261,19 @@ export class DeclarativeFormComponent implements DeclarativeForm, OnInit, OnDest
 
   private getFields(): Array<FormFieldConfig> {
     const flatten = (fields: Array<FormFieldConfig>): Array<FormFieldConfig> =>
-      _.flatMap(fields, (field: FormFieldConfig) => {
-        if (_.isArray(field.fields)) {
-          return flatten(field.fields);
-        } else {
-          return field;
+      _.flatMap(
+        _.filter(
+          fields,
+          (field: FormFieldConfig) => !_.isUndefined(field.name) || _.isArray(field.fields)
+        ),
+        (field: FormFieldConfig) => {
+          if (_.isArray(field.fields)) {
+            return flatten(field.fields);
+          } else {
+            return field;
+          }
         }
-      });
+      );
     return flatten(this.config?.fields || []);
   }
 
@@ -282,7 +289,7 @@ export class DeclarativeFormComponent implements DeclarativeForm, OnInit, OnDest
   private applyModifier(field: FormFieldConfig, modifier: FormFieldModifier) {
     const successful = ConstraintService.test(modifier.constraint, this.values);
     const opposite = _.defaultTo(modifier?.opposite, true);
-    const control: AbstractControl | null = this.getControl(field.name);
+    const control: AbstractControl | null = this.getControl(field.name!);
     switch (modifier.type) {
       case 'readonly':
         if (successful) {

--- a/src/glass/src/app/shared/models/declarative-form-config.type.ts
+++ b/src/glass/src/app/shared/models/declarative-form-config.type.ts
@@ -15,7 +15,7 @@ export type FormFieldModifier = {
 };
 
 export type FormFieldConfig = {
-  name: string;
+  name?: string;
   type:
     | 'text'
     | 'number'
@@ -25,7 +25,8 @@ export type FormFieldConfig = {
     | 'select'
     | 'hidden'
     | 'binary'
-    | 'container';
+    | 'container'
+    | 'paragraph';
   label?: string;
   value?: any;
   placeholder?: string;
@@ -77,6 +78,11 @@ export type FormFieldConfig = {
 
   // --- binary ---
   defaultUnit?: 'b' | 'k' | 'm' | 'g' | 't' | 'p' | 'e' | 'z' | 'y';
+
+  // --- paragraph ---
+  title?: string;
+  text?: string;
+  hasDivider?: boolean;
 
   // internal only
   id?: string;


### PR DESCRIPTION
Example:
```
{
  type: 'paragraph',
  title: 'foo bar baz',
  hasDivider: true,
  text: 'asfdasd asdjnklasd as dklasjd as askldjaskld  askldjaslkjdla'
}
```

Without divider:
![Bildschirmfoto vom 2021-10-21 10-08-13](https://user-images.githubusercontent.com/1897962/138238593-77918f87-7ae0-4afe-9ac0-417ae1a3ed76.png)

With divider:
![Bildschirmfoto vom 2021-10-21 10-15-03](https://user-images.githubusercontent.com/1897962/138238635-ead27f5e-43e7-414d-9c24-b886e22947e2.png)

Signed-off-by: Volker Theile <vtheile@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [issue id or URL on https://github.com/aquarist-labs/aquarium/issues, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The component is the short name of a major module or subsystem, something 
like "tools", "gravel", "glass", "doc", etc.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://github.com/aquarist-labs/aquarium/blob/main/CONTRIBUTING.md

-->

## Checklist
- [ ] References issues, create if required
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins run tumbleweed`
- `jenkins run leap`
- `jenkins run ubuntu`

</details>
