### PR TITLE
glass: Rename datatable column property 'unsortable' to 'sortable'

### DIFF
--- a/src/glass/src/app/pages/install-welcome-page/install-welcome-page.component.ts
+++ b/src/glass/src/app/pages/install-welcome-page/install-welcome-page.component.ts
@@ -59,7 +59,7 @@ export class InstallWelcomePageComponent implements OnInit {
         name: TEXT('Qualified'),
         prop: 'qualified',
         cellTemplate: this.qualifiedColTpl,
-        unsortable: true
+        sortable: false
       },
       {
         name: TEXT('Name'),

--- a/src/glass/src/app/pages/network-page/network-page.component.ts
+++ b/src/glass/src/app/pages/network-page/network-page.component.ts
@@ -65,7 +65,6 @@ export class NetworkPageComponent {
       {
         name: '',
         prop: '',
-        unsortable: true,
         cellTemplateName: DatatableCellTemplateName.actionMenu,
         cellTemplateConfig: this.getActionMenu.bind(this)
       }

--- a/src/glass/src/app/pages/users-page/users-page.component.ts
+++ b/src/glass/src/app/pages/users-page/users-page.component.ts
@@ -63,7 +63,6 @@ export class UsersPageComponent {
       {
         name: '',
         prop: '',
-        unsortable: true,
         cellTemplateName: DatatableCellTemplateName.actionMenu,
         cellTemplateConfig: this.getActionMenu.bind(this)
       }

--- a/src/glass/src/app/shared/components/datatable/datatable.component.spec.ts
+++ b/src/glass/src/app/shared/components/datatable/datatable.component.spec.ts
@@ -143,7 +143,7 @@ describe('DatatableComponent', () => {
   });
 
   it('should not sort not sortable columns', () => {
-    component.columns[0].unsortable = true;
+    component.columns[0].sortable = false;
     fixture.detectChanges();
     expect(component.sortHeader).toBe('bar');
     component.updateSorting(columns[0]);

--- a/src/glass/src/app/shared/components/datatable/datatable.component.ts
+++ b/src/glass/src/app/shared/components/datatable/datatable.component.ts
@@ -107,13 +107,16 @@ export class DatatableComponent implements OnInit, OnDestroy {
     if (this.columns) {
       // Sanitize the columns.
       _.forEach(this.columns, (column: DatatableColumn) => {
+        _.defaultsDeep(column, {
+          sortable: true
+        });
         if (_.isString(column.cellTemplateName)) {
           column.cellTemplate = this.cellTemplates[column.cellTemplateName];
           switch (column.cellTemplateName) {
             case 'actionMenu':
               column.name = '';
               column.prop = '_action'; // Add a none existing name here.
-              column.unsortable = true;
+              column.sortable = false;
               break;
           }
         }
@@ -131,7 +134,7 @@ export class DatatableComponent implements OnInit, OnDestroy {
       });
     }
     this.sortableColumns = this.columns
-      .filter((c) => !c.unsortable)
+      .filter((c) => c.sortable === true)
       .map((c) => this.getSortProp(c));
     if (!this.sortHeader && this.sortableColumns.length > 0) {
       this.sortHeader = this.sortableColumns[0];
@@ -180,7 +183,7 @@ export class DatatableComponent implements OnInit, OnDestroy {
 
   setHeaderClasses(column: DatatableColumn): string {
     let css = column.css || '';
-    if (column.unsortable) {
+    if (column.sortable !== true) {
       return css;
     }
     css += ' sortable';

--- a/src/glass/src/app/shared/models/datatable-column.type.ts
+++ b/src/glass/src/app/shared/models/datatable-column.type.ts
@@ -46,6 +46,6 @@ export type DatatableColumn = {
   cellTemplateConfig?: any;
   cellTemplate?: TemplateRef<any>;
   pipe?: PipeTransform;
-  unsortable?: boolean;
+  sortable?: boolean; // Defaults to 'true'.
   align?: 'start' | 'center' | 'end';
 };


### PR DESCRIPTION
Naming this property 'sortable' is more common practice than 'unsortable'. The new name is also more intuitive.

Signed-off-by: Volker Theile <vtheile@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [issue id or URL on https://github.com/aquarist-labs/aquarium/issues, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The component is the short name of a major module or subsystem, something 
like "tools", "gravel", "glass", "doc", etc.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://github.com/aquarist-labs/aquarium/blob/main/CONTRIBUTING.md

-->

## Checklist
- [ ] References issues, create if required
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins run tumbleweed`
- `jenkins run leap`
- `jenkins run ubuntu`

</details>
