### PR TITLE
gravel: clean up systemdisk

### DIFF
--- a/src/gravel/controllers/nodes/deployment.py
+++ b/src/gravel/controllers/nodes/deployment.py
@@ -340,10 +340,10 @@ class NodeDeployment:
             keyringpath.chmod(0o600)
             confpath.chmod(0o644)
 
-        systemdisk = SystemDisk(self._gstate)
+        systemdisk = SystemDisk()
         try:
             progress(0, "Creating System Disk")
-            await systemdisk.create(sysdiskpath)
+            await systemdisk.create(self._gstate, sysdiskpath)
             progress(10, "Enabling System Disk")
             await systemdisk.enable()
         except GravelError as e:

--- a/src/gravel/controllers/nodes/systemdisk.py
+++ b/src/gravel/controllers/nodes/systemdisk.py
@@ -104,7 +104,6 @@ def get_mounts() -> List[MountEntry]:
 
 class SystemDisk:
 
-    _gstate: GlobalState
     _overlaydirs: Dict[str, str] = {
         "etc": "/etc",
         "logs": "/var/log",
@@ -114,8 +113,8 @@ class SystemDisk:
     }
     _bindmounts: Dict[str, str] = {"ceph": "/var/lib/ceph"}
 
-    def __init__(self, gstate: GlobalState) -> None:
-        self._gstate = gstate
+    def __init__(self) -> None:
+        pass
 
     @property
     def mounted(self):
@@ -135,10 +134,10 @@ class SystemDisk:
         if retcode != 0:
             raise LVMError(msg=err)
 
-    async def create(self, devicestr: str) -> None:
+    async def create(self, gstate: GlobalState, devicestr: str) -> None:
 
         logger.debug(f"prepare system disk: {devicestr}")
-        inventory: Optional[NodeInfoModel] = self._gstate.inventory.latest
+        inventory: Optional[NodeInfoModel] = gstate.inventory.latest
         assert inventory is not None
 
         device: Optional[DiskDevice] = next(

--- a/src/gravel/tests/unit/controllers/nodes/data/mounts_silly.raw
+++ b/src/gravel/tests/unit/controllers/nodes/data/mounts_silly.raw
@@ -1,3 +1,3 @@
 tmpfs
-foo bar
-asd fgh
+foo bar myfs myopts
+asd fgh myfs2 myopts2

--- a/src/gravel/tests/unit/controllers/nodes/test_systemdisk.py
+++ b/src/gravel/tests/unit/controllers/nodes/test_systemdisk.py
@@ -109,20 +109,20 @@ async def test_lvm(mocker: MockerFixture) -> None:
         called_lvm_failure = True
         return 1, None, "foobar"
 
+    from gravel.controllers.nodes.systemdisk import LVMError, lvm
+
     mocker.patch(
         "gravel.controllers.nodes.systemdisk.aqr_run_cmd", new=mock_success_call
     )
-    from gravel.controllers.nodes.systemdisk import LVMError, SystemDisk
 
-    systemdisk = SystemDisk()
-    await systemdisk.lvm("foo bar baz")
+    await lvm(["foo", "bar", "baz"])
     assert called_lvm_success
 
     mocker.patch(
         "gravel.controllers.nodes.systemdisk.aqr_run_cmd", new=mock_failure_call
     )
     try:
-        await systemdisk.lvm("foo bar baz")
+        await lvm(["foo", "bar", "baz"])
     except LVMError as e:
         assert e.message == "foobar"
     assert called_lvm_failure
@@ -164,10 +164,10 @@ async def test_create(
     inventory._latest = nodeinfo
 
     systemdisk = SystemDisk()
-    systemdisk.lvm = mock_lvm
     mocker.patch(
         "gravel.controllers.nodes.systemdisk.aqr_run_cmd", new=mock_call
     )
+    mocker.patch("gravel.controllers.nodes.systemdisk.lvm", new=mock_lvm)
     throws = False
     try:
         await systemdisk.create(gstate, "/dev/foobar")


### PR DESCRIPTION
This is preparatory clean up work for a bigger cleanup and rework of how we deploy the system. In part to account for an inevitable change in how we install the system, but mostly (and more pressing) to better handle error states.

Signed-off-by: Joao Eduardo Luis \<joao@suse.com>