### PR TITLE
gravel: check registry before deployment

### DIFF
--- a/src/gravel/controllers/containers.py
+++ b/src/gravel/controllers/containers.py
@@ -69,7 +69,7 @@ async def registry_check(registry: str, image: str, secure: bool) -> None:
     # check for an existing registry
     #
     try:
-        req = requests.get(f"{proto}://{registry}/v2/")
+        req = requests.get(f"{proto}://{registry}/v2/", timeout=5)
         if req.status_code != requests.codes.ok:
             raise UnknownRegistryError(
                 registry,

--- a/src/gravel/controllers/containers.py
+++ b/src/gravel/controllers/containers.py
@@ -8,8 +8,9 @@
 #
 import shlex
 from pathlib import Path
-from typing import Any, Dict, MutableMapping
+from typing import Any, Dict, MutableMapping, Optional
 
+import requests
 import toml
 
 from gravel.controllers.errors import GravelError
@@ -24,6 +25,90 @@ class ContainerError(GravelError):
 
 class ContainerPullError(ContainerError):
     pass
+
+
+class ContainerRegistryError(ContainerError):
+    registry: str
+
+    def __init__(self, registry: str, msg: Optional[str] = None) -> None:
+        super().__init__(msg)
+        self.registry = registry
+
+
+class UnknownRegistryError(ContainerRegistryError):
+    pass
+
+
+class RegistrySecurityError(ContainerRegistryError):
+    pass
+
+
+class ContainerImageError(ContainerError):
+    image: str
+
+    def __init__(self, image: str, msg: Optional[str] = None) -> None:
+        super().__init__(msg)
+        self.image = image
+
+
+class ImageNameError(ContainerImageError):
+    pass
+
+
+class UnknownImageError(ContainerImageError):
+    pass
+
+
+class UnknownImageTagError(ContainerImageError):
+    pass
+
+
+async def registry_check(registry: str, image: str, secure: bool) -> None:
+
+    proto = "https" if secure else "http"
+    # check for an existing registry
+    #
+    try:
+        req = requests.get(f"{proto}://{registry}/v2/")
+        if req.status_code != requests.codes.ok:
+            raise UnknownRegistryError(
+                registry,
+                msg=f"Error connecting to registry at '{registry}: {req.text}",
+            )
+    except requests.exceptions.SSLError:
+        req_proto = "https" if not secure else "http"
+        raise RegistrySecurityError(
+            registry,
+            msg=f"Registry at '{registry}' requires an {req_proto} connection.",
+        )
+    except requests.exceptions.ConnectionError as e:
+        raise UnknownRegistryError(
+            registry,
+            msg=f"Error connecting to registry at '{registry}': {str(e)}",
+        )
+
+    # check for image:tag
+    #
+    img = image.split(":")
+    if len(img) != 2:
+        raise ImageNameError(image, msg="Missing tag information from image.")
+    (imgname, imgtag) = img
+
+    try:
+        req = requests.get(f"{proto}://{registry}/v2/{imgname}/tags/list")
+    except Exception as e:
+        raise ContainerError(msg=str(e))
+
+    if req.status_code != requests.codes.ok:
+        raise UnknownImageError(
+            imgname, msg=f"Could not find image '{imgname}'."
+        )
+    res = req.json()
+    assert res["name"] == imgname
+    if imgtag not in res["tags"]:
+        raise UnknownImageTagError(
+            image, msg=f"Could not find image '{imgname}' with tag '{imgtag}'."
+        )
 
 
 async def container_pull(registry: str, image: str) -> str:

--- a/src/gravel/controllers/nodes/deployment.py
+++ b/src/gravel/controllers/nodes/deployment.py
@@ -26,6 +26,7 @@ from gravel.controllers.ceph.orchestrator import Orchestrator
 from gravel.controllers.containers import (
     ContainerPullError,
     container_pull,
+    registry_check,
     set_registry,
 )
 from gravel.controllers.errors import GravelError
@@ -275,6 +276,25 @@ class NodeDeployment:
 
         return 0
 
+    async def _prepare_check(
+        self,
+        containerconf: Optional[DeploymentContainerConfig] = None,
+    ) -> None:
+
+        # check container image exists
+        #
+        ctrcfg = self._gstate.config.options.containers
+        if containerconf is not None:
+            assert len(containerconf.url) > 0
+            assert len(containerconf.image) > 0
+            ctrcfg.registry = containerconf.url
+            ctrcfg.secure = containerconf.secure
+            ctrcfg.image = containerconf.image
+
+        logger.debug(f"prepare_check > registry: {ctrcfg}")
+        # propagate exceptions to caller, let them handle the various errors.
+        await registry_check(ctrcfg.registry, ctrcfg.image, ctrcfg.secure)
+
     async def _prepare_node(
         self,
         sysdiskpath: str,
@@ -283,7 +303,6 @@ class NodeDeployment:
         pubkey: Optional[str],
         keyring: Optional[str],
         cephconf: Optional[str],
-        containerconf: Optional[DeploymentContainerConfig],
         is_join: bool,
         progress_cb: Optional[Callable[[int, Optional[str]], None]],
     ) -> None:
@@ -352,13 +371,6 @@ class NodeDeployment:
 
         progress(50, "Obtaining containers")
         ctrcfg = self._gstate.config.options.containers
-        if containerconf is not None:
-            assert len(containerconf.url) > 0
-            assert len(containerconf.image) > 0
-            ctrcfg.registry = containerconf.url
-            ctrcfg.secure = containerconf.secure
-            ctrcfg.image = containerconf.image
-
         try:
             await set_registry(ctrcfg.registry, ctrcfg.secure)
             await container_pull(ctrcfg.registry, ctrcfg.image)
@@ -427,7 +439,6 @@ class NodeDeployment:
             pubkey=welcome.pubkey,
             keyring=welcome.keyring,
             cephconf=welcome.cephconf,
-            containerconf=None,
             is_join=True,
             progress_cb=None,
         )
@@ -532,6 +543,12 @@ class NodeDeployment:
         if self._state.error:
             raise NodeCantDeployError("Node is in error state.")
 
+        try:
+            await self._prepare_check(containerconf=config.container)
+        except Exception:
+            logger.error("Unable to start deployment: prepare checks failed.")
+            raise NodeCantDeployError("failure checking node")
+
         self._progress = ProgressEnum.PREPARING
 
         await self._prepare_node(
@@ -542,7 +559,6 @@ class NodeDeployment:
             keyring=None,
             cephconf=None,
             is_join=False,
-            containerconf=config.container,
             progress_cb=None,
         )
 

--- a/src/gravel/controllers/nodes/deployment.py
+++ b/src/gravel/controllers/nodes/deployment.py
@@ -461,18 +461,6 @@ class NodeDeployment:
         post_bootstrap_cb: Callable[[bool, Optional[str]], Awaitable[None]],
         finisher: Callable[[bool, Optional[str]], Awaitable[None]],
     ) -> None:
-
-        assert config.hostname
-        assert config.address
-        assert config.token
-        assert config.ntp_addr
-
-        hostname = config.hostname
-        address = config.address
-
-        if self._state.error:
-            raise NodeCantDeployError("Node is in error state.")
-
         async def _start() -> None:
             assert self._state
             assert self._state.nostage
@@ -530,6 +518,19 @@ class NodeDeployment:
             self._progress = ProgressEnum.ASSIMILATING
             await self._assimilate_devices(hostname, devices)
             logger.debug("deployment > devices assimilated")
+
+        assert config.hostname
+        assert config.address
+        assert config.token
+        assert config.ntp_addr
+
+        hostname = config.hostname
+        address = config.address
+
+        logger.debug(f"deploy > hostname: {hostname}, addr: {address}")
+
+        if self._state.error:
+            raise NodeCantDeployError("Node is in error state.")
 
         self._progress = ProgressEnum.PREPARING
 

--- a/src/gravel/tests/unit/controllers/nodes/test_deployment.py
+++ b/src/gravel/tests/unit/controllers/nodes/test_deployment.py
@@ -172,6 +172,10 @@ async def test_deploy(mocker: MockerFixture, gstate: GlobalState):
         "gravel.controllers.nodes.deployment.set_registry",
         new=mock_set_registry,
     )
+    mocker.patch(
+        "gravel.controllers.nodes.deployment.registry_check",
+        new=mocker.AsyncMock(),
+    )
 
     from gravel.controllers.ceph.orchestrator import Orchestrator
     from gravel.controllers.nodes.bootstrap import Bootstrap

--- a/src/gravel/tests/unit/controllers/test_containers.py
+++ b/src/gravel/tests/unit/controllers/test_containers.py
@@ -1,0 +1,110 @@
+# project aquarium's backend
+# Copyright (C) 2021 SUSE, LLC.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+import pytest
+import requests
+import requests_mock
+
+from gravel.controllers.containers import (
+    ImageNameError,
+    RegistrySecurityError,
+    UnknownImageError,
+    UnknownImageTagError,
+    UnknownRegistryError,
+    registry_check,
+)
+
+
+@pytest.mark.asyncio
+async def test_registry_check_existing(
+    requests_mock: requests_mock.Mocker,
+) -> None:
+    requests_mock.get("http://secure.bar/v2/", exc=requests.exceptions.SSLError)
+    requests_mock.get("https://secure.bar/v2/")
+    requests_mock.get("http://insecure.bar/v2/")
+    requests_mock.get(
+        "https://insecure.bar/v2/", exc=requests.exceptions.SSLError
+    )
+    requests_mock.get(
+        "https://dne.tld/v2/", exc=requests.exceptions.ConnectionError
+    )
+
+    imgres = {
+        "name": "image/name",
+        "tags": ["tag"],
+    }
+    requests_mock.get("https://secure.bar/v2/image/name/tags/list", json=imgres)
+    requests_mock.get(
+        "http://insecure.bar/v2/image/name/tags/list", json=imgres
+    )
+
+    raised = False
+    await registry_check("secure.bar", "image/name:tag", True)
+    try:
+        await registry_check("secure.bar", "image/name:tag", False)
+    except RegistrySecurityError:
+        raised = True
+    assert raised
+
+    raised = False
+    await registry_check("insecure.bar", "image/name:tag", False)
+    try:
+        await registry_check("insecure.bar", "image/name:tag", True)
+    except RegistrySecurityError:
+        raised = True
+    assert raised
+
+    raised = False
+    try:
+        await registry_check("dne.tld", "image/name:tag", True)
+    except UnknownRegistryError:
+        raised = True
+    assert raised
+
+
+@pytest.mark.asyncio
+async def test_registry_check_image(
+    requests_mock: requests_mock.Mocker,
+) -> None:
+    res = {
+        "name": "image/name",
+        "tags": ["tag"],
+    }
+    requests_mock.get("https://secure.tld/v2/")
+    requests_mock.get("https://secure.tld/v2/image/name/tags/list", json=res)
+    requests_mock.get(
+        "https://secure.tld/v2/image/dne/tags/list", status_code=404
+    )
+
+    await registry_check("secure.tld", "image/name:tag", True)
+
+    raised = False
+    try:
+        await registry_check("secure.tld", "image/name", True)
+    except ImageNameError:
+        raised = True
+    assert raised
+
+    raised = False
+    try:
+        await registry_check("secure.tld", "image/dne:tag", True)
+    except UnknownImageError:
+        raised = True
+    assert raised
+
+    raised = False
+    try:
+        await registry_check("secure.tld", "image/name:dne", True)
+    except UnknownImageTagError:
+        raised = True
+    assert raised

--- a/src/requirements-test.txt
+++ b/src/requirements-test.txt
@@ -6,7 +6,9 @@ pytest-asyncio
 pytest-cov
 pytest-datadir
 pytest-mock
-requests
 types-psutil
 types-PyYAML
 types-toml
+types-requests
+requests-mock
+

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -5,6 +5,7 @@ h11==0.12.0
 pydantic==1.7.3
 python-multipart==0.0.5
 pyjwt==2.1.0
+requests==2.25.1
 starlette==0.13.6
 uvicorn==0.13.3
 pip
@@ -12,3 +13,4 @@ psutil==5.8.0
 websockets==8.1
 PyYAML==5.4.1
 toml==0.10.2
+


### PR DESCRIPTION
With this patch set we now check whether a registry is reachable, and the container image exists at the registry, before allowing the node to deploy.

The major issue with this patch set is that it perpetuates the bad habit of not handling exceptions in an ideal way, conveying to the caller what might be wrong (aside from something being wrong). This, I believe, needs to be addressed as a whole in a future patch set.

Signed-off-by: Joao Eduardo Luis \<joao@suse.com>