### PR TITLE
glass: update port number

### DIFF
--- a/src/glass/proxy.conf.json
+++ b/src/glass/proxy.conf.json
@@ -1,6 +1,6 @@
 {
   "/api": {
-    "target": "http://localhost:80",
+    "target": "http://localhost:18080",
     "secure": false
   }
 }


### PR DESCRIPTION
I'm not really sure why but I can't reach the API via `http://localhost:80`. `18080` works for me only. If it's an issue with my deployment, feel free to close the PR :upside_down_face:

Signed-off-by: Tatjana Dehler <tdehler@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [issue id or URL on https://github.com/aquarist-labs/aquarium/issues, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The component is the short name of a major module or subsystem, something 
like "tools", "gravel", "glass", "doc", etc.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://github.com/aquarist-labs/aquarium/blob/main/CONTRIBUTING.md

-->

## Checklist
- [ ] References issues, create if required
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins run tumbleweed`
- `jenkins run leap`
- `jenkins run ubuntu`

</details>
