### PR TITLE
glass: Set correct width of the datatable action column

### DIFF
--- a/src/glass/src/app/shared/components/datatable/datatable.component.spec.ts
+++ b/src/glass/src/app/shared/components/datatable/datatable.component.spec.ts
@@ -137,7 +137,7 @@ describe('DatatableComponent', () => {
     component.columns[1].cols = 12;
     expect(() => fixture.detectChanges()).toThrow(
       new Error(
-        'Only 12 cols can be used in one row by bootstrap, please redefine the "DatatableColumn.cols" values'
+        'Only 12 cols can be used in one row by Bootstrap, please redefine the "DatatableColumn.cols" values'
       )
     );
   });

--- a/src/glass/src/app/shared/components/datatable/datatable.component.ts
+++ b/src/glass/src/app/shared/components/datatable/datatable.component.ts
@@ -117,6 +117,7 @@ export class DatatableComponent implements OnInit, OnDestroy {
               column.name = '';
               column.prop = '_action'; // Add a none existing name here.
               column.sortable = false;
+              column.cols = 1;
               break;
           }
         }
@@ -243,7 +244,7 @@ export class DatatableComponent implements OnInit, OnDestroy {
   private colSanityCheck(availableCols: number, columnsToChange: number) {
     if (availableCols < 0 || (availableCols === 0 && columnsToChange >= 1)) {
       throw new Error(
-        'Only 12 cols can be used in one row by bootstrap, please redefine the "DatatableColumn.cols" values'
+        'Only 12 cols can be used in one row by Bootstrap, please redefine the "DatatableColumn.cols" values'
       );
     }
   }


### PR DESCRIPTION
Set it to 1 explicitely, otherwise the action column will consume too much space.

Signed-off-by: Volker Theile <vtheile@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [issue id or URL on https://github.com/aquarist-labs/aquarium/issues, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The component is the short name of a major module or subsystem, something 
like "tools", "gravel", "glass", "doc", etc.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://github.com/aquarist-labs/aquarium/blob/main/CONTRIBUTING.md

-->

## Checklist
- [ ] References issues, create if required
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins run tumbleweed`
- `jenkins run leap`
- `jenkins run ubuntu`

</details>
