### PR TITLE
Use default datatable cell template for all columns that have not defined a specific template

### DIFF
--- a/src/glass/src/app/shared/components/datatable/datatable.component.html
+++ b/src/glass/src/app/shared/components/datatable/datatable.component.html
@@ -19,7 +19,10 @@
       <td *ngFor="let column of columns"
           [class]="column.css"
           [ngStyle]="{'text-align': !column?.align ? 'start' : column?.align}">
-        <div *ngIf="!(column.cellTemplateName || column.cellTemplate)">{{ renderCellValue(row, column) }}</div>
+        <ng-template *ngIf="!(column.cellTemplateName || column.cellTemplate)"
+                     [ngTemplateOutlet]="defaultTpl"
+                     [ngTemplateOutletContext]="{ value: renderCellValue(row, column) }">
+        </ng-template>
         <ng-template *ngIf="column.cellTemplate"
                      [ngTemplateOutlet]="column.cellTemplate"
                      [ngTemplateOutletContext]="{ row: row, column: column, value: column.prop ? renderCellValue(row, column) : undefined,
@@ -70,6 +73,11 @@
                   (pageChange)="reloadData()">
   </ngb-pagination>
 </div>
+
+<ng-template #defaultTpl
+             let-value="value">
+  <span [title]="value">{{ value }}</span>
+</ng-template>
 
 <ng-template #rowSelectTpl
              let-value="value"


### PR DESCRIPTION
This default cell template will display a tooltip which is useful if the cell content overlaps and is hidden via CSS 'overflow-x'.

Signed-off-by: Volker Theile <vtheile@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [issue id or URL on https://github.com/aquarist-labs/aquarium/issues, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The component is the short name of a major module or subsystem, something 
like "tools", "gravel", "glass", "doc", etc.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://github.com/aquarist-labs/aquarium/blob/main/CONTRIBUTING.md

-->

## Checklist
- [ ] References issues, create if required
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins run tumbleweed`
- `jenkins run leap`
- `jenkins run ubuntu`

</details>
