### PR TITLE
gravel: add network controller and API endpoints

### DIFF
--- a/images/aquarium/config.xml
+++ b/images/aquarium/config.xml
@@ -582,6 +582,7 @@
         <package name="xfsprogs"/>
         <package name="python38-pip"/>
         <package name="python38-aiofiles"/>
+        <package name="python38-atomicwrites"/>
         <package name="python38-requests"/>
         <package name="python38-PyYAML"/>
         <package name="python3-rados"/>

--- a/src/aquarium.py
+++ b/src/aquarium.py
@@ -29,6 +29,7 @@ from gravel.controllers.gstate import GlobalState, setup_logging
 from gravel.controllers.inventory.inventory import Inventory
 from gravel.controllers.nodes.mgr import NodeMgr
 from gravel.controllers.resources.devices import Devices
+from gravel.controllers.resources.network import Network
 from gravel.controllers.resources.status import Status
 from gravel.controllers.resources.storage import Storage
 
@@ -80,6 +81,9 @@ async def aquarium_startup(_: FastAPI, aquarium_api: FastAPI):
         gstate.config.options.storage.probe_interval, nodemgr, ceph_mon
     )
     gstate.add_storage(storage)
+
+    network: Network = Network(gstate.config.options.network.probe_interval)
+    gstate.add_network(network)
 
     await nodemgr.start()
     await gstate.start()

--- a/src/gravel/api/local.py
+++ b/src/gravel/api/local.py
@@ -29,7 +29,7 @@ from gravel.controllers.nodes.requirements import (
     RequirementsModel,
     localhost_qualified,
 )
-from gravel.controllers.resources.network import InterfaceModel, RouteModel
+from gravel.controllers.resources.network import NetworkConfigModel
 from gravel.controllers.utils import aqr_run_cmd
 
 logger: Logger = fastapi_logger
@@ -49,12 +49,6 @@ class EventModel(BaseModel):
     ts: int = Field(title="The Unix time stamp")
     severity: Literal["info", "warn", "danger"]
     message: str
-
-
-class NetworkConfigModel(BaseModel):
-    interfaces: Dict[str, InterfaceModel]
-    nameservers: List[str]
-    routes: List[RouteModel]
 
 
 @router.get(

--- a/src/gravel/api/local.py
+++ b/src/gravel/api/local.py
@@ -12,7 +12,7 @@
 # GNU General Public License for more details.
 
 from logging import Logger
-from typing import Callable, List, Literal
+from typing import Callable, Dict, List, Literal
 
 from fastapi import Depends, HTTPException, Request, status
 from fastapi.logger import logger as fastapi_logger
@@ -29,6 +29,7 @@ from gravel.controllers.nodes.requirements import (
     RequirementsModel,
     localhost_qualified,
 )
+from gravel.controllers.resources.network import InterfaceModel, RouteModel
 from gravel.controllers.utils import aqr_run_cmd
 
 logger: Logger = fastapi_logger
@@ -48,6 +49,12 @@ class EventModel(BaseModel):
     ts: int = Field(title="The Unix time stamp")
     severity: Literal["info", "warn", "danger"]
     message: str
+
+
+class NetworkConfigModel(BaseModel):
+    interfaces: Dict[str, InterfaceModel]
+    nameservers: List[str]
+    routes: List[RouteModel]
 
 
 @router.get(
@@ -199,3 +206,43 @@ async def shutdown(_: Callable = Depends(jwt_auth_scheme)) -> None:
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Unable to shutdown the system: {stderr}",
         )
+
+
+@router.get(
+    "/network/config",
+    name="Obtain local node's network configuration",
+    response_model=NetworkConfigModel,
+)
+async def get_network_config(
+    request: Request, _=Depends(jwt_auth_scheme)
+) -> NetworkConfigModel:
+    """
+    Obtain this node's network configuration.
+    """
+
+    network = request.app.state.gstate.network
+    return NetworkConfigModel(
+        interfaces=network.interfaces,
+        nameservers=network.nameservers,
+        routes=network.routes,
+    )
+
+
+@router.post(
+    "/network/config",
+    name="Apply network config",
+    response_model=bool,
+)
+async def apply_network_config(
+    request: Request,
+    req_params: NetworkConfigModel,
+    _=Depends(jwt_auth_scheme),
+) -> bool:
+
+    network = request.app.state.gstate.network
+    await network.apply_config(
+        req_params.interfaces, req_params.nameservers, req_params.routes
+    )
+
+    # TODO: Make this return something sensible on failure
+    return True

--- a/src/gravel/api/nodes.py
+++ b/src/gravel/api/nodes.py
@@ -39,6 +39,7 @@ from gravel.controllers.nodes.mgr import (
     JoinParamsModel,
     NodeMgr,
 )
+from gravel.controllers.resources.network import NetworkConfigModel
 
 logger: Logger = fastapi_logger
 router = APIRouter(prefix="/nodes", tags=["nodes"])
@@ -73,7 +74,11 @@ class DeployStatusReplyModel(BaseModel):
 class NodeJoinRequestModel(BaseModel):
     address: str
     token: str
+    # Should we maybe collapse these next two params into a
+    # JoinParamsModel, which we could then pass straight through
+    # to nodemgr.join?
     hostname: str
+    network: Optional[NetworkConfigModel]
 
 
 class TokenReplyModel(BaseModel):
@@ -215,7 +220,9 @@ async def node_join(
 
     nodemgr = request.app.state.nodemgr
     return await nodemgr.join(
-        req.address, req.token, JoinParamsModel(hostname=req.hostname)
+        req.address,
+        req.token,
+        JoinParamsModel(hostname=req.hostname, network=req.network),
     )
 
 

--- a/src/gravel/controllers/config.py
+++ b/src/gravel/controllers/config.py
@@ -49,6 +49,10 @@ class StatusOptionsModel(BaseModel):
     probe_interval: float = Field(1.0, title="Status Probe Interval")
 
 
+class NetworkOptionsModel(BaseModel):
+    probe_interval: float = Field(5.0, title="Network Probe Interval")
+
+
 class AuthOptionsModel(BaseModel):
     jwt_secret: str = Field(
         title="The access token secret",
@@ -78,6 +82,7 @@ class OptionsModel(BaseModel):
     storage: StorageOptionsModel = Field(StorageOptionsModel())
     devices: DevicesOptionsModel = Field(DevicesOptionsModel())
     status: StatusOptionsModel = Field(StatusOptionsModel())
+    network: NetworkOptionsModel = Field(NetworkOptionsModel())
     auth: AuthOptionsModel = Field(AuthOptionsModel())
     containers: ContainersOptionsModel = Field(ContainersOptionsModel())
 

--- a/src/gravel/controllers/gstate.py
+++ b/src/gravel/controllers/gstate.py
@@ -31,6 +31,7 @@ from gravel.controllers.kv import KV
 if typing.TYPE_CHECKING:
     from gravel.controllers.inventory.inventory import Inventory
     from gravel.controllers.resources.devices import Devices
+    from gravel.controllers.resources.network import Network
     from gravel.controllers.resources.status import Status
     from gravel.controllers.resources.storage import Storage
 
@@ -130,6 +131,7 @@ class GlobalState:
     devices: Devices
     status: Status
     inventory: Inventory
+    network: Network
     storage: Storage
     cephadm: Cephadm
     ceph_mgr: Mgr
@@ -161,6 +163,10 @@ class GlobalState:
     def add_inventory(self, inventory: Inventory):
         self.inventory = inventory
         self.add_ticker("inventory", inventory)
+
+    def add_network(self, network: Network):
+        self.network = network
+        self.add_ticker("network", network)
 
     def add_storage(self, storage: Storage):
         self.storage = storage

--- a/src/gravel/controllers/nodes/mgr.py
+++ b/src/gravel/controllers/nodes/mgr.py
@@ -60,6 +60,7 @@ from gravel.controllers.nodes.messages import (
     ReadyToAddMessageModel,
     WelcomeMessageModel,
 )
+from gravel.controllers.resources.network import NetworkConfigModel
 from gravel.controllers.utils import aqr_run_cmd
 
 logger: Logger = fastapi_logger
@@ -130,6 +131,9 @@ class DeployRegistryModel(BaseModel):
 
 class DeployParamsBaseModel(BaseModel):
     hostname: str = Field(title="Hostname to use for this node")
+    network: Optional[NetworkConfigModel] = Field(
+        None, title="Network configuration"
+    )
 
 
 class DeployParamsModel(DeployParamsBaseModel):
@@ -326,6 +330,7 @@ class NodeMgr:
                 params.hostname,
                 self._state.address,
                 disks,
+                params.network,
             )
 
             if not res:
@@ -392,6 +397,7 @@ class NodeMgr:
                 ntp_addr=params.ntpaddr,
                 disks=disks,
                 container=ctrcfg,
+                network=params.network,
             ),
             self._post_bootstrap_finisher,
             self._finish_deployment,

--- a/src/gravel/controllers/resources/network.py
+++ b/src/gravel/controllers/resources/network.py
@@ -205,6 +205,7 @@ class Network(Ticker):
         return rawconf
 
     def _update_config(self, path: Path, new_config: Dict[str, str]):
+        new_config = new_config.copy()
         with path.open("r") as fin, atomic_write(path, overwrite=True) as fout:
             for line in fin:
                 stripped = line.strip()
@@ -214,7 +215,13 @@ class Network(Ticker):
                     if field in new_config:
                         # TODO: doesn't handle embedded quotes (but we're unlikely to care right now)
                         line = f'{field}="{new_config[field]}"\n'
+                        del new_config[field]
                 fout.write(line)
+            # This last bit adds any new fields that weren't already
+            # present to the end of the config file.
+            for field in new_config:
+                # (also doesn't handle embedded quotes, as above)
+                fout.write(f'{field}="{new_config[field]}"\n')
 
     def _update_route_file(
         self, path: Path, interface: str, routes: List[RouteModel]

--- a/src/gravel/controllers/resources/network.py
+++ b/src/gravel/controllers/resources/network.py
@@ -60,6 +60,12 @@ class RouteModel(BaseModel):
     interface: str = Field("-", title="Interface")
 
 
+class NetworkConfigModel(BaseModel):
+    interfaces: Dict[str, InterfaceModel]
+    nameservers: List[str]
+    routes: List[RouteModel]
+
+
 class Network(Ticker):
 
     _interfaces: Dict[str, InterfaceModel] = {}
@@ -223,6 +229,8 @@ class Network(Ticker):
             # No routes for this interface, delete config file if present
             path.unlink(missing_ok=True)
 
+    # TODO: This should probably just take a NetworkConfigModel,
+    # rather that separate interfaces, nameservers, routes.
     async def apply_config(
         self,
         interfaces: Dict[str, InterfaceModel],

--- a/src/gravel/controllers/resources/network.py
+++ b/src/gravel/controllers/resources/network.py
@@ -1,0 +1,297 @@
+# project aquarium's backend
+# Copyright (C) 2021 SUSE, LLC.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+import logging
+import os
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from atomicwrites import atomic_write
+from fastapi.logger import logger as fastapi_logger
+from pydantic import BaseModel, Field
+
+from gravel.controllers.gstate import Ticker
+from gravel.controllers.utils import aqr_run_cmd
+
+logger: logging.Logger = fastapi_logger
+
+
+class InterfaceConfigModel(BaseModel):
+    # Simplified "UI friendly" version of the actual config, i.e. we're not
+    # exposing everything in /etc/sysconfig/network/ifcfg-*, only the bits that
+    # we want the user to be able to change.
+    # TODO: bootproto would be better as a StrEnum (so we could force "dhcp" or "static")
+    bootproto: str = Field("dhcp", title="Boot Protocol")
+    ipaddr: Optional[str] = Field("", title="IP Address")
+    # If bonding_slaves is _not_ empty, this interface is a bonding master.
+    bonding_slaves: Optional[List] = Field(
+        [], title="Bonding slave network interfaces"
+    )
+    # TODO: Expose bonding module options
+
+
+# This is actually useful to have, because the interface might not *have* any config yet,
+# and in future we might want to see statistics, state (up/down, etc.) which would all
+# belong in this model.  OTOH, if we can get stats from cephadm, maybe this should be
+# dropped and we just do a dict of InterfaceConfigModels instead, and drop this extra
+# layer.
+class InterfaceModel(BaseModel):
+    name: str = Field(title="Logical Name")
+    config: Optional[InterfaceConfigModel] = Field(
+        None, title="Interface config"
+    )
+    # TODO: could add stats, current state etc. here but note that this would
+    # duplicate information available via /api/local/nodeinfo (which comes from cephadm)
+
+
+class RouteModel(BaseModel):
+    destination: str = Field("default", title="Destination")
+    gateway: str = Field("-", title="Gateway")
+    interface: str = Field("-", title="Interface")
+
+
+class Network(Ticker):
+
+    _interfaces: Dict[str, InterfaceModel] = {}
+    _nameservers: List[str] = []
+    _routes: List[RouteModel] = []
+    _is_busy: bool = False
+
+    def __init__(self, interval: float) -> None:
+        super().__init__(interval)
+
+    @property
+    def interfaces(self) -> Dict[str, InterfaceModel]:
+        return self._interfaces
+
+    @property
+    def nameservers(self) -> List[str]:
+        return self._nameservers
+
+    @property
+    def routes(self) -> List[RouteModel]:
+        return self._routes
+
+    async def _do_tick(self) -> None:
+        self._refresh_interfaces()
+        self._refresh_nameservers()
+        self._refresh_routes()
+        logger.debug(self._interfaces)
+        logger.debug(self._nameservers)
+        logger.debug(self._routes)
+
+    async def _should_tick(self) -> bool:
+        return not self._is_busy
+
+    def _refresh_interfaces(self) -> None:
+        # interfaces is the union of the physical interfaces (/sys/class/net/...) and
+        # any interfaces for which we have config files (/etc/sysconfig/network/ifcfg-*)
+        interfaces: Dict[str, InterfaceModel] = {}
+
+        # This gets the physical interfaces
+        sys_class_net = Path("/sys/class/net")
+        assert sys_class_net.exists() and sys_class_net.is_dir()
+        for dev in sys_class_net.glob("*"):
+            device = dev.joinpath("device")
+            if device.exists():
+                # /sys/class/net/$dev/device exist, so it's a physical interface
+                interfaces[dev.stem] = InterfaceModel(name=dev.stem)
+
+        # ...and this gets any configured interfaces
+        sysconfig = Path("/etc/sysconfig/network")
+        assert sysconfig.exists() and sysconfig.is_dir()
+        for conf in sysconfig.glob("ifcfg-*"):
+            # Blacklist here is lifted from wicked source
+            if conf.name.endswith("~") or conf.suffix in [
+                ".old",
+                ".bak",
+                ".orig",
+                ".scpmbackup",
+                ".rpmnew",
+                ".rpmsave",
+                ".rpmorig",
+            ]:
+                logger.debug(f"Skipping blacklisted suffix on {conf}")
+                continue
+            iface = conf.stem[6:]
+            if iface == "lo":
+                # We don't care about the loopback interface
+                continue
+            logger.debug(f"Reading {iface} config from {conf}")
+
+            rawconf = self._parse_config(conf)
+
+            config = InterfaceConfigModel()
+            if "IPADDR" in rawconf:
+                rawaddr = rawconf["IPADDR"]
+                if rawaddr:
+                    config.ipaddr = rawaddr
+                    # TODO: do we want to separate netmask etc. out?
+                    # (it can currently only be specified as "/" suffix
+                    # on ipaddr)
+            if "BOOTPROTO" in rawconf and rawconf["BOOTPROTO"] is not None:
+                config.bootproto = rawconf["BOOTPROTO"]
+
+            if iface not in interfaces:
+                interfaces[iface] = InterfaceModel(name=iface)
+            interfaces[iface].config = config
+
+        self._interfaces = interfaces
+
+    def _refresh_nameservers(self) -> None:
+        config = Path("/etc/sysconfig/network/config")
+        assert config.exists() and config.is_file()
+        rawconf = self._parse_config(config)
+        if (
+            "NETCONFIG_DNS_STATIC_SERVERS" in rawconf
+            and rawconf["NETCONFIG_DNS_STATIC_SERVERS"] is not None
+        ):
+            self._nameservers = rawconf["NETCONFIG_DNS_STATIC_SERVERS"].split()
+        else:
+            self._nameservers = []
+
+    def _refresh_routes(self) -> None:
+        routes: List[RouteModel] = []
+        route_paths = [Path("/etc/sysconfig/network/routes")]
+        for iface in self._interfaces:
+            route_paths.append(Path(f"/etc/sysconfig/network/ifroute-{iface}"))
+        for path in route_paths:
+            if not path.exists():
+                continue
+            with path.open("r") as f:
+                for line in f.readlines():
+                    stripped = line.strip()
+                    if len(stripped) == 0 or stripped.startswith("#"):
+                        continue
+                    fields = stripped.split()
+                    routes.append(
+                        RouteModel(
+                            destination=fields[0],
+                            gateway=fields[1],
+                            interface=fields[3],
+                        )
+                    )
+        self._routes = routes
+
+    def _parse_config(self, path: Path) -> Dict[str, Optional[str]]:
+        with path.open("r") as f:
+            contents = f.readlines()
+        rawconf: Dict[str, Optional[str]] = {}
+        for line in contents:
+            stripped = line.strip()
+            if len(stripped) == 0 or stripped.startswith("#"):
+                continue
+            first, second = stripped.split("=", maxsplit=1)
+            field = first.strip()
+            value = second.strip().strip("'\"")
+            assert len(field) > 0
+            rawconf[field] = value if len(value) > 0 else None
+        return rawconf
+
+    def _update_config(self, path: Path, new_config: Dict[str, str]):
+        with path.open("r") as fin, atomic_write(path, overwrite=True) as fout:
+            for line in fin:
+                stripped = line.strip()
+                if len(stripped) > 0 and not stripped.startswith("#"):
+                    first, second = stripped.split("=", maxsplit=1)
+                    field = first.strip()
+                    if field in new_config:
+                        # TODO: doesn't handle embedded quotes (but we're unlikely to care right now)
+                        line = f'{field}="{new_config[field]}"\n'
+                fout.write(line)
+
+    def _update_route_file(
+        self, path: Path, interface: str, routes: List[RouteModel]
+    ):
+        if routes:
+            with atomic_write(path, overwrite=True) as f:
+                for route in routes:
+                    f.write(
+                        f"{route.destination} {route.gateway} - {route.interface}\n"
+                    )
+        else:
+            # No routes for this interface, delete config file if present
+            path.unlink(missing_ok=True)
+
+    async def apply_config(
+        self,
+        interfaces: Dict[str, InterfaceModel],
+        nameservers: List[str],
+        routes: List[RouteModel],
+    ) -> None:
+        logger.debug("In Network.apply_config()")
+        self._is_busy = True
+        sysconfig = Path("/etc/sysconfig/network")
+
+        bonding_slave_interfaces: List[str] = []
+        for iface in interfaces:
+            conf = sysconfig.joinpath(f"ifcfg-{iface}")
+            new_config = interfaces[iface].config
+            if new_config is None:
+                # interface with no config, so get rid of it
+                conf.unlink(missing_ok=True)
+                continue
+            # This is destructive of any existing config
+            # (i.e. we're not mergeing here, we're clobbering)
+            logger.info(f"Writing {conf}")
+            with atomic_write(conf, overwrite=True) as f:
+                f.write(
+                    f"STARTMODE='auto'\n"
+                    f"BOOTPROTO='{new_config.bootproto}'\n"
+                    f"IPADDR='{new_config.ipaddr}'\n"
+                )
+                if new_config.bonding_slaves:
+                    f.write("BONDING_MASTER='yes'\n")
+                    for i, s in enumerate(new_config.bonding_slaves):
+                        f.write(f"BONDING_SLAVE{i}='{s}'\n")
+                        bonding_slave_interfaces.append(s)
+                    f.write(
+                        "BONDING_MODULE_OPTS='mode=active-backup miimon=100'\n"
+                    )
+        # special case for bonding slave interfaces, if any, which need to be
+        # overwritten with STARTMODE=hotplug, BOOTPROTO=none
+        for iface in bonding_slave_interfaces:
+            conf = sysconfig.joinpath(f"ifcfg-{iface}")
+            logger.info(f"Writing {conf}")
+            with atomic_write(conf, overwrite=True) as f:
+                f.write("STARTMODE='hotplug'\nBOOTPROTO='none'\n")
+        self._refresh_interfaces()
+
+        # Write nameserver config
+        self._update_config(
+            Path("/etc/sysconfig/network/config"),
+            {"NETCONFIG_DNS_STATIC_SERVERS": " ".join(nameservers)},
+        )
+        self._refresh_nameservers()
+
+        # Write route config
+        for iface in self._interfaces:
+            self._update_route_file(
+                Path(f"/etc/sysconfig/network/ifroute-{iface}"),
+                iface,
+                [route for route in routes if route.interface == iface],
+            )
+        self._update_route_file(
+            Path("/etc/sysconfig/network/routes"),
+            "-",
+            [route for route in routes if route.interface == "-"],
+        )
+        self._refresh_routes()
+
+        logger.info("Restarting network services...")
+        ret, _, err = await aqr_run_cmd(
+            ["systemctl", "restart", "network.service"]
+        )
+        # TODO: can this fail?
+        logger.info("Restarted network services")
+        self._is_busy = False

--- a/src/gravel/tests/conftest.py
+++ b/src/gravel/tests/conftest.py
@@ -192,6 +192,7 @@ async def aquarium_startup(
             NodeMgr,
         )
         from gravel.controllers.resources.devices import Devices
+        from gravel.controllers.resources.network import Network
         from gravel.controllers.resources.status import Status
         from gravel.controllers.resources.storage import Storage
 
@@ -312,6 +313,9 @@ async def aquarium_startup(
             gstate.config.options.storage.probe_interval, nodemgr, ceph_mon
         )
         gstate.add_storage(storage)
+
+        network: Network = Network(gstate.config.options.network.probe_interval)
+        gstate.add_network(network)
 
         await nodemgr.start()
         await gstate.start()

--- a/src/gravel/tests/unit/controllers/network/data/config
+++ b/src/gravel/tests/unit/controllers/network/data/config
@@ -1,0 +1,24 @@
+## Path:	Network/General
+## Description:	Global network configuration
+#
+# Note: 
+# Most of the options can and should be overridden by per-interface
+# settings in the ifcfg-* files.
+#
+# Note: The ISC dhclient started by the NetworkManager is not using any
+# of these options -- NetworkManager is not using any sysconfig settings.
+#
+
+#
+# List of DNS nameserver IP addresses to use for host-name lookup.
+# When the NETCONFIG_DNS_FORWARDER variable is set to "resolver",
+# the name servers are written directly to /etc/resolv.conf.
+# Otherwise, the nameserver are written into a forwarder specific
+# configuration file and the /etc/resolv.conf does not contain any
+# nameservers causing the glibc to use the name server on the local
+# machine (the forwarder). See also netconfig(8) manual page.
+#
+NETCONFIG_DNS_STATIC_SERVERS=""
+
+# Note: there's usually a lot more in this file on a real system
+# -- tserong@suse.com

--- a/src/gravel/tests/unit/controllers/network/data/ifcfg-eth0
+++ b/src/gravel/tests/unit/controllers/network/data/ifcfg-eth0
@@ -1,0 +1,4 @@
+BOOTPROTO='dhcp'
+MTU=''
+REMOTE_IPADDR=''
+STARTMODE='onboot'

--- a/src/gravel/tests/unit/controllers/network/test_network.py
+++ b/src/gravel/tests/unit/controllers/network/test_network.py
@@ -33,7 +33,8 @@ async def test_network(
         return 0, None, None
 
     mocker.patch(
-        "gravel.controllers.utils.aqr_run_cmd", new=mock_restart_network
+        "gravel.controllers.resources.network.aqr_run_cmd",
+        new=mock_restart_network,
     )
 
     from gravel.controllers.resources.network import (

--- a/src/gravel/tests/unit/controllers/network/test_network.py
+++ b/src/gravel/tests/unit/controllers/network/test_network.py
@@ -1,0 +1,119 @@
+# project aquarium's backend
+# Copyright (C) 2021 SUSE, LLC.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+import os
+from typing import List, Optional, Tuple
+
+import pytest
+from pyfakefs import fake_filesystem
+from pytest_mock import MockerFixture
+
+DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
+
+
+@pytest.mark.asyncio
+async def test_network(
+    mocker: MockerFixture,
+    fs: fake_filesystem.FakeFilesystem,
+) -> None:
+    async def mock_restart_network(
+        cmd: List[str],
+    ) -> Tuple[int, Optional[str], Optional[str]]:
+        assert cmd == ["systemctl", "restart", "network.service"]
+        return 0, None, None
+
+    mocker.patch(
+        "gravel.controllers.utils.aqr_run_cmd", new=mock_restart_network
+    )
+
+    from gravel.controllers.resources.network import (
+        InterfaceConfigModel,
+        InterfaceModel,
+        Network,
+        RouteModel,
+    )
+
+    fs.create_dir(
+        "/sys/devices/pci0000:00/0000:00:02.0/0000:01:00.0/net/enp1s0"
+    )
+    fs.create_symlink(
+        "/sys/class/net/enp1s0/device",
+        "/sys/devices/pci0000:00/0000:00:02.0/0000:01:00.0/net/enp1s0",
+    )
+    fs.create_dir("/sys/class/net/virbr0")
+
+    fs.add_real_file(
+        source_path=os.path.join(DATA_DIR, "ifcfg-eth0"),
+        target_path="/etc/sysconfig/network/ifcfg-eth0",
+    )
+    fs.create_file("/etc/sysconfig/network/ifcfg-eth0~")
+    fs.create_file("/etc/sysconfig/network/ifcfg-eth0.rpmsave")
+    fs.create_file("/etc/sysconfig/network/ifcfg-lo")
+    fs.add_real_file(
+        source_path=os.path.join(DATA_DIR, "config"),
+        target_path="/etc/sysconfig/network/config",
+    )
+
+    network = Network(5.0)
+    assert await network._should_tick()
+
+    await network._do_tick()
+
+    ifaces = network.interfaces
+    assert len(ifaces) > 0
+
+    assert "eth0" in ifaces
+    assert ifaces["eth0"].name == "eth0"
+    assert ifaces["eth0"].config.bootproto == "dhcp"
+    assert ifaces["eth0"].config.ipaddr == ""
+    assert ifaces["eth0"].config.bonding_slaves == []
+
+    assert "eth0~" not in ifaces
+    assert "eth0.rpmsave" not in ifaces
+
+    assert "enp1s0" in ifaces
+    assert ifaces["enp1s0"].config is None
+
+    assert "virbr0" not in ifaces
+
+    assert "lo" not in ifaces
+
+    assert network.nameservers == []
+
+    assert network.routes == []
+
+    ifaces["bond0"] = InterfaceModel(
+        name="bond0",
+        config=InterfaceConfigModel(
+            bootproto="static",
+            ipaddr="192.168.121.10/24",
+            bonding_slaves=["enp1s0", "enp2s0"],
+        ),
+    )
+    await network.apply_config(
+        ifaces,
+        ["8.8.8.8", "1.1.1.1"],
+        routes=[
+            RouteModel(destination="default", gateway="192.168.121.1"),
+            RouteModel(destination="192.168.0.0/16", interface="bond0"),
+        ],
+    )
+
+    ifaces = network.interfaces
+    assert "bond0" in ifaces
+    assert os.path.exists("/etc/sysconfig/network/ifcfg-enp1s0")
+    assert os.path.exists("/etc/sysconfig/network/ifcfg-enp2s0")
+    assert network.nameservers == ["8.8.8.8", "1.1.1.1"]
+    assert os.path.exists("/etc/sysconfig/network/routes")
+    assert os.path.exists("/etc/sysconfig/network/ifroute-bond0")
+    assert len(network.routes) == 2

--- a/src/gravel/tests/unit/controllers/nodes/test_mgr.py
+++ b/src/gravel/tests/unit/controllers/nodes/test_mgr.py
@@ -24,6 +24,7 @@ from gravel.controllers.gstate import GlobalState
 from gravel.controllers.nodes.conn import IncomingConnection
 from gravel.controllers.nodes.messages import MessageModel
 from gravel.controllers.nodes.mgr import DeployParamsModel, NodeMgr
+from gravel.controllers.resources.network import NetworkConfigModel
 
 
 @pytest.fixture
@@ -399,6 +400,7 @@ async def test_join(
         hostname: str,
         address: str,
         disks: DeploymentDisksConfig,
+        network: Optional[NetworkConfigModel],
     ) -> bool:
         assert leader_address == "10.1.2.3"
         assert token == "751b-51fd-10d7-f7b4"

--- a/src/requirements-test.txt
+++ b/src/requirements-test.txt
@@ -6,6 +6,7 @@ pytest-asyncio
 pytest-cov
 pytest-datadir
 pytest-mock
+types-atomicwrites
 types-psutil
 types-PyYAML
 types-toml

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,4 +1,5 @@
 aiofiles
+atomicwrites
 bcrypt==3.2.0
 fastapi==0.63.0
 h11==0.12.0


### PR DESCRIPTION
This adds the ability for gravel to read and write network interface configuration, nameservers and routes.  We've added an /api/local/network/config endpoint.  GET this, and you'll retrieve a dict of interfaces, a list of nameservers and a list of static routes.  In the simple case for a single NIC that's configured for DHCP, this'll give you:

```json
{
  "interfaces": {
     "eth0": {
      "name": "eth0",
      "config": {
        "bootproto": "dhcp",
        "ipaddr": "",
        "bonding_slaves": []
      }
    }
  },
  "nameservers": [],
  "routes": []
}
```

POST back to that same URL to apply a different config.  The config exposed is deliberately a subset of what's possible to specify in /etc/sysconfig/network/{config,routes,ifcfg-*,ifroute-*} files.  For 'interfaces', bootproto can be either "dhcp" or "static".  If it's "static", you also need to specify "ipaddr", and that needs to include the netmask or equivalent on the end (e.g.: "192.168.121.1/24"). If you want to create a bond, add a new interface to that dict and set bonding_slaves to a list of the physical interfaces to bond.  If the list is empty, it's just a normal interface.

'nameservers' is just a list of IP addresses, e.g.: ["8.8.8.8", ...]

'routes' is a list of dicts, each of which needs to include 'destination', 'gateway' and 'interface' as described in `man ifroute`.

When you apply the config, all network services are restarted.  Be particularly careful when applying a new config to the interface via which you're accessing the API.  Switch from DHCP to static IP and forget to configure DNS and/or a default route, and you can get yourself in trouble.  Likewise if you change the IP address to be on some other network.

Note that for NICs we've got an InterfaceModel which includes an InterfaceConfigModel.  This was based on Joao's work in https://github.com/aquarist-labs/aquarium/pull/603, the idea being that we may also want to add stats and other data to InterfaceModel. OTOH, that may duplicate information we already get from cephadm, so we might want to consider collapsing this instead.

Signed-off-by: Tim Serong <tserong@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [issue id or URL on https://github.com/aquarist-labs/aquarium/issues, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The component is the short name of a major module or subsystem, something 
like "tools", "gravel", "glass", "doc", etc.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://github.com/aquarist-labs/aquarium/blob/main/CONTRIBUTING.md

-->

## Checklist
- [ ] References issues, create if required
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins run tumbleweed`
- `jenkins run leap`
- `jenkins run ubuntu`

</details>
