### PR TITLE
tools: Fix Kiwi issue when using a container to build the Vagrant image

### DIFF
--- a/images/builder/Dockerfile
+++ b/images/builder/Dockerfile
@@ -18,8 +18,10 @@ LABEL aquarium.github="https://github.com/aquarist-labs/aquarium"
 LABEL version="0.1.0"
 LABEL description="Aquarium image builder"
 
+# Use the latest Kiwi version.
+RUN zypper ar --repo http://download.opensuse.org/repositories/Virtualization:/Appliances:/Builder/openSUSE_Leap_15.3/Virtualization:Appliances:Builder.repo
 
-RUN zypper ref
+RUN zypper --gpg-auto-import-keys ref
 RUN zypper --non-interactive install \
   git python3 python3-pip python3-rados \
   python3-kiwi nodejs-common npm \


### PR DESCRIPTION
Make sure we use the latest Kiwi version (which includes a fix to workaround the problem of aquarist-labs#738).

Fixes: https://github.com/aquarist-labs/aquarium/issues/738

Signed-off-by: Volker Theile <vtheile@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [issue id or URL on https://github.com/aquarist-labs/aquarium/issues, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The component is the short name of a major module or subsystem, something 
like "tools", "gravel", "glass", "doc", etc.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://github.com/aquarist-labs/aquarium/blob/main/CONTRIBUTING.md

-->

## Checklist
- [x] References issues, create if required
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins run tumbleweed`
- `jenkins run leap`
- `jenkins run ubuntu`

</details>
